### PR TITLE
ignore mtp.fc for qwen3_5 due to vllm failure

### DIFF
--- a/auto_round/special_model_handler.py
+++ b/auto_round/special_model_handler.py
@@ -584,6 +584,15 @@ register_ignore_layers(
     ],
 )
 
+register_ignore_layers(
+    matchers=[
+        ModelTypeMatcher(r"qwen3_5", mode="in"),
+    ],
+    ignore_layers=[
+        "mtp.fc",
+    ],
+)
+
 
 def get_predefined_ignore_layers(model: torch.nn.Module) -> list[str]:
     layers = []

--- a/auto_round/special_model_handler.py
+++ b/auto_round/special_model_handler.py
@@ -589,7 +589,10 @@ register_ignore_layers(
         ModelTypeMatcher(r"qwen3_5", mode="in"),
     ],
     ignore_layers=[
+        "mlp.gate",
+        "mlp.shared_expert_gate",
         "mtp.fc",
+        "mtp.gate",
     ],
 )
 


### PR DESCRIPTION
## Description

By default, we should ignore mtp.fc to ensure vllm works.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
