### PR TITLE
Fix #1284: preserve FP8 format for layers specified in ignore_layers

### DIFF
--- a/auto_round/compressors/base.py
+++ b/auto_round/compressors/base.py
@@ -41,6 +41,7 @@ from auto_round.compressors.utils import (
     check_need_act_calibration,
     check_skippable_keywords,
     collect_best_params,
+    get_fp_layer_names,
     get_shared_keys,
     infer_bits_by_data_type,
     init_cache,
@@ -1406,8 +1407,10 @@ class BaseCompressor(object):
                             shard_writer(self, name=n)
                         m.to("meta")
 
-        # Convert remaining fp8
-        convert_module_to_hp_if_necessary(self.model, self.amp_dtype, self.device)
+        # Convert remaining fp8, but keep ignored layers in their original format
+        convert_module_to_hp_if_necessary(
+            self.model, self.amp_dtype, self.device, ignore_layers=self._resolved_ignore_layers
+        )
         if self.is_immediate_saving:
             shard_writer(self, is_finalize=True)
 
@@ -1479,7 +1482,9 @@ class BaseCompressor(object):
                 materialize_model_(block)
                 block.to("cpu")
 
-                block = convert_module_to_hp_if_necessary(block, dtype=self.amp_dtype, device=self.device)
+                block = convert_module_to_hp_if_necessary(
+                    block, dtype=self.amp_dtype, device=self.device, ignore_layers=self._resolved_ignore_layers
+                )
                 update_block_global_scale_if_needed(block, self.data_type, self.group_size)
                 self._register_act_max_hook(block)
                 if is_auto_device_mapping(self.device_map) and len(self.device_list) > 1:
@@ -1602,6 +1607,7 @@ class BaseCompressor(object):
             is_mllm=self.mllm,
             fill_default_value=fill_default_value,
         )
+        self._resolved_ignore_layers = get_fp_layer_names(self.model, self.ignore_layers)
 
     def _adjust_immediate_packing_and_saving(self):
         formats = getattr(self, "formats", [])
@@ -1788,7 +1794,9 @@ class BaseCompressor(object):
         pbar.close()
         self._quantize_layers(layer_names, all_inputs)
 
-        convert_module_to_hp_if_necessary(self.model, self.amp_dtype, self.device, to_cpu=True)
+        convert_module_to_hp_if_necessary(
+            self.model, self.amp_dtype, self.device, to_cpu=True, ignore_layers=self._resolved_ignore_layers
+        )
         if self.is_immediate_saving:
             shard_writer(self, is_finalize=True)
 
@@ -2833,7 +2841,7 @@ class BaseCompressor(object):
         Tuple: (q_outputs, output) if self.enable_quanted_input is True, else (None, output)
         """
         materialize_model_(block)
-        convert_module_to_hp_if_necessary(block, self.amp_dtype, device)
+        convert_module_to_hp_if_necessary(block, self.amp_dtype, device, ignore_layers=self._resolved_ignore_layers)
 
         if auto_offload:
             # card_0_in_high_risk indicates that card_0 memory is already in high usage (90%) w/o any weights

--- a/auto_round/compressors/utils.py
+++ b/auto_round/compressors/utils.py
@@ -876,14 +876,14 @@ def get_fp_layer_names(model: torch.nn.Module, ignore_layers: str):
         list: A list of layer names that match the specified FP layers or are
         subcomponents of those layers.
     """
-    from auto_round.utils import SUPPORTED_LAYER_TYPES
+    from auto_round.utils import INNER_SUPPORTED_LAYER_TYPES, SUPPORTED_LAYER_TYPES
 
     if not ignore_layers:
         return []
     ignore_layers = ignore_layers.replace(" ", "").split(",")
     all_layer_names = []
     for n, m in model.named_modules():
-        if type(m) in SUPPORTED_LAYER_TYPES:
+        if type(m) in SUPPORTED_LAYER_TYPES or m.__class__.__name__ in INNER_SUPPORTED_LAYER_TYPES:
             all_layer_names.append(n)
     not_to_quantized_layers = []
 

--- a/auto_round/utils/weight_handler.py
+++ b/auto_round/utils/weight_handler.py
@@ -347,6 +347,7 @@ def convert_module_to_hp_if_necessary(
     dtype: torch.dtype = torch.bfloat16,
     device: str = "cpu",
     to_cpu: bool = False,
+    ignore_layers: Optional[list] = None,
 ) -> torch.nn.Module:
     """Convert quantized layer(s) to high-precision Linear layer(s) if necessary.
 
@@ -358,6 +359,8 @@ def convert_module_to_hp_if_necessary(
         dtype: Target dtype for the converted layer(s). Defaults to torch.bfloat16.
         device: Target device for the conversion. Defaults to "cpu".
         to_cpu: If True, move converted layers to CPU. Defaults to False.
+        ignore_layers: List of layer names to keep in their original format
+            instead of converting to high precision. Defaults to None.
 
     Returns:
         If input is a quantized layer: A new high-precision layer with dequantized weights.
@@ -366,6 +369,9 @@ def convert_module_to_hp_if_necessary(
     """
     from auto_round.utils.device import clear_memory
     from auto_round.utils.model import set_module
+
+    if ignore_layers is None:
+        ignore_layers = []
 
     # Check if it's a single quantized layer (has the attribute directly)
     if hasattr(model_or_layer, "quantized_weight_type") and model_or_layer.quantized_weight_type is not None:
@@ -377,6 +383,8 @@ def convert_module_to_hp_if_necessary(
     cnt = 0
     for n, m in model_or_layer.named_modules():
         if hasattr(m, "quantized_weight_type") and m.quantized_weight_type is not None:
+            if n in ignore_layers:
+                continue
             handler = get_handler(m.quantized_weight_type)
             new_module = handler.convert_layer(m, dtype, device, to_cpu)
             set_module(model_or_layer, n, new_module)

--- a/test/test_cpu/utils/test_fp8_ignore_layers.py
+++ b/test/test_cpu/utils/test_fp8_ignore_layers.py
@@ -1,0 +1,125 @@
+import unittest
+
+import torch
+import torch.nn as nn
+
+from auto_round.compressors.utils import get_fp_layer_names
+from auto_round.utils.model import (
+    check_and_mark_quantized_module,
+    convert_module_to_hp_if_necessary,
+)
+
+
+class FP8Linear(nn.Module):
+    """Mock FP8Linear layer for testing without GPU/triton dependencies."""
+
+    def __init__(self, in_features, out_features):
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.randn(out_features, in_features).to(torch.float8_e4m3fn))
+        self.weight_scale = nn.Parameter(torch.tensor(0.5))
+        self.bias = None
+        self.data_type = "fp8"
+
+
+class MockFP8Model(nn.Module):
+    """Mock model with FP8Linear layers to simulate an FP8-quantized model."""
+
+    def __init__(self):
+        super().__init__()
+        self.model = nn.Module()
+        self.model.layers = nn.ModuleList()
+        for _ in range(2):
+            layer = nn.Module()
+            layer.self_attn = nn.Module()
+            layer.self_attn.q_proj = FP8Linear(64, 64)
+            layer.self_attn.k_proj = FP8Linear(64, 64)
+            layer.mlp = nn.Module()
+            layer.mlp.up_proj = FP8Linear(64, 128)
+            layer.mlp.down_proj = FP8Linear(128, 64)
+            self.model.layers.append(layer)
+
+
+class TestGetFpLayerNamesWithFP8(unittest.TestCase):
+    """Test that get_fp_layer_names correctly detects FP8Linear layers."""
+
+    def test_fp8_layers_detected(self):
+        """FP8Linear layers should be found by get_fp_layer_names."""
+        model = MockFP8Model()
+        result = get_fp_layer_names(model, "self_attn")
+        self.assertTrue(len(result) > 0, "get_fp_layer_names should detect FP8Linear layers matching 'self_attn'")
+        for name in result:
+            self.assertIn("self_attn", name)
+
+    def test_fp8_layers_exact_match(self):
+        """Exact layer name match should work for FP8Linear layers."""
+        model = MockFP8Model()
+        result = get_fp_layer_names(model, "model.layers.0.mlp.up_proj")
+        self.assertEqual(result, ["model.layers.0.mlp.up_proj"])
+
+    def test_fp8_layers_empty_ignore(self):
+        """Empty ignore_layers should return empty list."""
+        model = MockFP8Model()
+        result = get_fp_layer_names(model, "")
+        self.assertEqual(result, [])
+
+
+class TestConvertModuleSkipsIgnoredLayers(unittest.TestCase):
+    """Test that convert_module_to_hp_if_necessary skips layers in ignore_layers."""
+
+    def test_ignored_layers_stay_fp8(self):
+        """Layers listed in ignore_layers should remain in their original FP8 format."""
+        model = MockFP8Model()
+        check_and_mark_quantized_module(model)
+
+        ignore = ["model.layers.0.self_attn.q_proj", "model.layers.0.self_attn.k_proj"]
+        convert_module_to_hp_if_necessary(model, dtype=torch.bfloat16, ignore_layers=ignore)
+
+        # Ignored layers should still be FP8Linear
+        q_proj = model.model.layers[0].self_attn.q_proj
+        self.assertIsInstance(q_proj, FP8Linear, "Ignored FP8 layer should not be converted")
+
+        k_proj = model.model.layers[0].self_attn.k_proj
+        self.assertIsInstance(k_proj, FP8Linear, "Ignored FP8 layer should not be converted")
+
+        # Non-ignored layers should be converted to nn.Linear
+        up_proj = model.model.layers[0].mlp.up_proj
+        self.assertIsInstance(up_proj, nn.Linear, "Non-ignored FP8 layer should be converted to Linear")
+        self.assertEqual(up_proj.weight.dtype, torch.bfloat16)
+
+    def test_no_ignore_converts_all(self):
+        """Without ignore_layers, all FP8 layers should be converted."""
+        model = MockFP8Model()
+        check_and_mark_quantized_module(model)
+
+        convert_module_to_hp_if_necessary(model, dtype=torch.bfloat16)
+
+        q_proj = model.model.layers[0].self_attn.q_proj
+        self.assertIsInstance(q_proj, nn.Linear, "All FP8 layers should be converted when no ignore_layers")
+
+    def test_ignore_by_pattern_match(self):
+        """Verify the full flow: get_fp_layer_names + convert with ignore."""
+        model = MockFP8Model()
+        check_and_mark_quantized_module(model)
+
+        ignore = get_fp_layer_names(model, "self_attn")
+        convert_module_to_hp_if_necessary(model, dtype=torch.bfloat16, ignore_layers=ignore)
+
+        # All self_attn layers should remain FP8Linear
+        for i in range(2):
+            q_proj = model.model.layers[i].self_attn.q_proj
+            k_proj = model.model.layers[i].self_attn.k_proj
+            self.assertIsInstance(q_proj, FP8Linear, f"layers.{i}.self_attn.q_proj should stay FP8")
+            self.assertIsInstance(k_proj, FP8Linear, f"layers.{i}.self_attn.k_proj should stay FP8")
+
+        # All mlp layers should be converted
+        for i in range(2):
+            up_proj = model.model.layers[i].mlp.up_proj
+            down_proj = model.model.layers[i].mlp.down_proj
+            self.assertIsInstance(up_proj, nn.Linear, f"layers.{i}.mlp.up_proj should be converted")
+            self.assertIsInstance(down_proj, nn.Linear, f"layers.{i}.mlp.down_proj should be converted")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

For FP8 models (e.g. Qwen3-8B-FP8, DeepSeek-V3), layers specified in `ignore_layers` are currently dequantized to BF16 even though the user explicitly wants them kept unchanged. This PR fixes two issues:

1. **Detection gap (supersedes #1283):** `get_fp_layer_names()` only checked `SUPPORTED_LAYER_TYPES` (nn.Linear, Conv1D), missing FP8-specific layer types like `FP8Linear`. Now also checks `INNER_SUPPORTED_LAYER_TYPES`.

2. **Preservation:** `convert_module_to_hp_if_necessary()` blindly converted all quantized layers to high precision. Now accepts an `ignore_layers` parameter to skip specified layers, keeping them in their original FP8 format.

## Type of Change
- [x] Bug fix
- [x] New feature

## Related Issues

Fixes #1284
Supersedes the detection fix from #1283

## Changes

- **`auto_round/compressors/utils.py`** — `get_fp_layer_names()` now detects FP8Linear via `INNER_SUPPORTED_LAYER_TYPES`
- **`auto_round/utils/weight_handler.py`** — `convert_module_to_hp_if_necessary()` gains backward-compatible `ignore_layers` parameter (default `None`)
- **`auto_round/compressors/base.py`** — Resolved ignore layer names stored after `configure_layer_config()` and threaded through all model-level conversion call sites
- **`test/test_cpu/utils/test_fp8_ignore_layers.py`** — 6 unit tests covering detection, skip-on-convert, and end-to-end flow with mock FP8Linear layers

## Checklist Before Submitting
- [x] My code has been tested locally.
- [x] Documentation has been updated as needed.
- [x] New or updated tests are included where applicable.