### PR TITLE
Fix #1679 (agentic)

### DIFF
--- a/auto_round/utils/device.py
+++ b/auto_round/utils/device.py
@@ -95,7 +95,7 @@ def compile_func_on_hpu(func):
 
 
 def compile_func_on_cuda_or_cpu(func):
-    return torch.compile(func)
+    return torch.compile(func, dynamic=True)
 
 
 def compile_func(


### PR DESCRIPTION
Fixes #1679.

Generated by **opensrcer agentic solve**. Claude explored the codebase via the
`opensrcer-repo-tools` MCP server (list_files / read_file / grep /
find_definition / find_references) before authoring the patch.

Full exploration + diagnosis: see dispatch log `d_2026-04-15T06-16-48_f14715` in the
opensrcer dashboard.

---

> ⚠️ This PR is opened as **draft** on purpose. Upstream CI should run first;
> mark Ready for review only after checks pass.
