### PR TITLE
avoid underflow and overflow for exllamav2

### DIFF
--- a/auto_round/auto_quantizer.py
+++ b/auto_round/auto_quantizer.py
@@ -329,11 +329,11 @@ class AutoRoundQuantizer(HfQuantizer):
         if hasattr(quantization_config, "backend"):  # pragma: no cover
             backend = quantization_config.backend
             if "hpu" in backend and model.dtype != torch.bfloat16:
-                logger.info("We suggest you to set `torch_dtype=torch.bfloat16` for better efficiency with AutoRound.")
+                logger.info("change the dtype to `bfloat16` as HPU does not support float16")
                 model = model.to(torch.bfloat16)
-            elif model.dtype != torch.float16:
-                logger.info("We suggest you to set `torch_dtype=torch.float16` for better efficiency with AutoRound.")
-                model = model.to(torch.float16)
+            # elif model.dtype != torch.float16:
+            #     logger.info("We suggest you to set `torch_dtype=torch.float16` for better efficiency with AutoRound.")
+            #     model = model.to(torch.float16)
         bits = quantization_config.bits
         group_size = quantization_config.group_size
         data_type = quantization_config.data_type if hasattr(quantization_config, "data_type") \

--- a/auto_round/auto_quantizer.py
+++ b/auto_round/auto_quantizer.py
@@ -332,9 +332,6 @@ class AutoRoundQuantizer(HfQuantizer):
             if "hpu" in backend and model.dtype != torch.bfloat16:
                 logger.info("change the dtype to `bfloat16` as HPU does not support float16")
                 model = model.to(torch.bfloat16)
-            # elif model.dtype != torch.float16:
-            #     logger.info("We suggest you to set `torch_dtype=torch.float16` for better efficiency with AutoRound.")
-            #     model = model.to(torch.float16)
         bits = quantization_config.bits
         group_size = quantization_config.group_size
         data_type = quantization_config.data_type if hasattr(quantization_config, "data_type") \

--- a/auto_round_extension/cuda/qliner_exllamav2.py
+++ b/auto_round_extension/cuda/qliner_exllamav2.py
@@ -40,7 +40,6 @@ from logging import getLogger
 import torch
 import torch.nn as nn
 
-
 logger = getLogger(__name__)
 
 try:
@@ -48,11 +47,13 @@ try:
 except ImportError as e:
     exllama_v2_import_exception = e
 
+
     def error_raiser_exllama(*args, **kwargs):
         raise ValueError(
             f"Trying to use the exllama v2 backend, but could not import the C++/CUDA dependencies with the following "
             f"error: {exllama_v2_import_exception}"
         )
+
 
     make_q_matrix = error_raiser_exllama
     gemm_half_q_half = error_raiser_exllama
@@ -167,7 +168,7 @@ class QuantLinear(nn.Module):
         self.bits = bits
         self.group_size = group_size if group_size != -1 else infeatures
         self.trainable = trainable
-        self.maxq = 2**self.bits - 1
+        self.maxq = 2 ** self.bits - 1
 
         assert infeatures % 32 == 0
         assert infeatures % self.group_size == 0
@@ -204,6 +205,7 @@ class QuantLinear(nn.Module):
             self.register_buffer("bias", torch.zeros((outfeatures), dtype=torch.float16))
         else:
             self.bias = None
+        self.clip = kwargs.get("clip", False)
 
     def post_init(self, temp_dq):
         assert self.qweight.device.type == "cuda"
@@ -230,10 +232,12 @@ class QuantLinear(nn.Module):
             x = x.half()
 
         output = ext_gemm_half_q_half(x, self.q_handle, self.outfeatures, force_cuda)
-        if orig_dtype!=torch.float16:
+        if orig_dtype != torch.float16:
             output = output.to(orig_dtype)
         if self.bias is not None:
             output.add_(self.bias)
+        if self.clip:
+            output = torch.clip(output, -65504, 65504)
         return output
 
     def temp_dq_size(self):


### PR DESCRIPTION
this is useful for Qwen2-57B, as the output of model.layers.3.mlp.shared_expert.down_proj could be up to ~50k