### PR TITLE
Freeze compressed-tensors & llmc version temporary

### DIFF
--- a/.azure-pipelines/template/ut-template.yml
+++ b/.azure-pipelines/template/ut-template.yml
@@ -57,7 +57,6 @@ steps:
             && uv pip install torch==2.10.0 auto-round-lib \
             && uv pip install -r requirements.txt \
             && uv pip install -r requirements-cpu.txt \
-            && BUILD_TYPE="nightly" uv pip install git+https://github.com/vllm-project/compressed-tensors.git@main \
             && uv pip install -r test/test_cpu/requirements.txt \
             && uv pip list"
         fi

--- a/test/test_cpu/requirements.txt
+++ b/test/test_cpu/requirements.txt
@@ -5,7 +5,8 @@ sentencepiece
 torchvision
 pillow
 numba
-llmcompressor @ git+https://github.com/vllm-project/llm-compressor.git@main
+llmcompressor @ git+https://github.com/vllm-project/llm-compressor.git@370c04c34191c0e5fb88cf889e16578bf8c7fe20
+compressed-tensors==0.14.1a20260313 # temporary pin for llmcompressor
 lm_eval >= 0.4.10  # for transformers >= 5.0.0
 diffusers
 protobuf

--- a/test/test_cuda/requirements_llmc.txt
+++ b/test/test_cuda/requirements_llmc.txt
@@ -1,2 +1,3 @@
-llmcompressor @ git+https://github.com/vllm-project/llm-compressor.git@main
+llmcompressor @ git+https://github.com/vllm-project/llm-compressor.git@370c04c34191c0e5fb88cf889e16578bf8c7fe20
+compressed-tensors==0.14.1a20260313 # temporary pin for llmcompressor
 parameterized


### PR DESCRIPTION
## Description

Freeze a working group of CT&LLMC version temporary. 
Remove this setting after AR adapt to the CT&LLMC main branch. https://github.com/intel/auto-round/issues/1566 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

https://dev.azure.com/lpot-inc/neural-compressor/_build/results?buildId=54734&view=logs&j=0718afd5-0193-50e2-f61e-339434831c57&t=f0cdb2f4-de39-53be-2df0-8ec80aae108c&l=2990  
https://dev.azure.com/lpot-inc/neural-compressor/_build/results?buildId=54894&view=logs&jobId=44c25250-aab3-5e31-d6d7-8ba2147b1266&j=44c25250-aab3-5e31-d6d7-8ba2147b1266&t=262f41be-8379-5409-f492-e6c716395db9

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
