### PR TITLE
Fix AutoScheme low memory flag propagation from CLI

### DIFF
--- a/auto_round/__main__.py
+++ b/auto_round/__main__.py
@@ -151,10 +151,7 @@ class BasicArgumentParser(argparse.ArgumentParser):
         basic.add_argument(
             "--disable_low_cpu_mem_usage",
             action="store_true",
-            help=(
-                "Disable low CPU memory mode. "
-                "Use this flag to turn off the default low CPU memory behavior."
-            ),
+            help=("Disable low CPU memory mode. " "Use this flag to turn off the default low CPU memory behavior."),
         )
         basic.add_argument(
             "--format",


### PR DESCRIPTION
## Description

This PR fixes inconsistent memory-mode behavior between the main AutoRound flow and AutoScheme when running from CLI.

low_gpu_mem_usage and low_cpu_mem_usage from CLI were passed to AutoRound but were not passed to AutoScheme.
This caused AutoScheme to run under a different memory strategy than the main quantization flow, which could lead to unexpectedly high CPU RAM usage and misleading memory behavior during AutoScheme generation.


CUDA_VISIBLE_DEVICES=6 python -m auto_round /mnt/disk2/lvl/Qwen3-1.7B/ --target_bits 2.5 --ignore_scale_zp_bits --options "gguf:q2_k_s,gguf:q4_k_s" --iters 1 --nsamples 16

Before fix:
<img width="2249" height="156" alt="image" src="https://github.com/user-attachments/assets/8aefab65-f8b5-4907-9023-87addb56187b" />


After fix:
<img width="2267" height="145" alt="image" src="https://github.com/user-attachments/assets/d2c6482a-e2f3-4de8-bd28-a600926414c0" />


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

https://github.com/intel/auto-round/issues/1586

## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
