### PR TITLE
fix llama4 kv quant

### DIFF
--- a/auto_round/experimental/utils.py
+++ b/auto_round/experimental/utils.py
@@ -71,13 +71,9 @@ def normalize_static_kv_dtype(static_kv_dtype: str | torch.dtype) -> torch.dtype
 def is_attention_module(module: torch.nn.Module):
     # FIXME: Handle this better.
     return (
-        "attention" in module.__class__.__name__.lower() 
-        and module.__class__.__name__ != "Llama4VisionAttention" # llama4 vision attention doesn't have cache
-        and (
-            hasattr(module, "k_proj")
-            or hasattr(module, "v_proj")
-            or hasattr(module, "qkv_proj")
-        )
+        "attention" in module.__class__.__name__.lower()
+        and module.__class__.__name__ != "Llama4VisionAttention"  # llama4 vision attention doesn't have cache
+        and (hasattr(module, "k_proj") or hasattr(module, "v_proj") or hasattr(module, "qkv_proj"))
     )
 
 


### PR DESCRIPTION
Llama4 vision model's attention doesn't have cache and will crash in vllm loading if there is k/v scale
https://github.com/vllm-project/vllm/blob/030fc4491465d361e4bed626d76c184f8a7d8a07/vllm/model_executor/models/mllama4.py#L258