### PR TITLE
FIXBUG: CPU Offloading for Cache Blocks in Low-Memory GPU Systems or Single GPU on ROCM Configs

### DIFF
--- a/auto_round/utils.py
+++ b/auto_round/utils.py
@@ -2066,7 +2066,7 @@ def out_of_vram(error_msg):
     # XPU
     if "UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY" in error_msg:
         return True
-    #ROCM
+    # ROCM
     if "HIP out of memory. Tried to allocate" in error_msg:
         return True
     return False

--- a/auto_round/utils.py
+++ b/auto_round/utils.py
@@ -2066,4 +2066,7 @@ def out_of_vram(error_msg):
     # XPU
     if "UR_RESULT_ERROR_OUT_OF_DEVICE_MEMORY" in error_msg:
         return True
+    #ROCM
+    if "HIP out of memory. Tried to allocate" in error_msg:
+        return True
     return False


### PR DESCRIPTION
Description
This Pull Request introduces a new feature designed to optimize memory usage, particularly beneficial for systems with integrated GPUs (like many Intel platforms) or discrete GPUs with limited memory. The new --force_cpu_caching option allows users to explicitly instruct the application to cache intermediate model block inputs directly on the CPU instead of the GPU.

This capability is especially valuable in scenarios where GPU memory (VRAM) is a bottleneck, as offloading this data to system RAM frees up crucial GPU resources. This can significantly improve the ability to run larger models or process more extensive datasets that might otherwise exceed the GPU's memory capacity.

Changes Introduced
--force_cpu_caching Argument: A new boolean argument has been added. When enabled, this flag temporarily shifts the model's device to the CPU specifically for the caching operation.

Intelligent Device Management: If --force_cpu_caching is active, the model is briefly moved to the CPU to cache intermediate data (all_inputs). Upon completion of the caching process, the model's device is automatically restored to its original configuration (e.g., the integrated Intel GPU or a discrete GPU). This ensures that subsequent model operations continue to execute on the intended hardware.

Logging: Informative log messages have been added to indicate when the force_cpu_caching flag is detected and activated, and when the original device is restored.

Impact
This enhancement provides greater flexibility and robustness to our application. It allows for better adaptability across various hardware configurations, notably benefiting systems leveraging Intel integrated graphics or other GPUs with restricted memory. Users encountering out-of-memory issues or performance degradation due to VRAM limitations now have a direct solution to alleviate pressure on GPU memory.