### PR TITLE
Stabilize Qwen3-Omni MoE weight fidelity test for matching NaNs

### DIFF
--- a/test/test_cpu/models/test_omni_model.py
+++ b/test/test_cpu/models/test_omni_model.py
@@ -262,8 +262,11 @@ class TestQwen3OmniMoeReplacement:
     def test_weight_fidelity(self):
         """Test that unfused weights match original fused weights."""
         from auto_round.modeling.fused_moe.replace_modules import apply_replacements, materialize_model_
-
         torch.manual_seed(42)
+
+        def assert_same_weights(actual: torch.Tensor, expected: torch.Tensor):
+            assert torch.allclose(actual, expected, equal_nan=True)
+
         config = _make_tiny_qwen3_omni_moe_config()
         model = Qwen3OmniMoeForConditionalGeneration(config)
 
@@ -280,16 +283,16 @@ class TestQwen3OmniMoeReplacement:
         # Verify thinker expert weights
         for i in range(4):
             expert = model.thinker.model.layers[0].mlp.experts[i]
-            assert torch.allclose(expert.gate_proj.weight.data, thinker_gate_up[i, :intermediate, :])
-            assert torch.allclose(expert.up_proj.weight.data, thinker_gate_up[i, intermediate:, :])
-            assert torch.allclose(expert.down_proj.weight.data, thinker_down[i])
+            assert_same_weights(expert.gate_proj.weight.data, thinker_gate_up[i, :intermediate, :])
+            assert_same_weights(expert.up_proj.weight.data, thinker_gate_up[i, intermediate:, :])
+            assert_same_weights(expert.down_proj.weight.data, thinker_down[i])
 
         # Verify talker expert weights
         for i in range(4):
             expert = model.talker.model.layers[0].mlp.experts[i]
-            assert torch.allclose(expert.gate_proj.weight.data, talker_gate_up[i, :intermediate, :])
-            assert torch.allclose(expert.up_proj.weight.data, talker_gate_up[i, intermediate:, :])
-            assert torch.allclose(expert.down_proj.weight.data, talker_down[i])
+            assert_same_weights(expert.gate_proj.weight.data, talker_gate_up[i, :intermediate, :])
+            assert_same_weights(expert.up_proj.weight.data, talker_gate_up[i, intermediate:, :])
+            assert_same_weights(expert.down_proj.weight.data, talker_down[i])
 
     def test_forward_output_match(self):
         """Test that replaced MoE forward output matches original."""

--- a/test/test_cpu/models/test_omni_model.py
+++ b/test/test_cpu/models/test_omni_model.py
@@ -262,6 +262,7 @@ class TestQwen3OmniMoeReplacement:
     def test_weight_fidelity(self):
         """Test that unfused weights match original fused weights."""
         from auto_round.modeling.fused_moe.replace_modules import apply_replacements, materialize_model_
+
         torch.manual_seed(42)
 
         def assert_same_weights(actual: torch.Tensor, expected: torch.Tensor):

--- a/test/test_cpu/models/test_omni_model.py
+++ b/test/test_cpu/models/test_omni_model.py
@@ -265,7 +265,7 @@ class TestQwen3OmniMoeReplacement:
 
         torch.manual_seed(42)
 
-        def assert_same_weights(actual: torch.Tensor, expected: torch.Tensor):
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0, equal_nan=True)
             assert torch.allclose(actual, expected, equal_nan=True)
 
         config = _make_tiny_qwen3_omni_moe_config()

--- a/test/test_cpu/models/test_omni_model.py
+++ b/test/test_cpu/models/test_omni_model.py
@@ -262,11 +262,10 @@ class TestQwen3OmniMoeReplacement:
     def test_weight_fidelity(self):
         """Test that unfused weights match original fused weights."""
         from auto_round.modeling.fused_moe.replace_modules import apply_replacements, materialize_model_
-
         torch.manual_seed(42)
 
+        def assert_same_weights(actual: torch.Tensor, expected: torch.Tensor):
             torch.testing.assert_close(actual, expected, rtol=0, atol=0, equal_nan=True)
-            assert torch.allclose(actual, expected, equal_nan=True)
 
         config = _make_tiny_qwen3_omni_moe_config()
         model = Qwen3OmniMoeForConditionalGeneration(config)


### PR DESCRIPTION
## Description

This PR fixes a unstable failure in the Qwen3-Omni MoE CPU weight fidelity test.
The failure was in the test assertion.

For the failing talker path: finite values matched exactly and NaN masks also matched.
only the default torch.allclose behavior caused the assertion to fail. torch.allclose treats NaN != NaN by default and incorrectly reported a mismatch. 

Add a small helper in test_weight_fidelity to compare tensors with torch.allclose(..., equal_nan=True)


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

https://dev.azure.com/lpot-inc/neural-compressor/_build/results?buildId=57526&view=logs&j=44c25250-aab3-5e31-d6d7-8ba2147b1266&t=262f41be-8379-5409-f492-e6c716395db9&l=430


## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
