### PR TITLE
[Regression] Detach scale tensor to prevent holding computation graph references

### DIFF
--- a/auto_round/experimental/attention.py
+++ b/auto_round/experimental/attention.py
@@ -96,7 +96,7 @@ class QuantizedAttentionImpl(torch.nn.Module):
         )
         update_parameter_data(module, query_max, QUERY_MAX_NAME)
         _, query_scale = per_tensor_fp8_qdq(query, tensor_max=query_max)
-        update_parameter_data(module, query_scale.squeeze(0), QUERY_SCALE_NAME)
+        update_parameter_data(module, query_scale.squeeze(0).detach(), QUERY_SCALE_NAME)
         # original attention
         return ALL_ATTENTION_FUNCTIONS[self._original_impl](
             module,

--- a/auto_round/experimental/kv_cache.py
+++ b/auto_round/experimental/kv_cache.py
@@ -173,7 +173,8 @@ class QuantizedKVParameterCache(DynamicCache):
             scales = self.v_scales
 
         qdq_tensor, scale = per_tensor_fp8_qdq(tensor)
-        _pad_and_append_at_idx_(scales, layer_idx, scale.squeeze(0))
+        # Detach scale to prevent holding computation graph references
+        _pad_and_append_at_idx_(scales, layer_idx, scale.squeeze(0).detach())
         return qdq_tensor
 
 


### PR DESCRIPTION

## Description

Detach scale tensor to prevent holding computation graph references in attention and kv_cache modules

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
