### PR TITLE
Fix bug in mxfp.py where "--disable_act_dynamic" can't be call correctly

### DIFF
--- a/auto_round/data_type/mxfp.py
+++ b/auto_round/data_type/mxfp.py
@@ -84,6 +84,7 @@ def quant_element(tensor, ebits, mbits, max_norm, mantissa_rounding="even"):
     tensor = torch.clamp(tensor, min=-max_norm, max=max_norm)
     return tensor
 
+
 def _align_1d_to_num_groups(x, num_groups: int, pad_value: float):
     """
     Align a 1D tensor/scalar to length = num_groups.


### PR DESCRIPTION
## Description

**Fix bug in mxfp.py where `--disable_act_dynamic` can't be call correctly**

MXFP8 quantization ignored the `disable_act_dynamic` parameter and always recomputed the activation maximum dynamically. This PR enables MXFP to use the provided static `tensor_max` value for activation quantization.

Use `tensor_max` for static activation scaling when the value is available.
Retain the existing dynamic computation behavior when `tensor_max` is None.
Weight quantization behavior remains unchanged.

**Verified via debug:**
`act_max` is successfully passed to the MXFP module when `disable_act_dynamic=True`.
MXFP uses the static maximum value for activation scaling in this scenario.
The weight quantization process remains unaffected.



## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):


## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
