### PR TITLE
force auto-scheme low_gpu to True in CLI

### DIFF
--- a/auto_round/__main__.py
+++ b/auto_round/__main__.py
@@ -696,7 +696,7 @@ def tune(args):
             avg_bits=args.avg_bits,
             shared_layers=args.shared_layers,
             ignore_scale_zp_bits=args.ignore_scale_zp_bits,
-            low_gpu_mem_usage=False,  # force it to be False as it uses much smaller vram but similar time cost
+            low_gpu_mem_usage=True,  # force it to be True as it uses much smaller vram but similar time cost
             low_cpu_mem_usage=low_cpu_mem_usage,
         )
 


### PR DESCRIPTION
## Description

AutoScheme uses much larger vram  than AutoRound without low_gpu, set it to False

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
