### PR TITLE
temporary pin compressed-tensors version for llmcompressor

### DIFF
--- a/test/test_cpu/requirements.txt
+++ b/test/test_cpu/requirements.txt
@@ -6,6 +6,7 @@ torchvision
 pillow
 numba
 llmcompressor @ git+https://github.com/vllm-project/llm-compressor.git@main
+compressed-tensors==0.14.1a20260313 # temporary pin for llmcompressor
 lm_eval >= 0.4.10  # for transformers >= 5.0.0
 diffusers
 protobuf

--- a/test/test_cuda/requirements_llmc.txt
+++ b/test/test_cuda/requirements_llmc.txt
@@ -1,2 +1,3 @@
 llmcompressor @ git+https://github.com/vllm-project/llm-compressor.git@main
+compressed-tensors==0.14.1a20260313 # temporary pin for llmcompressor
 parameterized


### PR DESCRIPTION
## Description

The latest compressed-tensors==0.14.1a20260317 failed working with llmcompressor main, so temporary pin compressed-tensors==0.14.1a20260313

```
ModuleNotFoundError: No module named 'compressed_tensors.config.format'
```

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

https://dev.azure.com/lpot-inc/neural-compressor/_build/results?buildId=54621&view=logs&j=5c5351d8-ce46-59e1-9e52-f0f0641619d8&t=478fd128-70ad-53d2-42bd-f88959cdf7e4&s=aadfae5e-0eaf-564b-a3df-10bb939b2487 

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
