### PR TITLE
Add nightly release workflow

### DIFF
--- a/.github/workflows/nightly-binary-release.yml
+++ b/.github/workflows/nightly-binary-release.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for nightly binary builds and publishing. The workflow automates building and optionally publishing nightly Python package binaries to PyPI or TestPyPI, either on a schedule or manually.

**CI/CD workflow automation:**

* Added `.github/workflows/nightly-binary-release.yml` to define a scheduled and manually-triggered workflow for building and publishing nightly package binaries. The workflow sets up Python, installs dependencies, dynamically sets a nightly version, builds the package, and uploads it to either PyPI or TestPyPI based on user input.