### PR TITLE
Fix CI test_transformers issue caused by transformers 5.3.0

### DIFF
--- a/auto_round/utils/common.py
+++ b/auto_round/utils/common.py
@@ -171,28 +171,9 @@ def _patch_tensor_get_dtype_for_prequantized_loading():
     if hasattr(torch.Tensor, "get_dtype"):
         return
 
-    torch_to_safetensors_dtype = {
-        torch.int8: "I8",
-        torch.uint8: "U8",
-        torch.int16: "I16",
-        torch.int32: "I32",
-        torch.int64: "I64",
-        torch.float16: "F16",
-        torch.float32: "F32",
-        torch.float64: "F64",
-        torch.bfloat16: "BF16",
-    }
+    from safetensors.torch import _TYPES
 
-    if hasattr(torch, "uint16"):
-        torch_to_safetensors_dtype[torch.uint16] = "U16"
-    if hasattr(torch, "uint32"):
-        torch_to_safetensors_dtype[torch.uint32] = "U32"
-    if hasattr(torch, "uint64"):
-        torch_to_safetensors_dtype[torch.uint64] = "U64"
-    if hasattr(torch, "float8_e4m3fn"):
-        torch_to_safetensors_dtype[torch.float8_e4m3fn] = "F8_E4M3"
-    if hasattr(torch, "float8_e5m2"):
-        torch_to_safetensors_dtype[torch.float8_e5m2] = "F8_E5M2"
+    torch_to_safetensors_dtype = {v: k for k, v in _TYPES.items()}
 
     def _tensor_get_dtype(self):
         return torch_to_safetensors_dtype.get(self.dtype, str(self.dtype).removeprefix("torch.").upper())


### PR DESCRIPTION
## Description

This PR fixes a compatibility issue with transformers 5.3.0 in the pre-quantized model loading path.

In transformers 5.3.0, `convert_and_load_state_dict_in_model` assumes checkpoint tensors implement get_dtype(). However, some entries such as lm_head.weight are plain torch.Tensor objects, which only expose `.dtype`. This causes loading pre-quantized GPTQ models to fail with:

`AttributeError: 'Tensor' object has no attribute 'get_dtype'`

This change adds a local compatibility patch in our existing transformers monkey patch flow so AutoRound can continue loading affected models on newer transformers versions without changing model behavior.

https://inteltf-jenk.sh.intel.com/job/AutoRound_unit_test/121/artifact/auto-round/ut_log_dir/unittest_cuda_test_transformers.log


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
