### PR TITLE
rename scheme INT8_W8A8 to INT8

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ ar.quantize_and_save(output_dir="./qmodel", format="auto_round")
 | **auto_round**     | W4A16(Recommended), W2A16, W3A16, W8A16, W2A16G64, W2A16G32, `MXFP4`, `MXFP8`, `MXFP4_RCEIL`, `MXFP8_RCEIL`, `NVFP4`, `FPW8A16`, `FP8_STATIC`, `BF16`                     |
 | **auto_awq**       | W4A16(Recommended), BF16                                                                                                                                                  |
 | **auto_gptq**      | W4A16(Recommended), W2A16, W3A16, W8A16, W2A16G64, W2A16G32,BF16                                                                                                          |
-| **llm_compressor** | NVFP4(Recommended), `MXFP4`, `MXFP8`, `FPW8A16`, `FP8_STATIC`, `FP8_BLOCK`, `INT8_W8A8`, `W4A16`, `W8A16`                                                                   |
+| **llm_compressor** | NVFP4(Recommended), `MXFP4`, `MXFP8`, `FPW8A16`, `FP8_STATIC`, `FP8_BLOCK`, `INT8`, `W4A16`, `W8A16`                                                                   |
 | **gguf**           | GGUF:Q4_K_M(Recommended), GGUF:Q2_K_S, GGUF:Q3_K_S, GGUF:Q3_K_M, GGUF:Q3_K_L, GGUF:Q4_K_S, GGUF:Q5_K_S, GGUF:Q5_K_M, GGUF:Q6_K, GGUF:Q4_0, GGUF:Q4_1, GGUF:Q5_0, GGUF:Q5_1,GGUF:Q8_0 |
 | **fake**           | `all schemes (only for research)`                                                                                                                                         |
 </details>

--- a/README_CN.md
+++ b/README_CN.md
@@ -242,7 +242,7 @@ ar.quantize_and_save(output_dir="./qmodel", format="auto_round")
 |**auto_round**| W4A16（推荐）、W2A16、W3A16、W8A16、W2A16G64、W2A16G32、`MXFP4`​、`MXFP8`​、`MXFP4_RCEIL`​、`MXFP8_RCEIL`​、`NVFP4`​、`FPW8A16`​、`FP8_STATIC`​、`BF16`                                                          |
 |**auto_awq**| W4A16（推荐）、BF16                                                                                                                                                                                  |
 |**auto_gptq**| W4A16（推荐）、W2A16、W3A16、W8A16、W2A16G64、W2A16G32、BF16                                                                                                                                              |
-|**llm_compressor**| NVFP4（推荐）、`MXFP4`​、`MXFP8`​、`FPW8A16`​、`FP8_STATIC`、`FP8_BLOCK`、`INT8_W8A8`、`W4A16`、`W8A16`                                                                                                  |
+|**llm_compressor**| NVFP4（推荐）、`MXFP4`​、`MXFP8`​、`FPW8A16`​、`FP8_STATIC`、`FP8_BLOCK`、`INT8`、`W4A16`、`W8A16`                                                                                                  |
 |**gguf**| GGUF:Q4\_K\_M（推荐）、Auto-RoundGGUF:Q2\_K\_S、GGUF:Q3\_K\_S、GGUF:Q3\_K\_M、GGUF:Q3\_K\_L、GGUF:Q4\_K\_S、GGUF:Q5\_K\_S、GGUF:Q5\_K\_M、GGUF:Q6\_K、GGUF:Q4\_0、GGUF:Q4\_1、GGUF:Q5\_0、GGUF:Q5\_1、GGUF:Q8\_0 |
 |**fake**| ​`所有方案（仅用于研究）`                                                                                                                                                                                  |
 </details>

--- a/auto_round/formats.py
+++ b/auto_round/formats.py
@@ -350,7 +350,18 @@ class FakeFormat(OutputFormat):
 
 @OutputFormat.register("llm_compressor")
 class LLMCompressorFormat(OutputFormat):
-    support_schemes = ["MXFP4", "MXFP8", "NVFP4", "FPW8A16", "FP8_STATIC", "INT8", "INT8_W8A8", "FP8_BLOCK", "W4A16", "W8A16"]
+    support_schemes = [
+        "MXFP4",
+        "MXFP8",
+        "NVFP4",
+        "FPW8A16",
+        "FP8_STATIC",
+        "INT8",
+        "INT8_W8A8",
+        "FP8_BLOCK",
+        "W4A16",
+        "W8A16",
+    ]
     format_name = "llm_compressor"
 
     def __init__(self, format, ar):

--- a/auto_round/formats.py
+++ b/auto_round/formats.py
@@ -69,7 +69,7 @@ class AutoRoundExportFormat(str, Enum):
     NV_FP = "nv_fp"
     MX_FP_RCEIL = "mx_fp_rceil"
     NV_FP4_WITH_STATIC_GS = "nv_fp4_with_static_gs"
-    INT8_W8A8 = "int8_w8a8"
+    INT8 = "int8_w8a8"
     FP8_BLOCK = "fp8_block"
     MXINT4 = "mxint4"
     MX_INT = "mx_int"
@@ -350,7 +350,7 @@ class FakeFormat(OutputFormat):
 
 @OutputFormat.register("llm_compressor")
 class LLMCompressorFormat(OutputFormat):
-    support_schemes = ["MXFP4", "MXFP8", "NVFP4", "FPW8A16", "FP8_STATIC", "INT8_W8A8", "FP8_BLOCK", "W4A16", "W8A16"]
+    support_schemes = ["MXFP4", "MXFP8", "NVFP4", "FPW8A16", "FP8_STATIC", "INT8", "INT8_W8A8", "FP8_BLOCK", "W4A16", "W8A16"]
     format_name = "llm_compressor"
 
     def __init__(self, format, ar):
@@ -388,7 +388,8 @@ class LLMCompressorFormat(OutputFormat):
                 from auto_round.export.export_to_llmcompressor import check_compressed_tensors_supported
 
                 check_compressed_tensors_supported()
-                self.backend = LLMCompressorFormat(AutoRoundExportFormat.INT8_W8A8.value, ar)
+                self.backend = LLMCompressorFormat(AutoRoundExportFormat.INT8.name, ar)
+                self.backend.output_format = f"llm_compressor:{AutoRoundExportFormat.INT8.value}"
             elif is_wint_woq(ar):
                 from auto_round.export.export_to_llmcompressor import check_compressed_tensors_supported
 
@@ -475,7 +476,7 @@ class LLMCompressorFormat(OutputFormat):
             from auto_round.export.export_to_llmcompressor.export_to_static_fp import pack_layer
 
             return pack_layer(layer_name, model, self.get_backend_name(), device=device)
-        elif re.search(f"{AutoRoundExportFormat.INT8_W8A8.value}", self.output_format):
+        elif re.search(f"{AutoRoundExportFormat.INT8.value}", self.output_format):
             from auto_round.export.export_to_llmcompressor.export import pack_layer
 
             return pack_layer(layer_name, model, device=device)

--- a/auto_round/schemes.py
+++ b/auto_round/schemes.py
@@ -298,7 +298,7 @@ FP8_STATIC = QuantizationScheme.from_dict(
     }
 )
 
-INT8_W8A8 = QuantizationScheme.from_dict(
+INT8 = QuantizationScheme.from_dict(
     {
         "bits": 8,
         "group_size": -1,
@@ -340,7 +340,8 @@ PRESET_SCHEMES = {
     "FP8_STATIC": FP8_STATIC,
     "BF16": BF16,
     "W4A16_MIXED": W4A16,
-    "INT8_W8A8": INT8_W8A8,
+    "INT8": INT8,
+    "INT8_W8A8": INT8,
     "FP8_BLOCK": FP8_BLOCK,
     "MXINT4": MXINT4,
 }

--- a/auto_round/schemes.py
+++ b/auto_round/schemes.py
@@ -105,6 +105,12 @@ def preset_name_to_scheme(name: str) -> QuantizationScheme:
     if name not in PRESET_SCHEMES:
         raise KeyError(f"Unknown preset scheme name {name}, " f"available names: {list(PRESET_SCHEMES.keys())}")
 
+    if name == "INT8_W8A8":
+        logger.warning_once(
+            "The 'INT8_W8A8' scheme name is deprecated and will be removed in a future release. "
+            "Please use 'INT8' instead."
+        )
+
     scheme_args = deepcopy(PRESET_SCHEMES[name])
     return scheme_args
 

--- a/test/test_cpu/export/test_export.py
+++ b/test/test_cpu/export/test_export.py
@@ -485,8 +485,8 @@ class TestAutoRound:
     @pytest.mark.parametrize(
         "iters,use_dataloader,scheme",
         [
-            (0, False, "INT8"),   # RTN with new scheme name
-            (1, True, "INT8"),    # tuning with new scheme name
+            (0, False, "INT8"),  # RTN with new scheme name
+            (1, True, "INT8"),  # tuning with new scheme name
             (0, False, "INT8_W8A8"),  # RTN with old scheme name (backward compat)
         ],
         ids=["rtn", "tuning", "rtn-old-scheme"],

--- a/test/test_cpu/export/test_export.py
+++ b/test/test_cpu/export/test_export.py
@@ -400,13 +400,24 @@ class TestAutoRound:
 
         autoround = AutoRound(
             model=self.model_name,
-            scheme="INT8_W8A8",
+            scheme="INT8",
         )
         format_list = get_formats("llm_compressor, auto_round:llm_compressor", autoround)
         assert format_list[0].output_format == "llm_compressor"
         assert format_list[0].get_backend_name() == "llm_compressor:int8_w8a8"
         assert format_list[1].output_format == "auto_round"
         assert format_list[1].get_backend_name() == "auto_round:llm_compressor:int8_w8a8"
+
+        # Verify backward compatibility: INT8_W8A8 (old name) produces identical formats to INT8
+        autoround_old = AutoRound(
+            model=self.model_name,
+            scheme="INT8_W8A8",
+        )
+        format_list_old = get_formats("llm_compressor, auto_round:llm_compressor", autoround_old)
+        assert format_list_old[0].output_format == "llm_compressor"
+        assert format_list_old[0].get_backend_name() == "llm_compressor:int8_w8a8"
+        assert format_list_old[1].output_format == "auto_round"
+        assert format_list_old[1].get_backend_name() == "auto_round:llm_compressor:int8_w8a8"
 
     def test_export_format_with_scheme(self, tiny_qwen_model_path):
         from auto_round.formats import get_formats
@@ -472,14 +483,15 @@ class TestAutoRound:
         ), f"'model.visual.blocks' should be in modules_to_not_convert. Got: {modules_to_not_convert}"
 
     @pytest.mark.parametrize(
-        "iters,use_dataloader",
+        "iters,use_dataloader,scheme",
         [
-            (0, False),  # RTN (no tuning)
-            (1, True),  # with tuning
+            (0, False, "INT8"),   # RTN with new scheme name
+            (1, True, "INT8"),    # tuning with new scheme name
+            (0, False, "INT8_W8A8"),  # RTN with old scheme name (backward compat)
         ],
-        ids=["rtn", "tuning"],
+        ids=["rtn", "tuning", "rtn-old-scheme"],
     )
-    def test_llmc_dynamic_wint8aint8_export(self, iters, use_dataloader, dataloader):
+    def test_llmc_dynamic_wint8aint8_export(self, iters, use_dataloader, scheme, dataloader):
         from safetensors import safe_open
 
         dataset = dataloader if use_dataloader else None
@@ -489,7 +501,7 @@ class TestAutoRound:
             nsamples=2,
             seqlen=2,
             dataset=dataset,
-            scheme="INT8_W8A8",
+            scheme=scheme,
         )
         quantized_model_path = self.save_dir
         autoround.quantize_and_save(output_dir=quantized_model_path, format="llm_compressor")


### PR DESCRIPTION
## Description

Rename scheme INT8_W8A8 to INT8, including code, test, doc.  

Use INT8 in doc, but also keep backward compatibility of using old name.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Other (please specify):

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #1674

## Checklist Before Submitting

- [x] My code has been tested locally.
- [x] Documentation has been updated as needed.
- [x] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
