### PR TITLE
fix: add missing run_mllm entry point alias

### DIFF
--- a/auto_round/__main__.py
+++ b/auto_round/__main__.py
@@ -843,5 +843,9 @@ def run_fast():
     start("fast")
 
 
+def run_mllm():
+    run()
+
+
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
# Pull Request Description

## Description

This PR resolves an `ImportError` that occurs when attempting to run the `auto-round-mllm` or `auto_round_mllm` console scripts. The issue was caused by the `setup.cfg` entry points pointing to a non-existent function `run_mllm` in `auto_round.__main__`. 

Since MLLM functionality has been integrated into the main `run()` logic with auto-detection, this PR adds `run_mllm` as a simple alias to `run()` to restore the functionality of the dedicated MLLM command-line interface.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to # (No existing issue found, discovered during local testing of v0.13.0.dev)

## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
Note: Verified that `auto-round-mllm --help` now executes correctly after this change.