### PR TITLE
add autoround._generate_recipe()

### DIFF
--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -3006,6 +3006,7 @@ class AutoRound(object):
         recipe_layer_config.update(self.recipe_results)
         self._dump_average_bits(layer_config=recipe_layer_config)
         self.recipe_mode = False
+        recipe_layer_config.pop("lm_head")  # lm_head is not included in the recipe
         return recipe_layer_config
 
     def _generate_block_recipe(self, block, input_ids, input_others):

--- a/auto_round/data_type/mxfp.py
+++ b/auto_round/data_type/mxfp.py
@@ -77,7 +77,6 @@ def quant_element(tensor, ebits, mbits, max_norm, mantissa_rounding="even"):
     return tensor
 
 
-@torch.compile()
 def quant_mx(tensor, bits=4, group_size=-1, v=0, max_scale=1.0, mantissa_rounding="even", data_type="mx_fp", **kwargs):
     """Quantize the given tensor using the specified parameters.
 
@@ -128,7 +127,6 @@ def quant_mx(tensor, bits=4, group_size=-1, v=0, max_scale=1.0, mantissa_roundin
     return tensor.to(orig_dtype), shared_exp.to(orig_dtype), None
 
 
-@torch.compile()
 def quant_mx_rceil(
     tensor, bits=4, group_size=-1, v=0, max_scale=1.0, mantissa_rounding="even", data_type="mx_fp", **kwargs
 ):

--- a/auto_round/data_type/mxfp.py
+++ b/auto_round/data_type/mxfp.py
@@ -180,7 +180,7 @@ def quant_mx_rceil(
 
 
 # HPU returns error with Habana software 1.22.0, so skip torch.compile here.
-if not is_hpex_available():
+if False and not is_hpex_available():
     quant_mx = torch.compile(quant_mx)
     quant_mx_rceil = torch.compile(quant_mx_rceil)
 

--- a/auto_round/data_type/mxfp.py
+++ b/auto_round/data_type/mxfp.py
@@ -22,6 +22,7 @@ from auto_round.data_type.utils import (
     revert_tensor_by_pad,
     round_ste,
 )
+from auto_round.utils import is_hpex_available
 
 MXFP_FORMAT_CACHE = {
     # data type: ebits, mbits, emax, max_norm, min_norm
@@ -177,6 +178,11 @@ def quant_mx_rceil(
     tensor = revert_tensor_by_pad(tensor, orig_shape=orig_shape, pad_len=pad_len)
     return tensor.to(orig_dtype), shared_exp.to(orig_dtype), None
 
+
+# HPU returns error with Habana software 1.22.0, so skip torch.compile here.
+if not is_hpex_available():
+    quant_mx = torch.compile(quant_mx)
+    quant_mx_rceil = torch.compile(quant_mx_rceil)
 
 for key in MXFP_FORMAT_CACHE.keys():
     QUANT_FUNC_WITH_DTYPE[key] = quant_mx

--- a/auto_round/data_type/nvfp.py
+++ b/auto_round/data_type/nvfp.py
@@ -89,6 +89,7 @@ def nv_fp4(tensor, bits=4, group_size=16, v=0, global_scale=None, **kwargs):
         tensor_max = tensor.abs().max().to(torch.float32)
         global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX * get_reciprocal(tensor_max)
     global_scale = global_scale.to(tensor.device)
+    # Ensure global_scale is in float32, sometimes tensor is in bf16/fp16
     global_scale = global_scale.to(torch.float32)
     qdq_res, scale = ref_nvfp4_quant(tensor, global_scale, group_size, v)
     qdq_res = revert_tensor_by_pad(qdq_res, orig_shape=orig_shape, pad_len=pad_len)
@@ -110,6 +111,7 @@ def nv_fp4_with_static_gs(tensor, bits=4, group_size=16, v=0, tensor_max=None, *
             tensor_max = tensor.abs().max().to(torch.float32)
     global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX * get_reciprocal(tensor_max)
     global_scale = global_scale.to(tensor.device)
+    # Ensure global_scale is in float32, sometimes tensor is in bf16/fp16
     global_scale = global_scale.to(torch.float32)
     qdq_res, scale = ref_nvfp4_quant(tensor, global_scale, group_size, v)
     qdq_res = revert_tensor_by_pad(qdq_res, orig_shape=orig_shape, pad_len=pad_len)

--- a/auto_round/data_type/nvfp.py
+++ b/auto_round/data_type/nvfp.py
@@ -89,6 +89,7 @@ def nv_fp4(tensor, bits=4, group_size=16, v=0, global_scale=None, **kwargs):
         tensor_max = tensor.abs().max().to(torch.float32)
         global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX * get_reciprocal(tensor_max)
     global_scale = global_scale.to(tensor.device)
+    global_scale = global_scale.to(torch.float32)
     qdq_res, scale = ref_nvfp4_quant(tensor, global_scale, group_size, v)
     qdq_res = revert_tensor_by_pad(qdq_res, orig_shape=orig_shape, pad_len=pad_len)
     return qdq_res.to(orig_dtype), scale, None
@@ -109,6 +110,7 @@ def nv_fp4_with_static_gs(tensor, bits=4, group_size=16, v=0, tensor_max=None, *
             tensor_max = tensor.abs().max().to(torch.float32)
     global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX * get_reciprocal(tensor_max)
     global_scale = global_scale.to(tensor.device)
+    global_scale = global_scale.to(torch.float32)
     qdq_res, scale = ref_nvfp4_quant(tensor, global_scale, group_size, v)
     qdq_res = revert_tensor_by_pad(qdq_res, orig_shape=orig_shape, pad_len=pad_len)
     return qdq_res.to(orig_dtype), scale, None

--- a/auto_round/utils.py
+++ b/auto_round/utils.py
@@ -34,7 +34,6 @@ from torch.amp import autocast
 
 from auto_round.export.export_to_gguf.config import GGML_QUANT_SIZES, GGUF_CONFIG, GGUF_INNER_CONFIG, QK_K, ModelType
 from auto_round.special_model_handler import SPECIAL_MULTIMODAL_BLOCK, SPECIAL_SHARED_CACHE_KEYS
-from auto_round.wrapper import WrapperLinear
 
 SHARED_CACHE_KEYS = ("position_ids", "cache_position", "position_embeddings")
 
@@ -2547,6 +2546,8 @@ def create_mp_block(block, mp_layers, mp_dtype):
     Returns:
         torch.nn.Module: mixed precision block.
     """
+    from auto_round.wrapper import WrapperLinear
+
     for layer_name in mp_layers:
         layer = get_module(block, layer_name)
         layer.data_type, layer.bits, layer.sym = mp_dtype["data_type"], mp_dtype["bits"], mp_dtype["sym"]
@@ -2581,6 +2582,8 @@ def recover_mp_block(block, mp_layers, raw_dtype):
     Returns:
         torch.nn.Module: recovered block.
     """
+    from auto_round.wrapper import WrapperLinear
+
     for n, m in block.named_modules():
         if isinstance(m, WrapperLinear):
             set_module(block, n, m.orig_layer)

--- a/auto_round/utils.py
+++ b/auto_round/utils.py
@@ -85,7 +85,6 @@ if deepspeed_exists:
 
     SUPPORTED_LAYER_TYPES = SUPPORTED_LAYER_TYPES + (LinearLayer, LinearAllreduce)
 
-SUPPORTED_DTYPES = ("int", "mx_fp", "fp", "nv_fp")
 DTYPE_INFO_MAPPING = {
     "nv_fp4": {"bits": 4, "group_size": 16, "sym": True},
     "mx_fp4": {"bits": 4, "group_size": 32, "sym": True},

--- a/auto_round/wrapper.py
+++ b/auto_round/wrapper.py
@@ -91,6 +91,7 @@ class WrapperLinear(torch.nn.Module):
         self.orig_layer = orig_layer
         self.output_device = device
         self.device = self.orig_layer.tuning_device if hasattr(self.orig_layer, "tuning_device") else device
+        self.extra_repr_org = orig_layer.extra_repr
         self.enable_minmax_tuning = enable_minmax_tuning
         self.enable_round_tuning = enable_round_tuning
         self.enable_norm_bias_tuning = enable_norm_bias_tuning and (orig_layer.bias is not None)
@@ -450,6 +451,9 @@ class WrapperLinear(torch.nn.Module):
 
         output = self.orig_forward(x, weight_q, bias).to(self.output_device)
         return output
+
+    def extra_repr(self):
+        return f"{self.extra_repr_org()}, weight_type={self.data_type}, act_data_type={self.act_data_type}"
 
 
 class WrapperWALayer(torch.nn.Module):

--- a/test/test_cpu/test_recipe.py
+++ b/test/test_cpu/test_recipe.py
@@ -52,7 +52,17 @@ class TestAutoRound(unittest.TestCase):
             seqlen=2,
             dataset=self.llm_dataloader,
         )
-        layer_config = autoround._generate_recipe()
+        layer_config = autoround._generate_recipe(
+            mp_dtype={
+                "data_type": "mx_fp8",
+                "act_data_type": "mx_fp8",
+            },
+            mp_config={
+                "mp_ratio": 1 / 3,
+                "loss_weight": 2.0,
+                "numel_weight": 1.0,
+            },
+        )
         autoround.layer_config = layer_config
         autoround.quantize()
         # autoround.quantize_and_save()  # save is not supported for mix-precision

--- a/test/test_cpu/test_recipe.py
+++ b/test/test_cpu/test_recipe.py
@@ -1,0 +1,63 @@
+import shutil
+import sys
+import unittest
+
+sys.path.insert(0, "../..")
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from auto_round import AutoRound
+
+
+class LLMDataLoader:
+    def __init__(self):
+        self.batch_size = 1
+
+    def __iter__(self):
+        for i in range(2):
+            yield torch.ones([1, 10], dtype=torch.long)
+
+
+class TestAutoRound(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        model_name = "facebook/opt-125m"
+        self.save_dir = "./saved"
+        self.model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype="auto", trust_remote_code=True)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+        self.llm_dataloader = LLMDataLoader()
+
+    @classmethod
+    def tearDownClass(self):
+        shutil.rmtree("./saved", ignore_errors=True)
+        shutil.rmtree("runs", ignore_errors=True)
+
+    def test_recipe_api(self):
+        bits = 4
+        act_bits = 4
+        data_type = "nv_fp"
+        act_data_type = "nv_fp4_with_static_gs"
+        group_size = 16
+        sym = True
+        autoround = AutoRound(
+            self.model,
+            self.tokenizer,
+            bits=bits,
+            act_bits=act_bits,
+            data_type=data_type,
+            act_data_type=act_data_type,
+            group_size=group_size,
+            sym=sym,
+            iters=2,
+            seqlen=2,
+            dataset=self.llm_dataloader,
+        )
+        layer_config = autoround._generate_recipe()
+        autoround.layer_config = layer_config
+        autoround.quantize()
+        # autoround.quantize_and_save()  # save is not supported for mix-precision
+        print(autoround.model)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,25 +1,28 @@
  
  ```bash
 ############################### Gaudi model path #############################################
-deepspeed --include="localhost:0,1,2,3" --master_port=29500 quantize.py   --autoround --batch_size  16 --accuracy  --dtype mx_fp4  --mp_ratio 4/7   2>&1 |tee mxfp4_ratio_2_8b.log
+deepspeed --include="localhost:2,3" --master_port=29520 quantize.py   --autoround --batch_size  16 --accuracy  --dtype mx_fp4  --mp_ratio 5/7   2>&1 |tee mxfp4_op_5_8b.log
 
-deepspeed --include="localhost:4,5,6,7" --master_port=29510 quantize.py   --autoround --batch_size  16 --accuracy  --dtype mx_fp4  --mp_ratio 3/7   2>&1 |tee mxfp4_ratio_3_8b.log
+deepspeed --include="localhost:4,5,6,7" --master_port=29510 quantize.py   --autoround --batch_size  16 --accuracy  --dtype mx_fp4  --mp_ratio 3/7   2>&1 |tee mxfp4_op_3_8b.log
 
-deepspeed  --include="localhost:0,1,2,3,4,5,6,7" --master_port=29510  quantize.py  --model_name_or_path /git_lfs/data/pytorch/llama3.3/Meta-Llama-3.3-70B-Instruct/  --batch_size  8 --accuracy  --dtype mx_fp4   --mp_ratio 4/7 --autoround 2>&1 |tee mxfp4_op_4_3.3_70b.log
+deepspeed  --include="localhost:4,5,6,7" --master_port=29510  quantize.py  --model_name_or_path /git_lfs/data/pytorch/llama3.3/Meta-Llama-3.3-70B-Instruct/  --batch_size  8 --accuracy  --dtype mx_fp4   --mp_ratio 4/7 --autoround 2>&1 |tee mxfp4_op_4_3.3_70b.log
 
-deepspeed  --include="localhost:0,1,2,3,4,5,6,7" --master_port=29510  quantize.py  --model_name_or_path /git_lfs/data/pytorch/llama3.3/Meta-Llama-3.3-70B-Instruct/  --batch_size  8 --accuracy  --dtype mx_fp4   --mp_ratio 5/7 --autoround 2>&1 |tee mxfp4_op_5_3.3_70b.log
+deepspeed  --include="localhost:4,5,6,7" --master_port=29510  quantize.py  --model_name_or_path /git_lfs/data/pytorch/llama3.3/Meta-Llama-3.3-70B-Instruct/  --batch_size  8 --accuracy  --dtype mx_fp4   --mp_ratio 5/7 --autoround 2>&1 |tee mxfp4_op_5_3.3_70b.log
 
 
 ############################### H20 model path #############################################
-deepspeed --include="localhost:4,5,6,7" --master_port=29500 quantize.py   --model_name_or_path  /ssd/xinhe/Llama-3.1-8B-Instruct/ --autoround --batch_size  64 --accuracy  --dtype mx_fp4  --device cuda --mp_ratio 3/7   2>&1 |tee mxfp4_ratio_3_8b.log
+deepspeed --include="localhost:4,5,6,7" --master_port=29500 quantize.py   --model_name_or_path  /ssd/xinhe/Llama-3.1-8B-Instruct/ --autoround --batch_size  64 --accuracy  --dtype mx_fp4  --device cuda --mp_ratio 3/7   2>&1 |tee mxfp4_op_3_8b.log
 
-deepspeed --include="localhost:2,3" --master_port=29510 quantize.py   --model_name_or_path  /ssd/xinhe/Llama-3.1-8B-Instruct/ --autoround --batch_size 32 --accuracy  --dtype mx_fp4  --device cuda --mp_ratio 3/7   2>&1 |tee mxfp4_ratio_3_8b.log
+deepspeed --include="localhost:2,3" --master_port=29520 quantize.py   --model_name_or_path  /ssd/xinhe/Llama-3.1-8B-Instruct/ --autoround --batch_size 32 --accuracy  --dtype mx_fp4  --device cuda --mp_ratio 5/7   2>&1 |tee mxfp4_op_5_8b.log 
 
+deepspeed --include="localhost:2,3" --master_port=29520 quantize.py   --model_name_or_path  /ssd/xinhe/Llama-3.1-8B-Instruct/ --autoround --batch_size 32 --accuracy  --dtype mx_fp4  --device cuda --mp_ratio 6/7   2>&1 |tee mxfp4_op_6_8b.log
 
-deepspeed --include="localhost:0,1,2,3" --master_port=29500  quantize.py  --model_name_or_path /ssd/xinhe/Llama-3.3-70B-Instruct/  --batch_size  32 --accuracy  --dtype mx_fp4   --device cuda   --mp_ratio 4/7 --autoround   2>&1 |tee mxfp4_ratio_2_3.3_70b.log 
+deepspeed --include="localhost:0,1,2,3" --master_port=29500  quantize.py  --model_name_or_path /ssd/xinhe/Llama-3.3-70B-Instruct/  --batch_size  32 --accuracy  --dtype mx_fp4   --device cuda   --mp_ratio 5/7 --autoround   2>&1 |tee mxfp4_op_5_3.3_70b.log
 
+deepspeed --include="localhost:4,5,6,7" --master_port=29510  quantize.py  --model_name_or_path /ssd/xinhe/Llama-3.3-70B-Instruct/  --batch_size  32 --accuracy  --dtype mx_fp4   --device cuda   --mp_ratio 3/7 --autoround   2>&1 |tee mxfp4_op_3_3.3_70b.log 
 
-deepspeed --include="localhost:4,5,6,7" --master_port=29510  quantize.py  --model_name_or_path /ssd/xinhe/Llama-3.3-70B-Instruct/  --batch_size  32 --accuracy  --dtype mx_fp4   --device cuda   --mp_ratio 3/7 --autoround   2>&1 |tee mxfp4_ratio_3_3.3_70b.log 
+H20-2-1
+deepspeed --include="localhost:4,5,6,7" --master_port=29510  quantize.py  --model_name_or_path /ssd/xinhe/Llama-3.3-70B-Instruct/  --batch_size  32 --accuracy  --dtype mx_fp4   --device cuda   --mp_ratio 4/7 --autoround   2>&1 |tee mxfp4_op_4_3.3_70b.log 
 
 
 ```

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,0 +1,26 @@
+ 
+ ```bash
+############################### Gaudi model path #############################################
+deepspeed --include="localhost:0,1,2,3" --master_port=29500 quantize.py   --autoround --batch_size  16 --accuracy  --dtype mx_fp4  --mp_ratio 4/7   2>&1 |tee mxfp4_ratio_2_8b.log
+
+deepspeed --include="localhost:4,5,6,7" --master_port=29510 quantize.py   --autoround --batch_size  16 --accuracy  --dtype mx_fp4  --mp_ratio 3/7   2>&1 |tee mxfp4_ratio_3_8b.log
+
+deepspeed  --include="localhost:0,1,2,3,4,5,6,7" --master_port=29510  quantize.py  --model_name_or_path /git_lfs/data/pytorch/llama3.3/Meta-Llama-3.3-70B-Instruct/  --batch_size  8 --accuracy  --dtype mx_fp4   --mp_ratio 4/7 --autoround 2>&1 |tee mxfp4_op_4_3.3_70b.log
+
+deepspeed  --include="localhost:0,1,2,3,4,5,6,7" --master_port=29510  quantize.py  --model_name_or_path /git_lfs/data/pytorch/llama3.3/Meta-Llama-3.3-70B-Instruct/  --batch_size  8 --accuracy  --dtype mx_fp4   --mp_ratio 5/7 --autoround 2>&1 |tee mxfp4_op_5_3.3_70b.log
+
+
+############################### H20 model path #############################################
+deepspeed --include="localhost:4,5,6,7" --master_port=29500 quantize.py   --model_name_or_path  /ssd/xinhe/Llama-3.1-8B-Instruct/ --autoround --batch_size  64 --accuracy  --dtype mx_fp4  --device cuda --mp_ratio 3/7   2>&1 |tee mxfp4_ratio_3_8b.log
+
+deepspeed --include="localhost:2,3" --master_port=29510 quantize.py   --model_name_or_path  /ssd/xinhe/Llama-3.1-8B-Instruct/ --autoround --batch_size 32 --accuracy  --dtype mx_fp4  --device cuda --mp_ratio 3/7   2>&1 |tee mxfp4_ratio_3_8b.log
+
+
+deepspeed --include="localhost:0,1,2,3" --master_port=29500  quantize.py  --model_name_or_path /ssd/xinhe/Llama-3.3-70B-Instruct/  --batch_size  32 --accuracy  --dtype mx_fp4   --device cuda   --mp_ratio 4/7 --autoround   2>&1 |tee mxfp4_ratio_2_3.3_70b.log 
+
+
+deepspeed --include="localhost:4,5,6,7" --master_port=29510  quantize.py  --model_name_or_path /ssd/xinhe/Llama-3.3-70B-Instruct/  --batch_size  32 --accuracy  --dtype mx_fp4   --device cuda   --mp_ratio 3/7 --autoround   2>&1 |tee mxfp4_ratio_3_3.3_70b.log 
+
+
+```
+python quantize.py  --model_name_or_path facebook/opt-125m  --batch_size 8 --accuracy  --dtype mx_fp4   --mp_ratio 1/3 --autoround

--- a/workspace/quantize.py
+++ b/workspace/quantize.py
@@ -1,0 +1,320 @@
+# Copyright (c) 2025 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+
+import torch
+import transformers
+
+######################## HPU Memory Optimization ###########################
+# ensure that unnecessary memory is released during quantization.
+os.environ.setdefault("PT_HPU_LAZY_MODE", "1")
+os.environ.setdefault("PT_HPU_WEIGHT_SHARING", "0")
+if int(os.getenv("WORLD_SIZE", "0")) > 0:
+    os.environ.setdefault("PT_HPU_LAZY_ACC_PAR_MODE", "0")
+    os.environ.setdefault("PT_HPU_ENABLE_LAZY_COLLECTIVES", "true")
+from neural_compressor.torch.utils import is_hpex_available
+
+if is_hpex_available():
+    import habana_frameworks.torch.core as htcore
+    from habana_frameworks.torch.hpu import wrap_in_hpu_graph
+    from neural_compressor.torch.utils import get_used_hpu_mem_MB
+
+    htcore.hpu_set_env()
+
+
+def initialize_model_and_tokenizer(model_name_or_path):
+    tokenizer = transformers.AutoTokenizer.from_pretrained(model_name_or_path)
+    config = transformers.AutoConfig.from_pretrained(model_name_or_path)
+    # using memory mapping with torch_dtype=config.torch_dtype
+    model = transformers.AutoModelForCausalLM.from_pretrained(model_name_or_path, torch_dtype=config.torch_dtype)
+    # shard model for multi-cards and enable hpu graph
+    from neural_compressor.torch.utils import local_rank, logger, world_size
+
+    if world_size > 1:
+        ds_inference_kwargs = {
+            "dtype": config.torch_dtype,
+            "tensor_parallel": {"tp_size": world_size},
+        }
+        import deepspeed
+
+        ds_model = deepspeed.init_inference(model, **ds_inference_kwargs)
+        model = ds_model.module
+    model.eval()
+    return model, tokenizer
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Habana FP8 quantization.", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "--model_name_or_path", type=str, default="meta-llama/Meta-Llama-3.1-8B-Instruct", help="model name or path"
+    )
+    parser.add_argument("--output_dir", type=str, default="saved_results", help="model name or path")
+    parser.add_argument("--device", type=str, default="hpu", help="device")
+    parser.add_argument("--dtype", type=str, default="mx_fp4", help="model name or path")
+    parser.add_argument("--quantize", action="store_true", help="whether to quantize model")
+    parser.add_argument("--tune", action="store_true", help="whether to autoround model")
+    parser.add_argument("--autoround", action="store_true", help="whether to autoround model")
+    parser.add_argument("--iters", default=None, type=int, help="iters for autoround.")
+    parser.add_argument("--seqlen", default=None, type=int, help="sequence length for autoround.")
+    parser.add_argument("--nsamples", default=None, type=int, help="number of samples for autoround.")
+    parser.add_argument("--target_bits", default=5, type=float, help="number of samples for autoround.")
+    parser.add_argument("--target_loss_ratio", default=1.2, type=float, help="number of samples for autoround.")
+    parser.add_argument(
+        "--use_hpu_graph", action="store_true", help="whether to use hpu graph mode to accelerate performance"
+    )
+    parser.add_argument(
+        "--enable_block_wise_calibration", action="store_true", help="whether to use block-wise calibration"
+    )
+    parser.add_argument(
+        "--disable_optimum_habana", action="store_true", help="whether to use adapt_transformers_to_gaudi"
+    )
+    parser.add_argument("--mp_ratio", default="1/3", type=str, help="number of samples for autoround.")
+    parser.add_argument("--save", action="store_true", help="whether to save the quantized model")
+    parser.add_argument("--load", action="store_true", help="whether to load the quantized model")
+    parser.add_argument("--save_path", type=str, default="saved_results", help="path to save the quantized model")
+    parser.add_argument("--quant_lm_head", action="store_true", help="performance measurement")
+    parser.add_argument("--accuracy", action="store_true", help="accuracy measurement")
+    parser.add_argument("--performance", action="store_true", help="performance measurement")
+    parser.add_argument("--local_rank", type=int, default=0, metavar="N", help="Local process rank.")
+    parser.add_argument("--batch_size", default=4, type=int, help="batch size for accuracy measurement.")
+    parser.add_argument("--num_fewshot", default=0, type=int, help="num_fewshot of lm_eval.")
+    parser.add_argument(
+        "--mxfp8_mod_list",
+        type=str,
+        nargs="*",
+        default=[],  # 默认值
+        help="List of module names or patterns for MXFP8 quantization.",
+    )
+    parser.add_argument(
+        "--fp8_mod_list",
+        type=str,
+        nargs="+",  # 接受一个或多个字符串作为列表
+        default=[],  # 默认值
+        help="List of module names or patterns for FP8 quantization.",
+    )
+    parser.add_argument(
+        "--bf16_mod_list",
+        type=str,
+        nargs="+",  # 接受一个或多个字符串作为列表
+        default=[],  # 默认值
+        help="List of module names or patterns for MXFP8 quantization.",
+    )
+    parser.add_argument(
+        "--dump_stats_path", type=str, default="./hqt_output/measure", help="path and prefix to calibration info file."
+    )
+    parser.add_argument(
+        "--tasks",
+        type=str,
+        nargs="+",  # 接受一个或多个字符串作为列表
+        default=[
+            "piqa",
+            "hellaswag",
+            "mmlu",
+            "winogrande",
+            "lambada_openai",
+        ],  # 默认值
+        help="tasks for accuracy validation, text-generation and code-generation tasks are different.",
+    )
+    parser.add_argument(
+        "--dataset_name", type=str, default="NeelNanda/pile-10k", help="dataset name for calibration dataloader"
+    )
+    parser.add_argument("--limit", type=int, default=None, help="number of samples for accuracy evaluation")
+    args = parser.parse_args()
+    print("Target data type:", args.dtype)
+
+    model, tokenizer = initialize_model_and_tokenizer(args.model_name_or_path)
+    if args.quantize:
+        lm_head_config = {
+            "group_size": 32 if "mx" in args.dtype else 16,
+            "data_type": args.dtype,
+            "act_data_type": "fp4_v2_with_global_scale" if "fp4_v2" in args.dtype else args.dtype,
+        }
+        layer_config = {"lm_head": lm_head_config}
+        from auto_round import AutoRound
+
+        autoround = AutoRound(
+            model,
+            tokenizer,
+            device=args.device,
+            iters=200 if args.tune else 0,
+            low_gpu_mem_usage=True,
+            group_size=32 if "mx" in args.dtype else 16,
+            data_type=args.dtype,
+            act_data_type="fp4_v2_with_global_scale" if "fp4_v2" in args.dtype else args.dtype,
+            layer_config=layer_config if args.quant_lm_head else None,
+        )
+        autoround.quantize()
+        model = autoround.model
+
+    if args.autoround:
+        from deepspeed.module_inject import (
+            LinearAllreduce,
+            LinearLayer,
+        )
+
+        MXFP4_MODULE_MAPPING = {
+            torch.nn.Linear: None,
+            torch.nn.EmbeddingBag: None,
+            LinearLayer: None,
+            LinearAllreduce: None,
+        }
+
+        from auto_round import AutoRound
+
+        def match_pattern(name, pattern):
+            for pat in pattern:
+                if pat in name:
+                    return True
+            return False
+
+        layer_config = {}
+        fp8_config = {
+            "bits": 8,
+            "data_type": "fp8",
+            "act_data_type": "fp8",
+        }
+        mxfp4_config = {
+            "bits": 4,
+            "group_size": 32,
+            "data_type": "mx_fp4",
+            "act_data_type": "mx_fp4",
+        }
+        mxfp8_config = {
+            "bits": 8,
+            "group_size": 32,
+            "data_type": "mx_fp8",
+            "act_data_type": "mx_fp8",
+        }
+        module_name_to_quantize: list[str] = [
+            n for n, m in model.named_modules() if isinstance(m, tuple(MXFP4_MODULE_MAPPING.keys()))
+        ]
+        for name in module_name_to_quantize:
+            if match_pattern(name, args.mxfp8_mod_list):
+                layer_config.update({name: mxfp8_config})
+            if match_pattern(name, args.fp8_mod_list):
+                layer_config.update({name: fp8_config})
+        if args.quant_lm_head:
+            layer_config.update({"lm_head": mxfp8_config})
+
+        from auto_round import AutoRound
+
+        autoround = AutoRound(
+            model,
+            tokenizer,
+            device=args.device,
+            low_gpu_mem_usage=True,
+            group_size=32 if "mx" in args.dtype else 16,
+            data_type=args.dtype,
+            act_data_type="fp4_v2_with_global_scale" if "fp4_v2" in args.dtype else args.dtype,
+            layer_config=layer_config,
+        )
+
+        recipe_results = autoround._generate_recipe(
+            mp_config={
+                "mp_ratio": float(eval(args.mp_ratio)),
+            },
+        )
+        autoround.layer_config = recipe_results["recipe"]
+        autoround.quantize()
+        model = autoround.model
+
+    # preprocess model for accuracy and performance measurement
+    if not args.load and not args.autoround and not args.quantize:
+        # compare fp8 with bf16, not fp32.
+        model = model.to(torch.bfloat16)
+    model = model.eval().to(args.device)
+    print(model)
+
+    if args.accuracy:
+        if is_hpex_available():
+            model = wrap_in_hpu_graph(model)
+            htcore.hpu_inference_initialize(model, mark_only_scales_as_const=True)
+            from neural_compressor.evaluation.lm_eval import LMEvalParser, evaluate
+
+            tasks = ",".join(args.tasks)
+            eval_args = LMEvalParser(
+                model="hf",
+                user_model=model,
+                tokenizer=tokenizer,
+                batch_size=args.batch_size,
+                tasks=tasks,
+                device="hpu",
+                pad_to_buckets=True,
+                num_fewshot=args.num_fewshot,
+                limit=args.limit,
+                add_bos_token=True,
+            )
+            results = evaluate(eval_args)
+            torch.hpu.synchronize()
+            all_accuracy = {}
+            for task_name, task_results in results["results"].items():
+                if task_name in ["hellaswag", "lambada_openai", "piqa", "winogrande", "mmlu"]:
+                    accu = task_results["acc,none"]
+                    all_accuracy[task_name] = accu
+                    print(f"Accuracy for {task_name}: {accu:.4f}")
+            print(f"Overall accuracy: {sum(all_accuracy.values())/len(all_accuracy):.4f}")
+        else:
+            # model = torch.compile(model)
+            args.tasks = ["piqa", "hellaswag", "mmlu", "gsm8k"]
+            all_accuracy = {}
+            test_gsm8k = False
+            test_normal = False
+            if "gsm8k" in args.tasks:
+                test_gsm8k = True
+                args.tasks.remove("gsm8k")
+            if args.tasks:
+                test_normal = True
+            import lm_eval
+            from lm_eval.models.huggingface import HFLM
+
+            if test_normal:
+                lm = HFLM(
+                    pretrained=model,
+                    tokenizer=tokenizer,
+                    add_bos_token=True,
+                    batch_size=args.batch_size,
+                )
+                results = lm_eval.simple_evaluate(
+                    lm,
+                    tasks=args.tasks,
+                    limit=args.limit,
+                )
+                for task_name, task_results in results["results"].items():
+                    if task_name in ["hellaswag", "lambada_openai", "piqa", "winogrande", "mmlu"]:
+                        accu = task_results["acc,none"]
+                        all_accuracy[task_name] = accu
+            ########################## gms8k #########################
+            if test_gsm8k:
+                lm = HFLM(
+                    pretrained=model,
+                    tokenizer=tokenizer,
+                    add_bos_token=False,
+                    batch_size=args.batch_size,
+                )
+                results_gsm8k = lm_eval.simple_evaluate(
+                    lm,
+                    tasks=["gsm8k"],
+                    limit=args.limit,
+                )
+                for task_name, task_results in results_gsm8k["results"].items():
+                    accu = task_results["exact_match,strict-match"]
+                    all_accuracy[task_name] = accu
+            ########################## gms8k end #########################
+            for task_name, accu in all_accuracy.items():
+                print(f"Accuracy for {task_name}: {accu:.4f}")
+            print(f"Overall accuracy: {sum(all_accuracy.values())/len(all_accuracy):.4f}")


### PR DESCRIPTION
```python
layer_config, avg_bits = autoround._generate_recipe(
        # same data type config as before
        mp_dtype={
            "data_type": "mx_fp8",
            "act_data_type": "mx_fp8",
        },
        # special mix-precision configuration
        mp_config={
            "mp_ratio": 1/3,
            "loss_weight": 2.0,
            "numel_weight": 1.0,
        },
)
autoround.layer_config = layer_config
autoround.quantize()
```
This code is used for INC accuracy tuning, currently only `mx_fp8` is supported for mixing with `mx_fp4` and `nv_fp4`.
<img width="1889" height="971" alt="image" src="https://github.com/user-attachments/assets/3e81765c-4d36-4b24-aac1-45b0d46e1838" />
