### PR TITLE
Optimize mtp tensor process by compiling layer names once for all

### DIFF
--- a/auto_round/compressors/base.py
+++ b/auto_round/compressors/base.py
@@ -80,6 +80,7 @@ from auto_round.utils import (
     check_to_quantized,
     clear_memory,
     compile_func,
+    compress_layer_names,
     convert_dtype_str2torch,
     convert_module_to_hp_if_necessary,
     detect_device,
@@ -1629,8 +1630,9 @@ class BaseCompressor(object):
         is_gguf_format = (f := getattr(self, "formats", None)) is not None and len(f) > 0 and f[0].is_gguf()
         if not is_gguf_format:
             predefined_ignore_layers = get_predefined_ignore_layers(self.model)
+            compressed_predefined_ignore_layers = compress_layer_names(predefined_ignore_layers)
             if predefined_ignore_layers:
-                logger.info(f"Using predefined ignore_layers: {predefined_ignore_layers}")
+                logger.info(f"Using predefined ignore_layers: {compressed_predefined_ignore_layers}")
                 tmp_str = ",".join(predefined_ignore_layers)
                 if self.ignore_layers == "":
                     self.ignore_layers = tmp_str
@@ -1884,7 +1886,8 @@ class BaseCompressor(object):
             f"Summary: quantized {len(quantized_layers)}/{len(quantized_layers) + len(unquantized_layers)} in the model"
         )
         if len(unquantized_layers) > 0:
-            summary_info += f",  {unquantized_layers} have not been quantized"
+            compressed_unquantized_layers = compress_layer_names(unquantized_layers)
+            summary_info += f",  {compressed_unquantized_layers} have not been quantized"
         logger.info(summary_info)
 
         self.quantized = True

--- a/auto_round/formats.py
+++ b/auto_round/formats.py
@@ -45,6 +45,7 @@ from auto_round.schemes import (
 from auto_round.utils import (
     SUPPORTED_FORMATS,
     check_to_quantized,
+    compress_layer_names,
     copy_python_files_from_model_cache,
     find_matching_blocks,
     get_block_names,
@@ -149,6 +150,7 @@ def _check_divisible_by_32(ar):
         default_dict = asdict(preset_name_to_scheme(ar.scheme.upper()))
     else:
         default_dict = asdict(ar.scheme)
+    skipped_layers = []
     if default_dict["data_type"] == "int" and default_dict["act_bits"] >= 16:
         for n, m in ar.model.named_modules():
             if type(m) in ar.supported_types or m.__class__.__name__ in ar.inner_supported_types:
@@ -159,7 +161,11 @@ def _check_divisible_by_32(ar):
                         continue
                     ar.layer_config.setdefault(n, copy.deepcopy(default_dict))
                     ar.layer_config[n].update({"bits": 16, "data_type": "fp", "fixed_by_user": True})
-                    logger.warning_once("some layers are skipped quantization (shape not divisible by 32).")
+                    skipped_layers.append(n)
+    compressed_skipped_layers = compress_layer_names(skipped_layers)
+    logger.warning_once(
+        f"some layers are skipped quantization (shape not divisible by 32): {compressed_skipped_layers}"
+    )
 
 
 class OutputFormat(ABC):

--- a/auto_round/utils/common.py
+++ b/auto_round/utils/common.py
@@ -542,3 +542,51 @@ def parse_layer_config_arg(s: str) -> dict:
         return result
 
     return _dict()
+
+
+def compress_layer_names(names: list) -> str:
+    """Compress numbered layer names, e.g. layer.0, layer.1, layer.2 → layer.[0-2]."""
+    import re as _re
+
+    # group by (prefix, suffix) where the number varies
+    from collections import defaultdict
+
+    groups: dict = defaultdict(list)
+    singles: list = []
+    for name in names:
+        m = _re.match(r"^(.*?\.)?(\d+)(\..+)?$", name)
+        if m:
+            prefix = m.group(1) or ""
+            num = int(m.group(2))
+            suffix = m.group(3) or ""
+            groups[(prefix, suffix)].append(num)
+        else:
+            singles.append(name)
+    parts: list = []
+    for (prefix, suffix), nums in groups.items():
+        nums_sorted = sorted(set(nums))
+        if len(nums_sorted) == 1:
+            parts.append(f"{prefix}{nums_sorted[0]}{suffix}")
+        else:
+            # Build comma-separated contiguous ranges, e.g. [0,2-3,5]
+            ranges = []
+            start = prev = nums_sorted[0]
+            for n in nums_sorted[1:]:
+                if n == prev + 1:
+                    prev = n
+                    continue
+                # Close the current range
+                if start == prev:
+                    ranges.append(str(start))
+                else:
+                    ranges.append(f"{start}-{prev}")
+                start = prev = n
+            # Close the final range
+            if start == prev:
+                ranges.append(str(start))
+            else:
+                ranges.append(f"{start}-{prev}")
+            range_str = ",".join(ranges)
+            parts.append(f"{prefix}[{range_str}]{suffix}")
+    parts.extend(singles)
+    return ", ".join(parts)

--- a/auto_round/utils/missing_tensors.py
+++ b/auto_round/utils/missing_tensors.py
@@ -44,6 +44,7 @@ from typing import Optional, Tuple
 import torch
 
 from auto_round.logger import logger
+from auto_round.utils.common import compress_layer_names
 from auto_round.utils.weight_handler import _dequant_fp8_linear_weight
 
 
@@ -220,55 +221,8 @@ def copy_missing_tensors_from_source(
     except ImportError:
         _tqdm = None
 
-    def _compress_layer_names(names: list) -> str:
-        """Compress numbered layer names, e.g. layer.0, layer.1, layer.2 → layer.[0-2]."""
-        import re as _re
-
-        # group by (prefix, suffix) where the number varies
-        from collections import defaultdict
-
-        groups: dict = defaultdict(list)
-        singles: list = []
-        for name in names:
-            m = _re.match(r"^(.*?\.)?(\d+)(\..+)?$", name)
-            if m:
-                prefix = m.group(1) or ""
-                num = int(m.group(2))
-                suffix = m.group(3) or ""
-                groups[(prefix, suffix)].append(num)
-            else:
-                singles.append(name)
-        parts: list = []
-        for (prefix, suffix), nums in groups.items():
-            nums_sorted = sorted(set(nums))
-            if len(nums_sorted) == 1:
-                parts.append(f"{prefix}{nums_sorted[0]}{suffix}")
-            else:
-                # Build comma-separated contiguous ranges, e.g. [0,2-3,5]
-                ranges = []
-                start = prev = nums_sorted[0]
-                for n in nums_sorted[1:]:
-                    if n == prev + 1:
-                        prev = n
-                        continue
-                    # Close the current range
-                    if start == prev:
-                        ranges.append(str(start))
-                    else:
-                        ranges.append(f"{start}-{prev}")
-                    start = prev = n
-                # Close the final range
-                if start == prev:
-                    ranges.append(str(start))
-                else:
-                    ranges.append(f"{start}-{prev}")
-                range_str = ",".join(ranges)
-                parts.append(f"{prefix}[{range_str}]{suffix}")
-        parts.extend(singles)
-        return ", ".join(parts)
-
     # Compressed parent-layer summary for display
-    parent_summary = _compress_layer_names(list({name.rsplit(".", 1)[0] for name in missing_tensor_names}))
+    parent_summary = compress_layer_names(list({name.rsplit(".", 1)[0] for name in missing_tensor_names}))
     logger.info(
         f"Found {len(missing_tensor_names)} tensor(s) in the source checkpoint that are "
         f"absent from the saved output (e.g., MTP parameters). Copying them now...\n"
@@ -362,7 +316,7 @@ def copy_missing_tensors_from_source(
         missing_tensors_dict.pop(k, None)
 
     if dequantized_keys:
-        dq_summary = _compress_layer_names([k.rsplit(".", 1)[0] for k in dequantized_keys])
+        dq_summary = compress_layer_names([k.rsplit(".", 1)[0] for k in dequantized_keys])
         logger.info(f"Dequantized {len(dequantized_keys)} FP8 weight(s) to BF16 before saving: " f"{dq_summary}")
 
     if not missing_tensors_dict:
@@ -699,7 +653,7 @@ def _woq_quantize_missing_tensors(target_dir: str, missing_tensors_dict: dict) -
         _tqdm_woq = None
 
     logger.info(
-        f"Applying WOQ to "
+        f"Applying WOQ[RTN] to "
         f"{len(weight_keys)} missing Linear weight(s) (per-layer overrides from extra_config applied)..."
     )
 
@@ -707,7 +661,7 @@ def _woq_quantize_missing_tensors(target_dir: str, missing_tensors_dict: dict) -
     packed_weight_keys: set = set()
 
     _woq_iter = (
-        _tqdm_woq(weight_keys, desc="WOQ quantizing missing weights", unit="weight") if _tqdm_woq else weight_keys
+        _tqdm_woq(weight_keys, desc="WOQ[RTN] quantizing missing weights", unit="weight") if _tqdm_woq else weight_keys
     )
     for weight_key in _woq_iter:
         weight = missing_tensors_dict[weight_key]
@@ -724,7 +678,8 @@ def _woq_quantize_missing_tensors(target_dir: str, missing_tensors_dict: dict) -
             continue
 
         logger.debug(
-            f"WOQ [{layer_name}]: bits={bits}, group_size={effective_gs}, sym={sym}, " f"shape={list(weight.shape)}"
+            f"WOQ[RTN] [{layer_name}]: bits={bits}, group_size={effective_gs}, sym={sym}, "
+            f"shape={list(weight.shape)}"
         )
 
         base_name = layer_name


### PR DESCRIPTION
## Description

Got report that mtp process uses 10min for name matching and 5 min for WOQ [GLM-5]
Now the time usage reduces from 15min to 1min

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
