### PR TITLE
[HPU] Add lazy mode back

### DIFF
--- a/.azure-pipelines/scripts/ut/run_ut_hpu.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_hpu.sh
@@ -18,9 +18,14 @@ LOG_DIR=/auto-round/log_dir
 mkdir -p ${LOG_DIR}
 ut_log_name=${LOG_DIR}/ut.log
 
-find . -name "test*hpu_only.py" | sed "s,\.\/,python -m pytest --cov=\"${auto_round_path}\" --cov-report term --html=report.html --self-contained-html  --cov-report xml:coverage.xml --cov-append -vs --disable-warnings ,g" > run.sh
-cat run.sh
-bash run.sh 2>&1 | tee ${ut_log_name}
+find . -name "test*hpu_only.py" | sed "s,\.\/,python -m pytest --cov=\"${auto_round_path}\" --cov-report term --html=report.html --self-contained-html  --cov-report xml:coverage.xml --cov-append -vs --disable-warnings ,g" > run_lazy.sh
+find . -name "test*hpu_only.py" | sed "s,\.\/,python -m pytest --mode compile --cov=\"${auto_round_path}\" --cov-report term --html=report.html --self-contained-html  --cov-report xml:coverage.xml --cov-append -vs --disable-warnings ,g" > run_compile.sh
+
+cat run_lazy.sh
+bash run_lazy.sh 2>&1 | tee ${ut_log_name}
+
+cat run_compile.sh
+bash run_compile.sh 2>&1 | tee ${ut_log_name}
 
 cp report.html ${LOG_DIR}/
 cp coverage.xml ${LOG_DIR}/

--- a/auto_round/utils.py
+++ b/auto_round/utils.py
@@ -975,7 +975,7 @@ TORCH_VERSION_AT_LEAST_2_4 = torch_version_at_least("2.4.0")
 #   1) Set `PT_HPU_LAZY_MODE=1`
 
 
-def check_hpu_compile_mode():
+def _check_hpu_compile_mode():
     assert (
         os.getenv("PT_HPU_LAZY_MODE") == "0"
     ), "Please set `PT_HPU_LAZY_MODE=0` to use HPU compile mode"
@@ -995,7 +995,7 @@ def _use_hpu_compile_mode():
 
 def compile_func_on_hpu(func):
     if _use_hpu_compile_mode():
-        check_hpu_compile_mode()
+        _check_hpu_compile_mode()
         return torch.compile(func, backend="hpu_backend")
     return func
 

--- a/auto_round/utils.py
+++ b/auto_round/utils.py
@@ -968,11 +968,11 @@ TORCH_VERSION_AT_LEAST_2_4 = torch_version_at_least("2.4.0")
 
 # Note on HPU usage:
 # There are two modes available for enabling auto-round on HPU:
-# 1. Compile Mode (Recommended)
+# 1. Compile Mode
 #   1) Use PyTorch version ≥ 2.4 (Intel® Gaudi® v1.18 or later)
 #   2) Set `PT_HPU_LAZY_MODE=0` and `PT_ENABLE_INT64_SUPPORT=1`
-# 2. Lazy Mode
-#   1) Set `PT_HPU_LAZY_MODE=1`
+#   The compile mode can speed up quantization process but still in experimental stage.
+# 2. Lazy Mode (By default)
 
 
 def _check_hpu_compile_mode():
@@ -986,7 +986,7 @@ def _check_hpu_compile_mode():
 
 
 def is_hpu_lazy_mode():
-    return os.getenv("PT_HPU_LAZY_MODE") == "1"
+    return os.getenv("PT_HPU_LAZY_MODE") != "0"
 
 
 def _use_hpu_compile_mode():

--- a/test/_test_helpers.py
+++ b/test/_test_helpers.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+def is_pytest_mode_compile():
+    return pytest.mode == "compile"
+
+
+def is_pytest_mode_lazy():
+    return pytest.mode == "lazy"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,34 @@
+import os
+from typing import Mapping
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--mode",
+        action="store",
+        default="lazy",
+        help="{compile|lazy}, default lazy. Choose mode to run tests",
+    )
+
+
+backup_env = pytest.StashKey[Mapping]()
+
+
+def pytest_configure(config):
+    pytest.mode = config.getoption("--mode")
+    assert pytest.mode.lower() in ["lazy", "compile"]
+
+    config.stash[backup_env] = os.environ
+
+    if pytest.mode == "lazy":
+        os.environ["PT_HPU_LAZY_MODE"] = "1"
+    elif pytest.mode == "compile":
+        os.environ["PT_HPU_LAZY_MODE"] = "0"
+        os.environ["PT_ENABLE_INT64_SUPPORT"] = "1"
+
+
+def pytest_unconfigure(config):
+    os.environ.clear()
+    os.environ.update(config.stash[backup_env])

--- a/test/test_auto_round_hpu_only.py
+++ b/test/test_auto_round_hpu_only.py
@@ -1,3 +1,46 @@
+import pytest
+import torch
+from auto_round.utils import is_hpu_supported
+
+from _test_helpers import is_pytest_mode_compile, is_pytest_mode_lazy
+
+
+def run_opt_125m_on_hpu():
+    from auto_round import AutoRound
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    model_name = "facebook/opt-125m"
+    model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype="auto", trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+
+    bits, group_size, sym = 4, 128, False
+    autoround = AutoRound(
+        model,
+        tokenizer,
+        bits=bits,
+        group_size=group_size,
+        sym=sym,
+        iters=2,
+        seqlen=2,
+    )
+    q_model, qconfig = autoround.quantize()
+    assert q_model is not None, f"Expected q_model to be not None"
+
+
+@pytest.mark.skipif(not is_hpu_supported(), reason="HPU is not supported")
+@pytest.mark.skipif(not is_pytest_mode_lazy(), reason="Only for lazy mode")
+def test_opt_125m_lazy_mode():
+    run_opt_125m_on_hpu()
+
+
+@pytest.mark.skipif(not is_hpu_supported(), reason="HPU is not supported")
+@pytest.mark.skipif(not is_pytest_mode_compile(), reason="Only for compile mode")
+def test_opt_125m_compile_mode():
+    torch._dynamo.reset()
+    run_opt_125m_on_hpu()
+
+
 def test_import():
     from auto_round import AutoRound
-    from auto_round.export.export_to_itrex.export import save_quantized_as_itrex, WeightOnlyLinear
+    from auto_round.export.export_to_itrex.export import (
+        WeightOnlyLinear, save_quantized_as_itrex)


### PR DESCRIPTION
Background: previous PRs forced the use of compile mode for HPU, but lazy mode can still work, albeit slowly, and some INC UTs rely on lazy mode.


This PR:
- check environment variables for `compile` mode if needed
```bash
# lazy mode
PT_HPU_LAZY_MODE=1 python xxx

# compile mode
PT_HPU_LAZY_MODE=0 PT_ENABLE_INT64_SUPPORT=0 python xxx
```

- Add UTs for both lazy mode and compile mode