### PR TITLE
fix: update cleanup logic for quantized model path in tests

### DIFF
--- a/test/test_cuda/quantization/test_mxfp_nvfp.py
+++ b/test/test_cuda/quantization/test_mxfp_nvfp.py
@@ -84,7 +84,7 @@ class TestAutoRound:
             quantization_config["format"] == "nvfp4-pack-quantized"
             and quantization_config["config_groups"]["group_0"]["input_activations"]["num_bits"] == 4
         ), f"Invalid NVFP4 quantization configuration: {quantization_config}"
-        shutil.rmtree("./saved", ignore_errors=True)
+        shutil.rmtree(quantized_model_path, ignore_errors=True)
         # from vllm import LLM, SamplingParams
         # prompts = [
         #     "The capital of France is",
@@ -122,6 +122,7 @@ class TestAutoRound:
         autoround.quantize()
         quantized_model_path = self.save_dir
         autoround.save_quantized(output_dir=quantized_model_path, inplace=False, format="auto_round")
+        shutil.rmtree(quantized_model_path, ignore_errors=True)
 
     def test_nvfp4_moe_actmax_ar(self, tiny_deepseek_v2_model_path, dataloader):
         scheme = "nvfp4"
@@ -136,6 +137,7 @@ class TestAutoRound:
         autoround.quantize()
         quantized_model_path = self.save_dir
         autoround.save_quantized(output_dir=quantized_model_path, inplace=False, format="auto_round")
+        shutil.rmtree(quantized_model_path, ignore_errors=True)
 
     def test_qwen_moe_quant_infer(self, dataloader):
         model_name = get_model_path("qwen/Qwen1.5-MoE-A2.7B")


### PR DESCRIPTION
## Description

FAILED test_cuda/quantization/test_mxfp_nvfp.py::TestAutoRound::test_qwen_moe_quant_infer - RuntimeError: Error(s) in loading state_dict for Linear:
	size mismatch for weight: copying a param with shape torch.Size([102400, 2048]) from checkpoint, the shape in current model is torch.Size([151936, 2048])

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #1227 

## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
