### PR TITLE
limit the scale minimum value not to 0

### DIFF
--- a/auto_round/data_type/int.py
+++ b/auto_round/data_type/int.py
@@ -19,7 +19,7 @@ from auto_round.data_type.register import register_dtype, QUANT_FUNC_WITH_DTYPE
 
 @register_dtype("int_asym")
 def quant_tensor_asym(weight, num_bits=4, v=0, min_scale=1.0, max_scale=1.0, scale_dtype=torch.float16,
-                      weight_min=None, weight_max=None, q_scale_thresh=0.0 ,**kwargs):
+                      weight_min=None, weight_max=None, q_scale_thresh=0.0, **kwargs):
     """Quantizes and dequantizes weight asymmetrically.
 
     Args:


### PR DESCRIPTION
Limit the scale minimum value not to 0
tested on common models(>=10)
currently, only effects Qwen2-57B-A14B-Instruct model