### PR TITLE
Fix typo: remove extra backtick in comment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ try:
 except Exception as error:
     assert False, "Error: Could not open '%s' due %s\n" % (filepath, error)
 
-# All BUILD_* flags are initially set to `False`` and
+# All BUILD_* flags are initially set to `False` and
 # will be updated to `True` if the corresponding environment check passes.
 PYPI_RELEASE = os.environ.get("PYPI_RELEASE", None)
 BUILD_HPU_ONLY = os.environ.get("BUILD_HPU_ONLY", "0") == "1"


### PR DESCRIPTION
Fixes a typo in setup.py where False had an extra backtick at the end.