### PR TITLE
Optimize CPU RAM peak memory during quantization

### DIFF
--- a/auto_round/compressors/base.py
+++ b/auto_round/compressors/base.py
@@ -1532,7 +1532,7 @@ class BaseCompressor(object):
         if tensor is None:
             return 0.0
         if isinstance(tensor, torch.Tensor):
-            return tensor.numel() * tensor.element_size() / (1024 ** 3)
+            return tensor.numel() * tensor.element_size() / (1024**3)
         elif isinstance(tensor, list):
             return sum(self._estimate_tensor_size_gb(t) for t in tensor)
         elif isinstance(tensor, dict):
@@ -1551,7 +1551,7 @@ class BaseCompressor(object):
         total = 0.0
         for param in self.model.parameters():
             if param.numel() > 0:  # Skip empty tensors
-                total += param.numel() * param.element_size() / (1024 ** 3)
+                total += param.numel() * param.element_size() / (1024**3)
         return total
 
     def _estimate_block_size_gb(self, block: torch.nn.Module) -> float:
@@ -1559,7 +1559,7 @@ class BaseCompressor(object):
         total = 0.0
         for param in block.parameters():
             if param.numel() > 0:
-                total += param.numel() * param.element_size() / (1024 ** 3)
+                total += param.numel() * param.element_size() / (1024**3)
         return total
 
     def _init_cpu_offload_dir(self) -> Optional[str]:
@@ -1701,7 +1701,9 @@ class BaseCompressor(object):
                     if hasattr(target, param_name):
                         old_param = getattr(target, param_name)
                         if isinstance(old_param, torch.nn.Parameter):
-                            setattr(target, param_name, torch.nn.Parameter(param, requires_grad=old_param.requires_grad))
+                            setattr(
+                                target, param_name, torch.nn.Parameter(param, requires_grad=old_param.requires_grad)
+                            )
                         else:
                             setattr(target, param_name, param)
             except Exception as e:
@@ -3057,7 +3059,11 @@ class BaseCompressor(object):
                 )
 
                 # Log output cache size for first block
-                if self.low_cpu_mem_usage and self.cpu_stream_offload_blocks and not hasattr(self, "_logged_output_size"):
+                if (
+                    self.low_cpu_mem_usage
+                    and self.cpu_stream_offload_blocks
+                    and not hasattr(self, "_logged_output_size")
+                ):
                     output_size = self._estimate_tensor_size_gb(output)
                     logger.info(f"[Memory] block output cache size: {output_size:.2f} GB")
                     self._logged_output_size = True
@@ -3363,7 +3369,9 @@ class BaseCompressor(object):
         if self.low_cpu_mem_usage and self.cpu_stream_offload_blocks:
             input_ids_size = self._estimate_tensor_size_gb(input_ids)
             input_others_size = self._estimate_tensor_size_gb(input_others)
-            logger.info(f"[Memory] input_ids size: {input_ids_size:.2f} GB, input_others size: {input_others_size:.2f} GB")
+            logger.info(
+                f"[Memory] input_ids size: {input_ids_size:.2f} GB, input_others size: {input_others_size:.2f} GB"
+            )
 
         if pbar is None:
             pbar = tqdm(range(0, len(block_names), nblocks))

--- a/auto_round/utils/model.py
+++ b/auto_round/utils/model.py
@@ -71,7 +71,7 @@ def save_module_weights(module: torch.nn.Module, save_path: str) -> dict:
 
     Args:
         module (torch.nn.Module): The module whose weights should be saved.
-        save_path (str): Path where the weights should be saved. 
+        save_path (str): Path where the weights should be saved.
                         This should be a unique path for each module.
 
     Returns:
@@ -97,36 +97,36 @@ def save_module_weights(module: torch.nn.Module, save_path: str) -> dict:
     if module is None:
         return {}
 
-    metadata = {'save_path': save_path}
+    metadata = {"save_path": save_path}
     tensors_to_save = {}
 
     # Save weight if it exists
-    if hasattr(module, 'weight') and module.weight is not None:
+    if hasattr(module, "weight") and module.weight is not None:
         weight = module.weight
-        if weight.device.type != 'meta' and weight.numel() > 0:
-            tensors_to_save['weight'] = weight.detach().cpu()
-            metadata['has_weight'] = True
-            metadata['weight_shape'] = tuple(weight.shape)
-            metadata['weight_dtype'] = weight.dtype
-            metadata['weight_device'] = str(weight.device)
+        if weight.device.type != "meta" and weight.numel() > 0:
+            tensors_to_save["weight"] = weight.detach().cpu()
+            metadata["has_weight"] = True
+            metadata["weight_shape"] = tuple(weight.shape)
+            metadata["weight_dtype"] = weight.dtype
+            metadata["weight_device"] = str(weight.device)
         else:
-            metadata['has_weight'] = False
+            metadata["has_weight"] = False
     else:
-        metadata['has_weight'] = False
+        metadata["has_weight"] = False
 
     # Save bias if it exists
-    if hasattr(module, 'bias') and module.bias is not None:
+    if hasattr(module, "bias") and module.bias is not None:
         bias = module.bias
-        if bias.device.type != 'meta' and bias.numel() > 0:
-            tensors_to_save['bias'] = bias.detach().cpu()
-            metadata['has_bias'] = True
-            metadata['bias_shape'] = tuple(bias.shape)
-            metadata['bias_dtype'] = bias.dtype
-            metadata['bias_device'] = str(bias.device)
+        if bias.device.type != "meta" and bias.numel() > 0:
+            tensors_to_save["bias"] = bias.detach().cpu()
+            metadata["has_bias"] = True
+            metadata["bias_shape"] = tuple(bias.shape)
+            metadata["bias_dtype"] = bias.dtype
+            metadata["bias_device"] = str(bias.device)
         else:
-            metadata['has_bias'] = False
+            metadata["has_bias"] = False
     else:
-        metadata['has_bias'] = False
+        metadata["has_bias"] = False
 
     # Save to disk
     if tensors_to_save:
@@ -155,48 +155,48 @@ def load_module_weights(module: torch.nn.Module, metadata: dict) -> None:
         >>> load_module_weights(module, metadata)
         >>> # Now module's weights are restored
     """
-    if module is None or not metadata or 'save_path' not in metadata:
+    if module is None or not metadata or "save_path" not in metadata:
         return
 
-    save_path = metadata['save_path']
+    save_path = metadata["save_path"]
     if not os.path.exists(save_path):
         logger.warning(f"Cannot load weights: file {save_path} does not exist")
         return
 
     # Load tensors from disk
     try:
-        tensors = torch.load(save_path, map_location='cpu')
+        tensors = torch.load(save_path, map_location="cpu")
     except Exception as e:
         logger.warning(f"Failed to load weights from {save_path}: {e}")
         return
 
     # Restore weight
-    if metadata.get('has_weight', False) and 'weight' in tensors:
-        weight = tensors['weight']
-        target_device = metadata.get('weight_device', 'cpu')
-        target_dtype = metadata.get('weight_dtype', weight.dtype)
+    if metadata.get("has_weight", False) and "weight" in tensors:
+        weight = tensors["weight"]
+        target_device = metadata.get("weight_device", "cpu")
+        target_dtype = metadata.get("weight_dtype", weight.dtype)
 
         # Move to target device and dtype
         weight = weight.to(device=target_device, dtype=target_dtype)
 
         # Set the weight back to the module
-        if hasattr(module, 'weight'):
+        if hasattr(module, "weight"):
             if isinstance(module.weight, torch.nn.Parameter):
                 module.weight = torch.nn.Parameter(weight, requires_grad=module.weight.requires_grad)
             else:
                 module.weight = weight
 
     # Restore bias
-    if metadata.get('has_bias', False) and 'bias' in tensors:
-        bias = tensors['bias']
-        target_device = metadata.get('bias_device', 'cpu')
-        target_dtype = metadata.get('bias_dtype', bias.dtype)
+    if metadata.get("has_bias", False) and "bias" in tensors:
+        bias = tensors["bias"]
+        target_device = metadata.get("bias_device", "cpu")
+        target_dtype = metadata.get("bias_dtype", bias.dtype)
 
         # Move to target device and dtype
         bias = bias.to(device=target_device, dtype=target_dtype)
 
         # Set the bias back to the module
-        if hasattr(module, 'bias'):
+        if hasattr(module, "bias"):
             if isinstance(module.bias, torch.nn.Parameter):
                 module.bias = torch.nn.Parameter(bias, requires_grad=module.bias.requires_grad)
             else:
@@ -211,11 +211,11 @@ def clear_module_weights(module: torch.nn.Module, to_meta: bool = False) -> None
 
     Args:
         module (torch.nn.Module): The module whose weights should be cleared.
-        to_meta (bool): If True, move tensors to meta device. 
+        to_meta (bool): If True, move tensors to meta device.
                        If False, set them to empty tensors. Default is False.
 
     Note:
-        This function should typically be called after save_module_weights() 
+        This function should typically be called after save_module_weights()
         to preserve the ability to restore weights later.
 
     Example:
@@ -230,30 +230,28 @@ def clear_module_weights(module: torch.nn.Module, to_meta: bool = False) -> None
 
     with torch.no_grad():
         # Clear weight
-        if hasattr(module, 'weight') and module.weight is not None:
+        if hasattr(module, "weight") and module.weight is not None:
             if to_meta:
                 # Move to meta device
-                if module.weight.device.type != 'meta':
+                if module.weight.device.type != "meta":
                     module.weight = torch.nn.Parameter(
-                        torch.empty_like(module.weight, device='meta'),
-                        requires_grad=module.weight.requires_grad
+                        torch.empty_like(module.weight, device="meta"), requires_grad=module.weight.requires_grad
                     )
             else:
                 # Use clean_module_parameter for safety
-                clean_module_parameter(module, 'weight')
+                clean_module_parameter(module, "weight")
 
         # Clear bias
-        if hasattr(module, 'bias') and module.bias is not None:
+        if hasattr(module, "bias") and module.bias is not None:
             if to_meta:
                 # Move to meta device
-                if module.bias.device.type != 'meta':
+                if module.bias.device.type != "meta":
                     module.bias = torch.nn.Parameter(
-                        torch.empty_like(module.bias, device='meta'),
-                        requires_grad=module.bias.requires_grad
+                        torch.empty_like(module.bias, device="meta"), requires_grad=module.bias.requires_grad
                     )
             else:
                 # Use clean_module_parameter for safety
-                clean_module_parameter(module, 'bias')
+                clean_module_parameter(module, "bias")
 
 
 def convert_dtype_str2torch(str_dtype):

--- a/test/test_cuda/advanced/test_cpu_ram_optimization.py
+++ b/test/test_cuda/advanced/test_cpu_ram_optimization.py
@@ -23,6 +23,7 @@ Optimization options:
 
 import gc
 import time
+
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 


### PR DESCRIPTION
## Description

### Optimize CPU RAM peak memory during quantization:
1. Two optional CPU RAM optimizations, gated by [low_cpu_mem_usage]: 
**cpu_stream_offload_blocks**: offload block weights to disk and load them on demand during block-wise quantization, then re-offload quantized weights; restore at the end.
**cpu_stream_loss**: avoid caching block outputs by computing targets on-the-fly with a frozen block copy (requires [nblocks=1]).

2. The quantization flow caches inputs once, then processes blocks sequentially, loading/offloading weights and optionally streaming loss to keep peak CPU RAM low.

### Test
Quantize Qwen/Qwen3-4B-Instruct-2507 with AutoRound (4-bit) and compare CPU RAM peak usage with different optimization options.

Optimization options:
1. cpu_stream_offload_blocks: Offload block weights to disk, load on demand
2. cpu_stream_loss: Compute loss on-the-fly using frozen block copy


**Summary: Peak RAM Comparison**

| Configuration       | Peak RAM (GB) | Time (s) | RAM Saved |
|--------------------|---------------|----------|-----------|
| Baseline           | 24.66         | 1624.0   | baseline  |
| + offload_blocks   | 20.34         | 1522.3   | -4.32 GB  |
| + stream_loss      | 20.67         | 1386.7   | -4.00 GB  |
| All optimizations  | 16.00         | 1333.6   | -8.66 GB  |


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

[<!-- Link to related issues using #issue_number -->](https://github.com/intel/auto-round/issues/912)

Fixes or relates to #

## Checklist Before Submitting

- [x] My code has been tested locally.
- [x] Documentation has been updated as needed.
- [x] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
