### PR TITLE
Extend ark CI test trigger scope

### DIFF
--- a/.azure-pipelines/unit-test-xpu.yml
+++ b/.azure-pipelines/unit-test-xpu.yml
@@ -10,6 +10,7 @@ pr:
     include:
       - auto_round/utils
       - auto_round_extension/ark
+      - auto_round/inference
       - test/test_ark
       - setup.py
       - .azure-pipelines/template/ut-template.yml


### PR DESCRIPTION
1. Extend ark CI test trigger scope
2. Disable ark CI test on cpu due to the ark cpu support is temperate disabled
https://github.com/intel/auto-round/commit/083b635105c4938bdde3ffe7d51d4bb5836abbd1 