### PR TITLE
fix bug of quantizing Z-image

### DIFF
--- a/auto_round/compressors/shard_writer.py
+++ b/auto_round/compressors/shard_writer.py
@@ -148,7 +148,11 @@ class ShardWriter:
 
             module = get_module(self.model, module_path)
             # Check if all parameters of this module are now in 'all_saved'
-            if module is not None and all(f"{module_path}.{k}" in all_saved for k in module.state_dict().keys()):
+            if (
+                module is not None
+                and isinstance(module, torch.nn.Module)
+                and all(f"{module_path}.{k}" in all_saved for k in module.state_dict().keys())
+            ):
                 module.to("meta")
 
     def finalize(self):


### PR DESCRIPTION
## Description

1. save config in FrozenDict type (ZImageTransformer2DModel.config)
2. stop evaluation if no args.tasks
3. skip .state_dict calling if module is an parameter object. (x_pad_token, cap_pad_token)


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #1507

## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
