### PR TITLE
add missing batch_size consideration

### DIFF
--- a/auto_round/compressors/base.py
+++ b/auto_round/compressors/base.py
@@ -625,7 +625,7 @@ class BaseCompressor(object):
         if self.low_gpu_mem_usage:
             input_output_memory = 0
 
-        mem_per_param_scale = 13 if self.mem_per_param_scale is None else self.mem_per_param_scale
+        mem_per_param_scale = 13 * self.batch_size if self.mem_per_param_scale is None else self.mem_per_param_scale
         if self.iters == 0:
             mem_per_param_scale = 1  # for rtn
 


### PR DESCRIPTION
Batch_size is not considered before, quantizing llama3.3 70b will only use 1 card and got OOM.