### PR TITLE
support packing immediately in new quantization api to save ram usage

### DIFF
--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -454,7 +454,11 @@ class AutoRound(object):
                     formats[index] = format
 
         # Remove duplicates from formats list
-        formats = list(set(formats))
+        def remove_duplicates(lst):
+            seen = set()
+            return [x for x in lst if not (x in seen or seen.add(x))]
+
+        formats = remove_duplicates(formats)
         self.formats = formats
 
         # # Check format compatibility

--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -19,12 +19,14 @@ import torch
 import transformers
 import copy
 import time
-from typing import Optional, Union
+from typing import Optional, Union, List
 from transformers import set_seed
 from torch import autocast
 from tqdm import tqdm
 import accelerate
 from packaging import version
+
+import auto_round.export.export_to_autogptq.export
 from .wrapper import WrapperMultiblock, wrapper_block, unwrapper_block, WrapperLinear, unwrapper_layer
 from .special_model_handler import (
     shareable_keywords,
@@ -170,7 +172,7 @@ class AutoRound(object):
         set_seed(self.seed)
         assert not unsupport_meta_device(model), (
             "AutoRound does not support for params on meta device."
-            " Please use more gpus vis set `--device 0,1,2,3` or just use one gpu")
+            " Please use more gpus by setting `--device 0,1,2,3` or just use one gpu")
 
         ## important tuning hype-parameters
         self.amp = amp
@@ -262,7 +264,36 @@ class AutoRound(object):
 
         self.set_device_map_in_blocks(self.device_map)
 
-        self.set_layerwise_config(self.layer_config)  ##better place in the end
+        self.is_packing_immediate = False  ## whether to pack the layer immediately after tuning
+
+        self.serialization_keys = [
+            "bits",
+            "group_size",
+            "sym",
+            "data_type",
+            "enable_quanted_input",
+            "enable_minmax_tuning",
+            "data_type",
+            "seqlen",
+            "batch_size",
+            "scale_dtype",
+            "lr",
+            "minmax_lr",
+            "gradient_accumulate_steps",
+            "iters",
+            "amp",
+            "nsamples",
+            "low_gpu_mem_usage",
+            "to_quant_block_names",
+            "enable_norm_bias_tuning",
+            "act_bits",
+            "act_group_size",
+            "act_sym",
+            "act_dynamic",
+            "act_data_type"
+        ]
+
+        self.has_qlayer_outside_block = self.set_layerwise_config(self.layer_config)  ##better place in the end
 
     def set_device_map_in_blocks(self, device_map):
         """Sets the device map for specific blocks in the model.
@@ -358,6 +389,52 @@ class AutoRound(object):
                     f" as nsamples must equal or greater"
                     f" than gradient_accumulate_steps * batch_size")
 
+    def _check_format_compatibility(self, format):  ##TODO
+        ##check lm_head, mixed_bits, bits, each layer supporting, etc
+        pass
+
+    def qsave(self, output_dir: str = "tmp_autoround", format: str = "auto_round"):
+        ##check format config
+        formats = format.replace(' ', '').split(',')
+        from auto_round.utils import supported_formats
+        for format_ in formats:
+            if format_ not in supported_formats:
+                logger.error(f"unsupported format {format_}, please choose from {supported_formats}")
+                exit(-1)
+
+        if len(formats) == 1 and ("awq" in formats or "gptq" in formats) and not self.has_qlayer_outside_block:
+            self.is_packing_immediate = True
+
+        for index in range(len(formats)):
+            format = formats[index]
+            if "auto_round" in format:
+                if self.sym and (
+                        "gptq" not in format and "awq" not in format):
+                    format = format.replace('auto_round', 'auto_round:gptq')
+                    formats[index] = format
+
+                if not ("triton" in format or "exllamav2" in format or "awq" in format or "gptq" in format):
+                    logger.info(f"AutoRound format does not support {format}, try to pack each layer with AutoGPTQ")
+                    format = format.replace("auto_round", "auto_gptq")
+                    formats[index] = format
+        formats = list(set(formats))
+        self.formats = formats
+
+        self._check_format_compatibility(formats)
+
+        model,_ = self.quantize()
+
+        inplace = False if len(format) > 1 else True
+        folders = []
+        for format in formats:
+            save_format_ = format.replace(":", "-")
+            save_format_ = save_format_.replace("_", "-")
+            save_folder = os.path.join(output_dir, save_format_) if len(formats) > 1 else output_dir
+            self.save_quantized(save_folder, format=format, inplace=inplace)
+            folders.append(save_folder)
+
+        return model, folders
+
     def quantize(self):
         """Quantize the model and return the quantized model along with layer configurations.
         the entry of AutoRound.
@@ -388,6 +465,8 @@ class AutoRound(object):
         self.model = mv_module_from_gpu(self.model, self.low_cpu_mem_usage)
         logger.info("caching done")
         pbar = tqdm(range(0, sum([len(i) for i in all_blocks]), self.nblocks))
+        pack_layer = auto_round.export.export_to_autogptq.export.pack_layer  ## TODO support awq,gptq later
+
         for block_names in all_blocks:
             inputs = all_inputs[block_names[0]]
             all_inputs.pop(block_names[0])
@@ -413,11 +492,20 @@ class AutoRound(object):
                 device=self.device,
                 pbar=pbar
             )
+            if self.is_packing_immediate:
+                assert len(self.formats) == 0
+                for n, m in self.model.named_modules():
+                    if isinstance(m, torch.nn.Linear):
+                        m.name = n
+                for _, tmp_m in m.named_modules():
 
-        self.quant_layers(layer_names, all_inputs)
+                    if hasattr(tmp_m, "bits") and tmp_m.bits <= 8:
+                        pack_layer(tmp_m.name, self.model, self.formats)
 
-        self.dump_qinfo_to_layer_config()
-
+        self.quant_layers(layer_names, all_inputs)  ##TODO pack layer immediately
+        for n, m in self.model.named_modules():
+            if hasattr(m, "name"):
+                delattr(m, "name")
         end_time = time.time()
         cost_time = end_time - self.start_time
         logger.info(f"quantization tuning time {cost_time}")
@@ -439,35 +527,7 @@ class AutoRound(object):
         logger.info(summary_info)
 
         self.quantized = True
-        ##self.model = self.model.to(self.model_orig_dtype)##keep it as amp dtype
         return self.model, self.layer_config
-
-    def dump_qinfo_to_layer_config(self):
-        """
-        dump quantization scale and zp to layer configuration, this function could be deleted later
-        Args:
-
-        Returns:
-            None
-        """
-        # load scale and zp if use low_cpu_memory
-        self.model = self.model.to('cpu')
-
-        for n, m in self.model.named_modules():
-            if n not in self.layer_config.keys():
-                continue
-            if hasattr(m, "orig_layer"):
-                m = m.orig_layer
-            if not hasattr(m, "scale"):
-                self.layer_config[n]["data_type"] = "float"
-                if self.amp_dtype == torch.bfloat16:
-                    self.layer_config[n]["data_type"] = "bfloat"
-                self.layer_config[n]["bits"] = 16
-                self.layer_config[n]["group_size"] = None
-                self.layer_config[n]["sym"] = None
-                m.bits = 16
-                m.group_size = None
-                m.sym = None
 
     def quant_layers(self, layer_names, layer_inputs):
         """Quantizes specified layers based on inputs and configuration.
@@ -497,7 +557,6 @@ class AutoRound(object):
 
         self.model = mv_module_from_gpu(self.model, self.low_cpu_mem_usage)
         clear_memory()
-        device = next(self.model.parameters()).device
         if self.enable_torch_compile:
             quant_layer = compile_func(self.quant_layer, self.device)
         else:
@@ -512,44 +571,69 @@ class AutoRound(object):
             clear_memory(q_layer_input)
 
     def set_layerwise_config(self, layer_config):
-        """Sets the layer-wise configuration based on the provided layer_config.
-           By default, only quantize layers in blocks.
+        """
+        Sets the layer-wise configuration based on the provided `layer_config`.
+        By default, only quantize layers in blocks.
 
         Args:
-        layer_config: The layer configuration.
+            layer_config (dict): The configuration dictionary for each layer containing various configuration options.
 
         Returns:
-        None
+            bool: Returns True if there are quantized layers outside the blocks (e.g., lm-head), otherwise returns False.
         """
+        # Get the names of layers in quantization blocks
         layers_in_blocks = get_layer_names_in_block(self.model, self.supported_types, self.quant_block_list)
-        keys = ["data_type", "bits", "group_size", "sym", "scale_dtype", "act_bits", "act_group_size", "act_sym",
-                "act_dynamic", "act_data_type"]
+
+        # List of configuration keys
+        keys = self.serialization_keys
+
+        has_qlayer_outside_block = False  # Flag to track if there are quantized layers outside blocks (e.g., lm-head)
+
+        # Iterate through all modules in the model
         for n, m in self.model.named_modules():
-            ##delete keys to avoid conflict with the previous tuning
+
+            # Delete previous configuration to avoid conflicts with prior tuning
             for key in keys:
                 if hasattr(m, key):
                     delattr(m, key)
 
+            # Skip unsupported types
             if not isinstance(m, tuple(self.supported_types)):
                 continue
-            ##not set in layer config, so use the default values
+
+            # If the layer is not in the config and is part of a quantization block, use default configuration
             if n not in layer_config.keys() and n in layers_in_blocks:
                 layer_config[n] = {}
                 for key in keys:
                     layer_config[n][key] = getattr(self, key)
-            elif n in layer_config.keys():  ## partly set
+            # If the layer is partially configured, fill in missing values
+            elif n in layer_config.keys():
                 for key in keys:
                     if key not in layer_config[n].keys():
                         layer_config[n][key] = getattr(self, key)
-            else:  ##not in layer_config and layers in block,
+            # If the layer is not in the config and not part of a quantization block, use default configuration and set specific values
+            else:
                 layer_config[n] = {}
                 for key in keys:
                     layer_config[n][key] = getattr(self, key)
                 layer_config[n]["bits"] = 16
                 layer_config[n]["act_bits"] = 16
 
+            if n in layers_in_blocks:
+                layer_config[n]["in_blocks"] = True
+            else:
+                layer_config[n]["in_blocks"] = False
+
+            # If the layer is outside a block and requires quantization, mark it as a quantized layer outside the block
+            if n not in layers_in_blocks and check_to_quantized(layer_config[n]):
+                has_qlayer_outside_block = True
+
+            # Apply the configuration to the corresponding layer in the model
             for key in keys:
                 setattr(m, key, layer_config[n][key])
+
+        # Return whether there are quantized layers outside the blocks
+        return has_qlayer_outside_block
 
     @torch.no_grad()
     def get_block_outputs(self, block, input_ids, input_others, bs, device, cache_device, save_output=True):
@@ -1413,38 +1497,10 @@ class AutoRound(object):
         if "awq" in format and not self.bits == 4:
             raise ValueError("The AWQ format only supports W4 quantization ")
 
-        serialization_keys = [
-            "bits",
-            "act_bits",
-
-            "group_size",
-            "sym",
-            "data_type",
-            "enable_quanted_input",
-            "enable_minmax_tuning",
-            "data_type",
-            "seqlen",
-            "batch_size",
-            "scale_dtype",
-            "lr",
-            "minmax_lr",
-            "gradient_accumulate_steps",
-            "iters",
-            "amp",
-            "nsamples",
-            "low_gpu_mem_usage",
-            "to_quant_block_names",
-            "enable_norm_bias_tuning"
-        ]
-        if self.act_bits <= 8:
-            serialization_keys.extend(["act_bits",
-                                       "act_group_size",
-                                       "act_sym",
-                                       "act_dynamic"])
         if isinstance(self.dataset, str):
-            serialization_keys.append("dataset")
+            self.serialization_keys.append("dataset")
         serialization_dict = {}
-        for key in serialization_keys:
+        for key in self.serialization_keys:
             serialization_dict[key] = getattr(self, key)
         from .version import __version__
 

--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -386,9 +386,9 @@ class AutoRound(object):
                     f" as nsamples must equal or greater"
                     f" than gradient_accumulate_steps * batch_size")
 
-    def _check_format_compatibility(self, format):  ##TODO
-        ##check lm_head, mixed_bits, bits, each layer supporting, etc
-        pass
+    # def _check_format_compatibility(self, format):  ##TODO
+    #     ##check lm_head, mixed_bits, bits, each layer supporting, etc
+    #     pass
 
     def quantize_and_save(self, output_dir: str = "tmp_autoround", format: str = "auto_round", inplace=True, **kwargs):
         """Quantizes the model and saves it in the specified format(s).
@@ -450,8 +450,8 @@ class AutoRound(object):
         formats = list(set(formats))
         self.formats = formats
 
-        # Check format compatibility
-        self._check_format_compatibility(formats)
+        # # Check format compatibility
+        # self._check_format_compatibility(formats)
 
         # Perform model quantization
         model, _ = self.quantize()

--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -1423,9 +1423,10 @@ class AutoRound(object):
                 q_input=q_input,
                 device=device,
             )
-            for _, tmp_m in m.named_modules():
-                if hasattr(tmp_m, "bits") and check_to_quantized(tmp_m):
-                    pack_layer(tmp_m.name, self.model, self.formats[0])
+            if self.is_packing_immediate:
+                for _, tmp_m in m.named_modules():
+                    if hasattr(tmp_m, "bits") and check_to_quantized(tmp_m):
+                        pack_layer(tmp_m.name, self.model, self.formats[0])
 
             pbar.update(1)
 

--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -1446,6 +1446,8 @@ class AutoRound(object):
                 m.name = n
 
         for i in range(0, len(block_names), nblocks):
+            if i!=0:
+                pbar.update(1)
             if nblocks == 1:
                 n = block_names[i]
                 pbar.set_description(f"Quantizing {n}")
@@ -1472,8 +1474,9 @@ class AutoRound(object):
                     if hasattr(tmp_m, "bits") and check_to_quantized(tmp_m):
                         target_backend = self.formats[0].split(":")[0] if ":" in self.formats[0] else self.formats[0]
                         PACKING_LAYER_WITH_FORMAT[target_backend](tmp_m.name, self.model, self.formats[0])
-
-            pbar.update(1)
+        pbar.set_description(f"Quantizing done")
+        pbar.update(1)
+        pbar.close()
 
         self.model = mv_module_from_gpu(self.model, self.low_cpu_mem_usage)
         for n, m in self.model.named_modules():

--- a/auto_round/export/__init__.py
+++ b/auto_round/export/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from auto_round.export.register import EXPORT_FORMAT, register_format
+from auto_round.export.register import EXPORT_FORMAT,PACKING_LAYER_WITH_FORMAT, register_format,register_layer_packing
 
 
 @register_format("auto_gptq")
@@ -53,3 +53,27 @@ def _save_quantized_as_autoawq(*args, **kwargs):
 def _save_quantized_as_autoawq(*args, **kwargs):
     from auto_round.export.export_to_gguf.export import save_quantized_as_gguf
     return save_quantized_as_gguf(*args, **kwargs)
+
+
+@register_layer_packing("auto_round")
+def _packing_layer_with_autoround(*args, **kwargs):
+    from auto_round.export.export_to_autoround.export import pack_layer
+
+    return pack_layer(*args, **kwargs)
+
+
+@register_layer_packing("auto_gptq")
+def _packing_layer_with_autogptq(*args, **kwargs):
+    from auto_round.export.export_to_autogptq.export import pack_layer
+
+    return pack_layer(*args, **kwargs)
+
+
+@register_layer_packing("auto_awq")
+def _packing_layer_with_autoawq(*args, **kwargs):
+    from auto_round.export.export_to_awq.export import pack_layer
+
+    return pack_layer(*args, **kwargs)
+
+
+

--- a/auto_round/export/export_to_autoround/export.py
+++ b/auto_round/export/export_to_autoround/export.py
@@ -154,10 +154,10 @@ def pack_layer(layer_name, model, backend):
     if not isinstance(layer, supported_layer_types):  ##already packed
         return
 
-    if layer.act_bits <= 8:
+    if int(layer.act_bits) <= 8:
         return pack_qact_layer(layer_name, model)
 
-    if layer.bits > 8:
+    if int(layer.bits) > 8:
         return
 
     device = layer.weight.device

--- a/auto_round/export/export_to_autoround/export.py
+++ b/auto_round/export/export_to_autoround/export.py
@@ -88,121 +88,132 @@ def dynamic_import_quant_linear_for_packing(backend, bits, group_size, sym, act_
 
 
 def pack_qact_layer(name, model):
-    with tctl.threadpool_limits(limits=1):
+    layer = get_module(model, name)
+    if hasattr(layer, "orig_layer"):
+        layer = layer.orig_layer
 
-        layer = get_module(model, name)
-        if hasattr(layer, "orig_layer"):
-            layer = layer.orig_layer
+    if layer.bits > 8:
+        return
 
-        if layer.bits > 8:
-            return
+    device = layer.weight.device
+    bits = layer.bits
+    group_size = layer.group_size
+    act_bits = layer.act_bits
 
-        device = layer.weight.device
+    act_scale = layer.act_scale if hasattr(layer, "act_scale") else None
+    w_bf16_to_fp8_scale = layer.w_bf16_to_fp8_scale if hasattr(layer, "w_bf16_to_fp8_scale") else None
+    scale = layer.scale
+    zp = layer.zp
+    QuantLinear = auto_round.export.export_to_autoround.qlinear_triton_act.QuantLinear
 
-        bits = layer.bits
-        group_size = layer.group_size
-        sym = layer.sym
-        act_bits = layer.act_bits
-        assert act_bits <= 8
+    if isinstance(layer, nn.Linear):
+        in_features = layer.in_features
+        out_features = layer.out_features
+    elif isinstance(layer, nn.Conv2d):
+        in_features = layer.in_channels
+        out_features = layer.out_channels
+    elif isinstance(layer, transformers.pytorch_utils.Conv1D):
+        in_features = layer.weight.shape[0]
+        out_features = layer.weight.shape[1]
+    bias = layer.bias is not None
+    use_pc = False
+    new_layer = QuantLinear(  ##pylint: disable=E1123
+        bits, group_size, in_features, out_features, bias, weight_dtype=layer.weight.dtype, use_pc=use_pc
+    )
+    new_layer.device = device
+    set_module(model, name, new_layer)
+    qlayer = new_layer
 
-        act_scale = layer.act_scale if hasattr(layer, "act_scale") else None
-        w_bf16_to_fp8_scale = layer.w_bf16_to_fp8_scale if hasattr(layer, "w_bf16_to_fp8_scale") else None
-        scale = layer.scale
-        zp = layer.zp
-        QuantLinear = auto_round.export.export_to_autoround.qlinear_triton_act.QuantLinear
+    qlayer.to("cpu")
 
-        if isinstance(layer, nn.Linear):
-            in_features = layer.in_features
-            out_features = layer.out_features
-        elif isinstance(layer, nn.Conv2d):
-            in_features = layer.in_channels
-            out_features = layer.out_channels
-        elif isinstance(layer, transformers.pytorch_utils.Conv1D):
-            in_features = layer.weight.shape[0]
-            out_features = layer.weight.shape[1]
-        bias = layer.bias is not None
-        use_pc = False
+    qlayer.pack(layer, scale, zp, act_scale, w_bf16_to_fp8_scale)
+    qlayer.to(device)
+
+
+def pack_layer(layer_name, model, backend):
+    """
+     Packs a model layer for quantization based on its type and configuration.
+
+    This function retrieves the specified layer from the model, checks its
+    compatibility for quantization, and replaces it with a quantized version
+    if applicable. The quantization process depends on the layer's bit-width,
+    group size, symmetry, and activation bits.
+
+    Args:
+        layer_name (str): The name of the layer to be packed.
+        model (torch.nn.Module): The model containing the layer.
+        backend (str): The backend framework to be used for quantization.
+
+    Returns:
+        None: The function modifies the model in place.
+    """
+    layer = get_module(model, layer_name)
+    if hasattr(layer, "orig_layer"):
+        layer = layer.orig_layer
+
+    if not isinstance(layer, supported_layer_types):  ##already packed
+        return
+
+    if layer.act_bits <= 8:
+        return pack_qact_layer(layer_name, model)
+
+    if layer.bits > 8:
+        return
+
+    device = layer.weight.device
+    bits = layer.bits
+    group_size = layer.group_size
+    sym = layer.sym
+    act_bits = layer.act_bits
+
+    scale = layer.scale
+    zp = layer.zp
+    QuantLinear = dynamic_import_quant_linear_for_packing(backend, bits, group_size, sym, act_bits)
+
+    if isinstance(layer, nn.Linear):
+        in_features = layer.in_features
+        out_features = layer.out_features
+    elif isinstance(layer, nn.Conv2d):
+        in_features = layer.in_channels
+        out_features = layer.out_channels
+    elif isinstance(layer, transformers.pytorch_utils.Conv1D):
+        in_features = layer.weight.shape[0]
+        out_features = layer.weight.shape[1]
+    bias = layer.bias is not None
+
+    if "awq" not in backend:
         new_layer = QuantLinear(  ##pylint: disable=E1123
-            bits, group_size, in_features, out_features, bias, weight_dtype=layer.weight.dtype, use_pc=use_pc
+            bits, group_size, in_features, out_features, bias, weight_dtype=layer.weight.dtype
         )
         new_layer.device = device
-        set_module(model, name, new_layer)
+        set_module(model, layer_name, new_layer)
         qlayer = new_layer
 
         qlayer.to("cpu")
-
-        qlayer.pack(layer, scale, zp, act_scale, w_bf16_to_fp8_scale)
-        qlayer.to(device)
-
-
-def pack_layer(name, model, backend):
-    with tctl.threadpool_limits(limits=1):
-        layer = get_module(model, name)
-        if hasattr(layer, "orig_layer"):
-            layer = layer.orig_layer
-
-        if not isinstance(layer,supported_layer_types): ##already packed
-            return
-        if layer.act_bits <= 8:
-            return pack_qact_layer(name, model)
-
-        if layer.bits > 8:
-            return
-        device = layer.weight.device
-
-        bits = layer.bits
-        group_size = layer.group_size
-        sym = layer.sym
-        act_bits = layer.act_bits
-
-        scale = layer.scale
-        zp = layer.zp
-        QuantLinear = dynamic_import_quant_linear_for_packing(backend, bits, group_size, sym, act_bits)
-
-        if isinstance(layer, nn.Linear):
-            in_features = layer.in_features
-            out_features = layer.out_features
-        elif isinstance(layer, nn.Conv2d):
-            in_features = layer.in_channels
-            out_features = layer.out_channels
-        elif isinstance(layer, transformers.pytorch_utils.Conv1D):
-            in_features = layer.weight.shape[0]
-            out_features = layer.weight.shape[1]
-        bias = layer.bias is not None
-
-        if "awq" not in backend:
-            new_layer = QuantLinear(  ##pylint: disable=E1123
-                bits, group_size, in_features, out_features, bias, weight_dtype=layer.weight.dtype
-            )
-            new_layer.device = device
-            set_module(model, name, new_layer)
-            qlayer = new_layer
-
-            qlayer.to("cpu")
-            ##force to float32 to be compatible with torch 2.0
-            sig = inspect.signature(qlayer.pack)
-            param_count = len(sig.parameters)
-            if param_count == 2:
-                qlayer.pack(layer, scale)
-            else:
-                qlayer.pack(layer, scale, zp, None)
-            qlayer.to(device)
+        ##force to float32 to be compatible with torch 2.0
+        sig = inspect.signature(qlayer.pack)
+        param_count = len(sig.parameters)
+        if param_count == 2:
+            qlayer.pack(layer, scale)
         else:
-            scale, zp = scale.to(torch.float32), zp.to(torch.float32)
-            scale = scale.t().contiguous()
-            zp = zp.t().contiguous()
-            if bits != 4:
-                logger.error("AutoAWQ format only supports 4-bits quantization.")
-            qlayer = QuantLinear.from_linear(
-                linear=layer,
-                w_bit=bits,
-                group_size=group_size,
-                init_only=False,
-                scales=scale,
-                zeros=zp,
-            )
-            qlayer.to(device)
-            set_module(model, name, qlayer)
+            qlayer.pack(layer, scale, zp, None)
+        qlayer.to(device)
+    else:
+        scale, zp = scale.to(torch.float32), zp.to(torch.float32)
+        scale = scale.t().contiguous()
+        zp = zp.t().contiguous()
+        if bits != 4:
+            logger.error("AutoAWQ format only supports 4-bits quantization.")
+        qlayer = QuantLinear.from_linear(
+            linear=layer,
+            w_bit=bits,
+            group_size=group_size,
+            init_only=False,
+            scales=scale,
+            zeros=zp,
+        )
+        qlayer.to(device)
+        set_module(model, layer_name, qlayer)
 
 
 def save_quantized_as_autoround(output_dir, inplace=True, backend="auto_round:exllamav2", **kwargs):
@@ -250,7 +261,8 @@ def save_quantized_as_autoround(output_dir, inplace=True, backend="auto_round:ex
     processor = kwargs.get("processor", None)
     extra_config = {}
     for layer_name in layer_config:
-        if not layer_config[layer_name]["in_blocks"] and layer_config[layer_name]["bits"] <= 8:  ##lm head ##TODO fix act and so on
+        if not layer_config[layer_name]["in_blocks"] and layer_config[layer_name][
+            "bits"] <= 8:  ##lm head ##TODO fix act and so on
             extra_config[layer_name] = {}
             extra_config[layer_name]["bits"] = layer_config[layer_name]["bits"]
             extra_config[layer_name]["data_type"] = layer_config[layer_name]["data_type"]
@@ -279,7 +291,8 @@ def save_quantized_as_autoround(output_dir, inplace=True, backend="auto_round:ex
         with tqdm(total=len(names), leave=True) as pbar:
             def wrapper(name):
                 pbar.set_description(f"packing {name}")
-                pack_layer(name, model, backend)
+                with tctl.threadpool_limits(limits=1):
+                    pack_layer(name, model, backend)
                 pbar.update(1)
 
             for _ in executor.map(wrapper, names):

--- a/auto_round/export/export_to_autoround/export.py
+++ b/auto_round/export/export_to_autoround/export.py
@@ -22,7 +22,7 @@ import torch.nn as nn
 import transformers
 
 import auto_round.export.export_to_autoround.qlinear_triton_act
-from auto_round.utils import get_layer_names_in_block, get_module, logger, set_module
+from auto_round.utils import get_layer_names_in_block, get_module, logger, set_module, supported_layer_types
 import threadpoolctl as tctl
 import inspect
 from tqdm import tqdm
@@ -140,6 +140,9 @@ def pack_layer(name, model, backend):
         layer = get_module(model, name)
         if hasattr(layer, "orig_layer"):
             layer = layer.orig_layer
+
+        if not isinstance(layer,supported_layer_types): ##already packed
+            return
         if layer.act_bits <= 8:
             return pack_qact_layer(name, model)
 

--- a/auto_round/export/export_to_itrex/export.py
+++ b/auto_round/export/export_to_itrex/export.py
@@ -20,7 +20,7 @@ from typing import Dict, List, Optional, Union
 import torch
 import transformers
 from auto_round.export.register import register_format
-from auto_round.utils import get_module, logger, set_module, detect_device
+from auto_round.utils import get_module, logger, set_module, detect_device, check_to_quantized
 
 from .config import QuantConfig
 from .model_wrapper import WeightOnlyLinear
@@ -203,7 +203,7 @@ def pack_model(
         q_config = layer_config
     
     for k, v in q_config.items():
-        if "float" in v["data_type"]:
+        if check_to_quantized(v) is False:
             continue
         logger.info(f"Packing {k}")
         dtype = v["data_type"]

--- a/auto_round/export/register.py
+++ b/auto_round/export/register.py
@@ -34,3 +34,26 @@ def register_format(name):
         return format
 
     return register
+
+
+
+PACKING_LAYER_WITH_FORMAT = {}
+
+def register_layer_packing(name):
+    """Class decorator to register a EXPORT subclass to the registry.
+
+    Decorator function used before a Pattern subclass.
+
+    Args:
+        cls (class): The subclass of register.
+        name: A string. Define the export type.
+
+    Returns:
+        cls: The class of register.
+    """
+
+    def register(format):
+        PACKING_LAYER_WITH_FORMAT[name] = format
+        return format
+
+    return register

--- a/auto_round/script/llm.py
+++ b/auto_round/script/llm.py
@@ -30,11 +30,9 @@ import re
 import argparse
 import sys
 
-import auto_round.utils
 from auto_round.utils import (
     get_fp_layer_names,
     clear_memory,
-    is_debug_mode,
     get_device_and_parallelism,
     set_cuda_visible_devices)
 
@@ -368,9 +366,10 @@ def tune(args):
         args.format = "auto_round"
 
     formats = args.format.lower().replace(' ', '').split(",")
+    from auto_round.utils import supported_formats
     for format in formats:
-        if format not in auto_round.supported_formats:
-            raise ValueError(f"{format} is not supported, we only support {auto_round.supported_formats}")
+        if format not in supported_formats:
+            raise ValueError(f"{format} is not supported, we only support {supported_formats}")
 
     args = _gguf_args_check(args)
 

--- a/auto_round/script/llm.py
+++ b/auto_round/script/llm.py
@@ -544,7 +544,7 @@ def tune(args):
     else:
         export_dir = os.path.join(args.output_dir, model_name.split('/')[-1] + f"-w{args.bits}g{args.group_size}")
 
-    model, folders = autoround.qsave(export_dir, format=args.format)
+    model, folders = autoround.quantize_and_save(export_dir, format=args.format)
 
     if args.low_cpu_mem_mode == 1 or args.low_cpu_mem_mode == 2:
         import shutil

--- a/auto_round/utils.py
+++ b/auto_round/utils.py
@@ -40,7 +40,6 @@ supported_formats = (
 supported_layer_types = (torch.nn.Linear, transformers.modeling_utils.Conv1D)
 
 
-
 @lru_cache(None)
 def warning_once(self, msg: str):
     self.warning(msg)
@@ -804,8 +803,8 @@ def check_memory_availability(device, inputs, weight, org_seqlen, org_bs):
     return False, seqlen, bs
 
 
-def get_layer_names_in_block(model, supported_types=[torch.nn.Linear,
-                                                     transformers.modeling_utils.Conv1D], quant_block_list=None):
+def get_layer_names_in_block(model, supported_types=(torch.nn.Linear,
+                                                     transformers.modeling_utils.Conv1D), quant_block_list=None):
     """Retrieves the names of layers within each block of the model.
 
     Returns:
@@ -813,7 +812,7 @@ def get_layer_names_in_block(model, supported_types=[torch.nn.Linear,
               within a block of the model.
     """
     for n, m in model.named_modules():
-        if isinstance(m, tuple(supported_types)):
+        if isinstance(m, supported_types):
             m.tmp_name = n
     layers_in_block = []
     if bool(quant_block_list):

--- a/auto_round/utils.py
+++ b/auto_round/utils.py
@@ -18,11 +18,8 @@ import os
 import sys
 import subprocess
 from collections import UserDict
-from typing import Union, Optional
 import re
-# for cpu usage
 import cpuinfo
-import numpy as np
 import psutil
 import torch
 from torch.amp import autocast
@@ -32,11 +29,16 @@ from packaging import version
 import gc
 from .special_model_handler import shareable_keywords, SPECIAL_MULTIMODAL_BLOCK
 import transformers
+from auto_round.export.export_to_gguf.config import GGUF_CONFIG
 
 supported_formats = (
     "auto_round", "auto_gptq", "auto_awq", "auto_round:auto_gptq", "auto_round:auto_awq", "auto_gptq:marlin",
-    "gguf:q4_0", "gguf:q4_1", "itrex", "itrex_xpu", "fake"
+    "itrex", "itrex_xpu", "fake"
 )
+
+
+supported_formats = supported_formats + tuple(GGUF_CONFIG.keys())
+
 supported_layer_types = (torch.nn.Linear, transformers.modeling_utils.Conv1D)
 
 

--- a/auto_round/utils.py
+++ b/auto_round/utils.py
@@ -32,6 +32,11 @@ from packaging import version
 import gc
 from .special_model_handler import shareable_keywords, SPECIAL_MULTIMODAL_BLOCK
 
+supported_formats = [
+    "auto_round", "auto_gptq", "auto_awq", "auto_round:auto_gptq", "auto_round:auto_awq", "auto_gptq:marlin",
+    "gguf:q4_0", "gguf:q4_1", "itrex", "itrex_xpu", "fake"
+]
+
 
 @lru_cache(None)
 def warning_once(self, msg: str):
@@ -515,11 +520,11 @@ def check_to_quantized(config):
     """
     if isinstance(config, dict):
 
-        if int(config["bits"]) > 8:
+        if int(config["bits"]) > 8 and int(config["act_bits"] > 8):
             return False
         return True
     else:
-        if int(config.bits) > 8:
+        if int(config.bits) > 8 and int(config.act_bits) > 8:
             return False
         return True
 
@@ -1157,6 +1162,7 @@ def check_awq_gemm_compatibility(model, bits, group_size, sym, layer_configs=Non
 
     return True, ""
 
+
 def get_device_and_parallelism(device):
     from auto_round.utils import detect_device
     devices = device.replace(" ", "").split(',')
@@ -1170,6 +1176,7 @@ def get_device_and_parallelism(device):
         device = detect_device(device)
         parallelism = False
     return device, parallelism
+
 
 def set_cuda_visible_devices(device):
     devices = device.replace(" ", "").split(',')

--- a/auto_round/utils.py
+++ b/auto_round/utils.py
@@ -31,11 +31,14 @@ from functools import lru_cache
 from packaging import version
 import gc
 from .special_model_handler import shareable_keywords, SPECIAL_MULTIMODAL_BLOCK
+import transformers
 
-supported_formats = [
+supported_formats = (
     "auto_round", "auto_gptq", "auto_awq", "auto_round:auto_gptq", "auto_round:auto_awq", "auto_gptq:marlin",
     "gguf:q4_0", "gguf:q4_1", "itrex", "itrex_xpu", "fake"
-]
+)
+supported_layer_types = (torch.nn.Linear, transformers.modeling_utils.Conv1D)
+
 
 
 @lru_cache(None)

--- a/auto_round/version.py
+++ b/auto_round/version.py
@@ -14,4 +14,4 @@
 """Intel® auto-round: An open-source Python library
 supporting popular model weight only compression based on signround."""
 
-__version__ = "0.4.6"
+__version__ = "0.5.0"

--- a/test/test_autoround.py
+++ b/test/test_autoround.py
@@ -237,7 +237,7 @@ class TestAutoRound(unittest.TestCase):
             dataset=self.llm_dataloader,
         )
         autoround.quantize()
-
+    #
     def test_signround(self):
         bits, group_size, sym = 4, -1, False
         autoround = AutoRound(
@@ -271,6 +271,7 @@ class TestAutoRound(unittest.TestCase):
             layer_config=layer_config,
         )
         autoround.quantize()
+
     def test_wa_quant(self):
         bits, group_size, sym, act_bits = 4, 128, False, 4
         autoround = AutoRound(
@@ -285,7 +286,7 @@ class TestAutoRound(unittest.TestCase):
             act_bits=4,
         )
         autoround.quantize()
-    
+
     def test_auto_device_map(self):
         bits, group_size, sym = 4, 128, False
         model_name = "facebook/opt-125m"
@@ -301,7 +302,7 @@ class TestAutoRound(unittest.TestCase):
             dataset=self.llm_dataloader,
         )
         autoround.quantize()
-    
+
     def test_fp32(self):
         bits, group_size, sym = 4, 128, False
         model_name = "facebook/opt-125m"
@@ -325,8 +326,8 @@ class TestAutoRound(unittest.TestCase):
         model_name = "facebook/opt-125m"
         model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.float32, trust_remote_code=True,
                                                      device_map='auto')
-        layer_config = {"model.decoder.layers.0.self_attn.q_proj": {"bits": "16"},
-                        "model.decoder.layers.1.self_attn.k_proj": {"bits": "16"}}
+        layer_config = {"model.decoder.layers.0.self_attn.q_proj": {"bits": 16},
+                        "model.decoder.layers.1.self_attn.k_proj": {"bits": 16}}
         autoround = AutoRound(
             model,
             self.tokenizer,

--- a/test/test_autoround_export_to_itrex.py
+++ b/test/test_autoround_export_to_itrex.py
@@ -90,7 +90,7 @@ class TestAutoroundExport(unittest.TestCase):
         self.assertEqual(config.desc_act, loaded_config.desc_act)
         self.assertEqual(config.bits, loaded_config.bits)
         self.assertEqual(config.sym, loaded_config.sym)
-        
+
     def test_xpu_export(self):
         model = copy.deepcopy(self.gptj)
         out1 = model(self.lm_input)

--- a/test/test_basic_usage.py
+++ b/test/test_basic_usage.py
@@ -26,13 +26,15 @@ class TestAutoRoundCmd(unittest.TestCase):
             assert False, "cmd line test fail, please have a check"
 
         res = os.system(
-            f"cd .. && {python_path} -m auto_round --model 'facebook/opt-125m' --iter 2 --nsamples 1 --format auto_gptq,auto_round --output_dir ./saved --tasks piqa,openbookqa")
+            f"cd .. && {python_path} -m auto_round --model 'facebook/opt-125m' --iter 2 --nsamples 1 --format auto_round --output_dir ./saved --tasks piqa,openbookqa")
         if res > 0 or res == -1:
             assert False, "cmd line test fail, please have a check"
         
         res = os.system(
-            f"cd .. && {python_path} -m auto_round --model './saved' --eval_task_by_task --tasks piqa,openbookqa --bs 32"
+            f"cd .. && {python_path} -m auto_round --model 'facebook/opt-125m' --eval_task_by_task --tasks piqa,openbookqa --bs 32"
         )
+        if res > 0 or res == -1:
+            assert False, "cmd line test fail, please have a check"
 
 
         # test mllm script
@@ -47,7 +49,7 @@ class TestAutoRoundCmd(unittest.TestCase):
             f"cd .. && {python_path} -m auto_round --mllm --eval -h")
         if res > 0 or res == -1:
             assert False, "cmd line test fail, please have a check"
-        
+
         # test auto_round_mllm --lmms help
         res = os.system(
             f"cd .. && {python_path} -m auto_round --mllm --lmms -h")

--- a/test/test_basic_usage.py
+++ b/test/test_basic_usage.py
@@ -26,7 +26,7 @@ class TestAutoRoundCmd(unittest.TestCase):
             assert False, "cmd line test fail, please have a check"
 
         res = os.system(
-            f"cd .. && {python_path} -m auto_round --model 'facebook/opt-125m' --iter 2 --nsamples 1 --format auto_round,auto_gptq --output_dir ./saved --tasks piqa,openbookqa")
+            f"cd .. && {python_path} -m auto_round --model 'facebook/opt-125m' --iter 2 --nsamples 1 --format auto_gptq,auto_round --output_dir ./saved --tasks piqa,openbookqa")
         if res > 0 or res == -1:
             assert False, "cmd line test fail, please have a check"
         

--- a/test/test_basic_usage.py
+++ b/test/test_basic_usage.py
@@ -26,7 +26,7 @@ class TestAutoRoundCmd(unittest.TestCase):
             assert False, "cmd line test fail, please have a check"
 
         res = os.system(
-            f"cd .. && {python_path} -m auto_round --model 'facebook/opt-125m' --iter 2 --nsamples 1 --format auto_round --output_dir ./saved --tasks piqa,openbookqa")
+            f"cd .. && {python_path} -m auto_round --model 'facebook/opt-125m' --iter 2 --nsamples 1 --format auto_round,auto_gptq --output_dir ./saved --tasks piqa,openbookqa")
         if res > 0 or res == -1:
             assert False, "cmd line test fail, please have a check"
         

--- a/test_cuda/test_export.py
+++ b/test_cuda/test_export.py
@@ -173,6 +173,7 @@ class TestAutoRound(unittest.TestCase):
                        "she is a great artist, she is a great artist, she is a great artist, she is")
         shutil.rmtree("./saved", ignore_errors=True)
 
+
     #
     def test_autoawq_format(self):
         model = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype="auto", trust_remote_code=True)

--- a/test_cuda/test_export.py
+++ b/test_cuda/test_export.py
@@ -115,7 +115,7 @@ class TestAutoRound(unittest.TestCase):
             layer_config=layer_config
         )
         quantized_model_path = "./saved"
-        autoround.qsave(output_dir=quantized_model_path, format="auto_gptq")
+        autoround.quantize_and_save(output_dir=quantized_model_path, format="auto_gptq")
 
         model = AutoModelForCausalLM.from_pretrained(quantized_model_path, device_map="auto", trust_remote_code=True)
         tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)

--- a/test_cuda/test_export.py
+++ b/test_cuda/test_export.py
@@ -1,0 +1,243 @@
+import copy
+import shutil
+import sys
+import unittest
+
+sys.path.insert(0, "..")
+import torch
+import transformers
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from auto_round import AutoRound
+
+
+class LLMDataLoader:
+    def __init__(self):
+        self.batch_size = 1
+
+    def __iter__(self):
+        for i in range(2):
+            yield torch.ones([1, 10], dtype=torch.long)
+
+
+class TestAutoRound(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.model_name = "facebook/opt-125m"
+
+        self.llm_dataloader = LLMDataLoader()
+
+    @classmethod
+    def tearDownClass(self):
+        shutil.rmtree("./saved", ignore_errors=True)
+        shutil.rmtree("runs", ignore_errors=True)
+
+    def test_autogptq_format(self):
+        model = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype="auto", trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_name, trust_remote_code=True)
+        bits, group_size, sym = 4, 128, False
+        autoround = AutoRound(
+            model,
+            tokenizer,
+            bits=bits,
+            group_size=group_size,
+            sym=sym,
+            iters=2,
+            seqlen=2,
+            dataset=self.llm_dataloader,
+        )
+        autoround.quantize()
+        quantized_model_path = "./saved"
+
+        autoround.save_quantized(output_dir=quantized_model_path, inplace=False, format="auto_gptq")
+        model = AutoModelForCausalLM.from_pretrained(quantized_model_path, device_map="auto", trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
+        text = "There is a girl who likes adventure,"
+        inputs = tokenizer(text, return_tensors="pt").to(model.device)
+        res = tokenizer.decode(model.generate(**inputs, max_new_tokens=50)[0])
+        assert (res == "</s>There is a girl who likes adventure, she is a good friend of mine, she is a good friend of"
+                       " mine, she is a good friend of mine, she is a good friend of mine, she is a good friend of mine, "
+                       "she is a good friend of mine, she is")
+        shutil.rmtree("./saved", ignore_errors=True)
+
+    def test_autogptq_format_fp_layers(self):
+        model = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype="auto", trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_name, trust_remote_code=True)
+        layer_config = {}
+        for n, m in model.named_modules():
+            if "q_proj" in n:
+                layer_config[n] = {"bits": 16}
+
+        bits, group_size, sym = 4, 128, False
+        autoround = AutoRound(
+            model,
+            tokenizer,
+            bits=bits,
+            group_size=group_size,
+            sym=sym,
+            iters=1,
+            seqlen=2,
+            dataset=self.llm_dataloader,
+            layer_config=layer_config
+        )
+        autoround.quantize()
+        quantized_model_path = "./saved"
+        autoround.save_quantized(output_dir=quantized_model_path, inplace=False, format="auto_gptq")
+
+        model = AutoModelForCausalLM.from_pretrained(quantized_model_path, device_map="auto", trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
+        text = "There is a girl who likes adventure,"
+        inputs = tokenizer(text, return_tensors="pt").to(model.device)
+        res = tokenizer.decode(model.generate(**inputs, max_new_tokens=50)[0])
+        assert res == ("</s>There is a girl who likes adventure, she is a great artist, she is a great artist, "
+                       "she is a great artist, she is a great artist, she is a great artist,"
+                       " she is a great artist, she is a great artist, she is a great artist, she is")
+        shutil.rmtree("./saved", ignore_errors=True)
+
+    def test_autogptq_format_qsave_fp_layers(self):
+        model = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype="auto", trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_name, trust_remote_code=True)
+        layer_config = {}
+        for n, m in model.named_modules():
+            if "q_proj" in n:
+                layer_config[n] = {"bits": 16}
+
+        bits, group_size, sym = 4, 128, False
+        autoround = AutoRound(
+            model,
+            tokenizer,
+            bits=bits,
+            group_size=group_size,
+            sym=sym,
+            iters=1,
+            seqlen=2,
+            dataset=self.llm_dataloader,
+            layer_config=layer_config
+        )
+        quantized_model_path = "./saved"
+        autoround.qsave(output_dir=quantized_model_path, format="auto_gptq")
+
+        model = AutoModelForCausalLM.from_pretrained(quantized_model_path, device_map="auto", trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
+        text = "There is a girl who likes adventure,"
+        inputs = tokenizer(text, return_tensors="pt").to(model.device)
+        res = tokenizer.decode(model.generate(**inputs, max_new_tokens=50)[0])
+        assert (
+                res == "</s>There is a girl who likes adventure, she is a great artist, she is a great artist,"
+                       " she is a great artist, she is a great artist, she is a great artist, "
+                       "she is a great artist, she is a great artist, she is a great artist, she is")
+        from auto_round import AutoRoundConfig
+
+        model = AutoModelForCausalLM.from_pretrained(quantized_model_path, device_map="auto", trust_remote_code=True,
+                                                     quantization_config=AutoRoundConfig())
+        tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
+        text = "There is a girl who likes adventure,"
+        inputs = tokenizer(text, return_tensors="pt").to(model.device)
+        g_tokens = model.generate(**inputs, max_new_tokens=50)[0]
+        res = tokenizer.decode(g_tokens)
+        assert (
+                res == "</s>There is a girl who likes adventure, she is a great artist, she is a great artist,"
+                       " she is a great artist, she is a great artist, she is a great artist, she is a great "
+                       "artist, she is a great artist, she is a great artist, she is")
+        ##print(res)
+        shutil.rmtree("./saved", ignore_errors=True)
+
+    def test_autoround_format(self):
+        model = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype="auto", trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_name, trust_remote_code=True)
+        bits, group_size, sym = 4, 128, False
+        autoround = AutoRound(
+            model,
+            tokenizer,
+            bits=bits,
+            group_size=group_size,
+            sym=sym,
+            iters=1,
+            seqlen=2,
+            dataset=self.llm_dataloader,
+        )
+        autoround.quantize()
+        quantized_model_path = "./saved"
+
+        autoround.save_quantized(output_dir=quantized_model_path, inplace=False, \
+                                 format="auto_round")
+
+        model = AutoModelForCausalLM.from_pretrained(quantized_model_path, device_map="auto")
+        tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
+        text = "There is a girl who likes adventure,"
+        inputs = tokenizer(text, return_tensors="pt").to(model.device)
+        res = tokenizer.decode(model.generate(**inputs, max_new_tokens=50)[0])
+        print(res)
+        assert res == ("</s>There is a girl who likes adventure, she is a great artist, she is a great artist,"
+                       " she is a great artist, she is a great artist, she is a great artist, "
+                       "she is a great artist, she is a great artist, she is a great artist, she is")
+        shutil.rmtree("./saved", ignore_errors=True)
+
+    #
+    def test_autoawq_format(self):
+        model = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype="auto", trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_name, trust_remote_code=True)
+        bits, group_size, sym = 4, 128, False
+        autoround = AutoRound(
+            model,
+            tokenizer,
+            bits=bits,
+            group_size=group_size,
+            sym=sym,
+            iters=1,
+            seqlen=2,
+            dataset=self.llm_dataloader,
+        )
+        autoround.quantize()
+        quantized_model_path = "./saved"
+
+        autoround.save_quantized(output_dir=quantized_model_path, inplace=False, \
+                                 format="auto_awq")
+
+        model = AutoModelForCausalLM.from_pretrained(quantized_model_path, device_map="auto")
+        tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
+        text = "There is a girl who likes adventure,"
+        inputs = tokenizer(text, return_tensors="pt").to(model.device)
+        res = tokenizer.decode(model.generate(**inputs, max_new_tokens=50)[0])
+        assert res == ("</s>There is a girl who likes adventure, but she's not a very good one.\nI don't"
+                       " know why you're getting downvoted. I think you're just being a dick.\nI'm not a dick, "
+                       "I just think it's funny that people are downvoting")
+        shutil.rmtree("./saved", ignore_errors=True)
+
+    def test_autoawq_format_fp_qsave_layers(self):
+        model = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype="auto", trust_remote_code=True)
+        layer_config = {"model.decoder.layers.0.self_attn.k_proj": {"bits": 16},
+                        "model.decoder.layers.9.self_attn.v_proj": {"bits": 16}, }
+        tokenizer = AutoTokenizer.from_pretrained(self.model_name, trust_remote_code=True)
+        bits, group_size, sym = 4, 128, False
+        autoround = AutoRound(
+            model,
+            tokenizer,
+            bits=bits,
+            group_size=group_size,
+            sym=sym,
+            iters=1,
+            seqlen=2,
+            dataset=self.llm_dataloader,
+            layer_config=layer_config
+        )
+        quantized_model_path = "/data5/wenhuach/test_export"
+        autoround.qsave(output_dir=quantized_model_path,
+                        format="auto_awq")
+        from auto_round import AutoRoundConfig
+        model = AutoModelForCausalLM.from_pretrained(quantized_model_path, device_map="auto",
+                                                     quantization_config=AutoRoundConfig())
+        tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
+        text = "There is a girl who likes adventure,"
+        inputs = tokenizer(text, return_tensors="pt").to(model.device)
+        res = tokenizer.decode(model.generate(**inputs, max_new_tokens=50)[0])
+        print(res)
+
+        model = AutoModelForCausalLM.from_pretrained(quantized_model_path, device_map="auto")
+        tokenizer = AutoTokenizer.from_pretrained(quantized_model_path)
+        text = "There is a girl who likes adventure,"
+        inputs = tokenizer(text, return_tensors="pt").to(model.device)
+        res = tokenizer.decode(model.generate(**inputs, max_new_tokens=50)[0])
+        print(res)
+
+        shutil.rmtree("./saved", ignore_errors=True)


### PR DESCRIPTION
Changing the API to know the export format before quantization will provide two key benefits:

Optimized Memory Usage – If only one export format is required, packing can begin immediately, reducing RAM consumption.
Flexible Configuration fallback– It simplifies switching to alternative configurations for GUFF qx_k as some formats have restrictions on shape