### PR TITLE
fix: update model imports from AutoModelForVision2Seq to AutoModelFor…

### DIFF
--- a/test/test_cuda/models/test_get_block_name.py
+++ b/test/test_cuda/models/test_get_block_name.py
@@ -7,7 +7,7 @@ import transformers
 from packaging import version
 from transformers import (
     AutoModelForCausalLM,
-    AutoModelForVision2Seq,
+    AutoModelForImageTextToText,
     AutoTokenizer,
     Gemma3ForConditionalGeneration,
     Mistral3ForConditionalGeneration,
@@ -113,7 +113,7 @@ class TestAutoRound:
 
     def test_Llama32(self):
         model_name = "/models/Llama-3.2-11B-Vision-Instruct"
-        model = AutoModelForVision2Seq.from_pretrained(model_name, torch_dtype="auto", trust_remote_code=True)
+        model = AutoModelForImageTextToText.from_pretrained(model_name, torch_dtype="auto", trust_remote_code=True)
         block_names = get_block_names(model)
         self.check_block_names(block_names, ["model.language_model.layers"], [40])
 
@@ -132,7 +132,7 @@ class TestAutoRound:
 
     def test_SmolVLM(self):
         model_name = "/models/SmolVLM-Instruct"
-        model = AutoModelForVision2Seq.from_pretrained(model_name, torch_dtype="auto", trust_remote_code=True)
+        model = AutoModelForImageTextToText.from_pretrained(model_name, torch_dtype="auto", trust_remote_code=True)
         block_names = get_block_names(model)
         self.check_block_names(block_names, ["model.text_model.layers"], [24])
 


### PR DESCRIPTION
## Description

Please briefly describe your main changes, the motivation.
AutoModelForVision2Seq is removed in transformers v5 and AutoModelForImageTextToText exists in transformers 4.42.0
So replace it directly without enabling compatible for older version.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
