### PR TITLE
Update nightly release workflow

### DIFF
--- a/.github/workflows/nightly-binary-release.yml
+++ b/.github/workflows/nightly-binary-release.yml
@@ -44,9 +44,9 @@ jobs:
             VERSION="${{ github.event.inputs.version }}"
           fi
           # Update version in setup.py (assumes version is set as version='...')
-          sed -i "s/version=get_build_version(),/version='$VERSION'/" setup.py
+          sed -i "s/version=get_build_version()/version='$VERSION'/" setup.py
           # Update project name in setup.py (assumes name='...')
-          sed -i "s/name=package_name,/name='auto-round-nightly'/" setup.py
+          sed -i "s/name=package_name/name='auto-round-nightly'/" setup.py
 
       - name: Build binary
         run: |


### PR DESCRIPTION
This pull request makes minor corrections to the `sed` commands in the `.github/workflows/nightly-binary-release.yml` workflow file to properly update the `setup.py` file during the nightly binary release process.

* Fixed the `sed` command pattern to correctly replace `version=get_build_version()` with the intended version string in `setup.py`.
* Fixed the `sed` command pattern to correctly replace `name=package_name` with the intended nightly package name in `setup.py`.