### PR TITLE
 fix critic bug for gradient_accumulate_steps!=1 and reduce cpu memory  of lm-head tuning

### DIFF
--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -925,7 +925,7 @@ class AutoRound(object):
             )
         else:
             lr_schedule = copy.deepcopy(self.lr_scheduler)
-            
+
         train_bs = self.train_bs
         pick_samples = train_bs
         n_samples = inputs.shape[0]
@@ -952,7 +952,7 @@ class AutoRound(object):
                     org_input = current_input
                 with torch.no_grad():
                     current_output = layer(org_input)
-                        
+
                 if self.amp:
                     with autocast(device_type=device.split(":")[0], dtype=self.amp_dtype):
                         output_q = wrapper_linear(current_input)  # pylint: disable=not-callable
@@ -1682,4 +1682,3 @@ class AutoAdamRound(AutoOPTRound):
             optimizer,
             **kwargs,
         )
-

--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -969,7 +969,7 @@ class AutoRound(object):
                     current_output = layer(org_input)
                     if q_inputs is not None:
                         org_input = org_input.to(cache_device)
-                        
+
                 if self.amp:
                     with autocast(device_type=device.split(":")[0], dtype=self.amp_dtype):
                         output_q = wrapper_linear(current_input)  # pylint: disable=not-callable
@@ -1699,4 +1699,3 @@ class AutoAdamRound(AutoOPTRound):
             optimizer,
             **kwargs,
         )
-


### PR DESCRIPTION
Resolve the issue of excessive CPU memory usage caused by saving layer outputs.
Fix the issue of generating random indices when using 'rand' sampler.