### PR TITLE
Fix transformers 5.2.0 transpose conversion issue

### DIFF
--- a/auto_round/utils/common.py
+++ b/auto_round/utils/common.py
@@ -130,7 +130,8 @@ def _patch_transpose_for_buffers():
             module_path, _, param_name = full_layer_name.rpartition(".")
             try:
                 module_obj = model.get_submodule(module_path) if module_path else model
-                if param_name in module_obj._buffers:
+                buffer_tensor = module_obj.get_buffer(param_name) if hasattr(module_obj, "get_buffer") else None
+                if buffer_tensor is not None:
                     # Buffer tensors must not be transposed – return as-is.
                     target_pattern = self.get_target_pattern(input_dict, source_patterns, target_patterns)
                     tensors = next(iter(input_dict.values()))


### PR DESCRIPTION
## Description

**Root cause**
In transformers 5.2.0, the new Transpose conversion class calls get_parameter() on weight tensors during quantized MoE checkpoint loading. auto_round's QuantLinear stores weight_packed and weight_scale as buffers (via register_buffer()), not nn.Parameter, so get_parameter() raises an AttributeError, which transformers then raises as a RuntimeError.

**Fix**
A _patch_transpose_for_buffers() monkey-patch wraps Transpose.convert() to check if the target tensor is a buffer first — if so, it returns the tensor as-is instead of attempting a transpose. This patch is applied in monkey_patch_transformers() for transformers ≥ 5.2.0.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

[<!-- Link to related issues using #issue_number -->](https://inteltf-jenk.sh.intel.com/job/AutoRound_unit_test/116//artifact/auto-round/ut_log_dir/unittest_cuda_test_moe_model.log)

Fixes or relates to #

## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
