### PR TITLE
change the scale thresh generally

### DIFF
--- a/auto_round/data_type/int.py
+++ b/auto_round/data_type/int.py
@@ -59,8 +59,6 @@ def quant_tensor_asym(weight, bits=4, v=0, min_scale=1.0, max_scale=1.0, scale_d
     wmax[tmp] = +1
     scale = ((wmax - wmin) / maxq).to(scale_dtype)
     scale = torch.clamp(scale, min=q_scale_thresh)
-    if (scale == 0.).any():
-        scale = torch.clamp(scale, min=1e-5)
     zp = round_ste(-wmin / scale)  # pylint: disable=E1130
     scale = scale.unsqueeze(dim=-1)
     zp = zp.unsqueeze(dim=-1)
@@ -117,8 +115,6 @@ def quant_tensor_sym(weight, bits=4, v=0, min_scale=1.0, max_scale=1.0, scale_dt
     wmax_new[tmp] = +1
     scale = ((wmax_new - wmin_new) / maxq).to(scale_dtype)
     scale = torch.clamp(scale, min=q_scale_thresh)
-    if (scale == 0.).any():
-        scale = torch.clamp(scale, min=1e-5)
     scale = scale.unsqueeze(dim=-1)
     zp = torch.full_like(scale, (maxq + 1) / 2)
 
@@ -174,4 +170,5 @@ def quant_tensor_asym_wo_round(weight, bits=4, v=0, min_scale=1.0, max_scale=1.0
     int_w = weight / scale + v
     q = torch.clamp(int_w + zp, 0, maxq)
     return scale * (q - zp), scale, zp
+
 

--- a/auto_round/quantizer.py
+++ b/auto_round/quantizer.py
@@ -46,7 +46,7 @@ def reshape_tensor(v, group_size=-1):
 
 def quant_tensor(
         quant_func, data, bits=4, group_size=-1, v=0, min_scale=1.0, max_scale=1.0, scale_dtype=torch.float16,
-        weight_min=None, weight_max=None, q_scale_thresh=0.0, **kwargs,
+        weight_min=None, weight_max=None, q_scale_thresh=1e-5, **kwargs,
 ):
     """Quantizes and dequantizes weight, handing the group size issue .
 


### PR DESCRIPTION
change the scale thresh generally
0.0 --->  1e-5
The effect of scale clip was evaluated on 4 commonly used models with acceptable accuracy fluctuations.
Adding scale clip prevents weight values from disappearing and reduces model instability after quantization.