### PR TITLE
add small zimage test and fix bug

### DIFF
--- a/auto_round/utils/model.py
+++ b/auto_round/utils/model.py
@@ -1975,6 +1975,10 @@ def rename_weights_files(path: str, prefix="diffusion_pytorch_model"):
     # rename safetensors
     files = sorted(glob.glob(f"{path}/*.safetensors"))
     total = len(files)
+    if total == 1:
+        new = f"{prefix}.safetensors"
+        os.rename(files[0], os.path.join(path, new))
+        return
 
     for i, f in enumerate(files, 1):
         new = f"{prefix}-{i:05d}-of-{total:05d}.safetensors"

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -133,6 +133,37 @@ def tiny_flux_model_path():
 
 
 @pytest.fixture(scope="session")
+def tiny_z_image_model_path():
+    model_name_or_path = "Tongyi-MAI/Z-Image"
+    tiny_model_path = "./tmp/tiny_z_image_model_path"
+    tiny_model_path = save_tiny_model(
+        model_name_or_path,
+        tiny_model_path,
+        num_layers=1,
+        is_diffusion=True,
+        from_config=True,
+        config_overrides={
+            "dim": 256,
+            "n_heads": 2,
+            "n_kv_heads": 2,
+            "n_layers": 1,
+            "n_refiner_layers": 1,
+            "cap_feat_dim": 512,
+            "in_channels": 16,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 2,
+            "attention_head_dim": 128,
+            "joint_attention_dim": 256,
+            "pooled_projection_dim": 256,
+            "hidden_size": 512,
+            "intermediate_size": 256,
+        },
+    )
+    yield tiny_model_path
+    shutil.rmtree(tiny_model_path, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
 def tiny_untied_qwen_model_path():
     model_name_or_path = qwen_name_or_path
     tiny_model_path = "./tmp/tiny_untied_qwen_model_path"

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -112,41 +112,6 @@ def get_model_path(model_name: str) -> str:
         return model_name
 
 
-def get_captions_dataset_path() -> str:
-    """Find captions_source.tsv locally or download it to tmp.
-
-    Checks /dataset/, /tf_dataset/, and test/tmp/ for the file.
-    If not found, downloads from the mlcommons URL to test/tmp/.
-
-    Returns:
-        str: The path to captions_source.tsv.
-    """
-    import urllib.request
-
-    filename = "captions_source.tsv"
-    url = (
-        "https://raw.githubusercontent.com/mlcommons/inference/refs/heads/master/"
-        "text_to_image/coco2014/captions/captions_source.tsv"
-    )
-
-    local_candidates = [
-        f"/dataset/{filename}",
-        f"/tf_dataset/{filename}",
-        os.path.join(os.path.dirname(__file__), "tmp", filename),
-    ]
-    for path in local_candidates:
-        if os.path.exists(path):
-            return path
-
-    # Download to tmp
-    tmp_dir = os.path.join(os.path.dirname(__file__), "tmp")
-    os.makedirs(tmp_dir, exist_ok=True)
-    tmp_path = os.path.join(tmp_dir, filename)
-    print(f"[Helper] Downloading {filename} from {url} to {tmp_path}")
-    urllib.request.urlretrieve(url, tmp_path)
-    return tmp_path
-
-
 opt_name_or_path = get_model_path("facebook/opt-125m")
 qwen_name_or_path = get_model_path("Qwen/Qwen3-0.6B")
 lamini_name_or_path = get_model_path("MBZUAI/LaMini-GPT-124M")

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -314,7 +314,8 @@ def get_tiny_model(
                         and isinstance(v, list)
                         and v[0] in ["diffusers", "transformers"]
                     ):
-                        _reduce_config_layers(getattr(model, k).config, num_layers, num_experts)
+                        tiny_module = _get_module(v[0], v[1], k)
+                        setattr(model, k, tiny_module)
         else:
             trust_remote_code = kwargs.pop("trust_remote_code", True)
             config = transformers.AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=trust_remote_code)

--- a/test/test_cuda/models/test_diffusion.py
+++ b/test/test_cuda/models/test_diffusion.py
@@ -8,7 +8,7 @@ import requests
 from packaging import version
 from PIL import Image
 
-from auto_round import AutoRoundDiffusion
+from auto_round import AutoRound
 
 from ...envs import multi_card, require_gptqmodel, require_optimum, require_vlm_env
 from ...helpers import get_model_path, transformers_version
@@ -37,7 +37,7 @@ class TestAutoRound:
         pipe.transformer.single_transformer_blocks = pipe.transformer.single_transformer_blocks[:2]
 
         ## quantize the model
-        autoround = AutoRoundDiffusion(
+        autoround = AutoRound(
             pipe,
             tokenizer=None,
             scheme="MXFP4",
@@ -50,7 +50,7 @@ class TestAutoRound:
         autoround.quantize()
 
     def test_z_image_tune(self, tiny_z_image_model_path, tmp_path):
-        autoround = AutoRoundDiffusion(
+        autoround = AutoRound(
             tiny_z_image_model_path,
             iters=1,
             nsamples=1,
@@ -82,7 +82,7 @@ class TestAutoRound:
 
         ## quantize the model
         # https://raw.githubusercontent.com/mlcommons/inference/refs/heads/master/text_to_image/coco2014/captions/captions_source.tsv
-        autoround = AutoRoundDiffusion(
+        autoround = AutoRound(
             pipe,
             tokenizer=None,
             scheme="MXFP4",
@@ -127,7 +127,7 @@ class TestAutoRound:
 
         ## quantize the model
         # https://raw.githubusercontent.com/mlcommons/inference/refs/heads/master/text_to_image/coco2014/captions/captions_source.tsv
-        autoround = AutoRoundDiffusion(
+        autoround = AutoRound(
             pipe,
             tokenizer=None,
             scheme="MXFP4",

--- a/test/test_cuda/models/test_diffusion.py
+++ b/test/test_cuda/models/test_diffusion.py
@@ -11,7 +11,7 @@ from PIL import Image
 from auto_round import AutoRoundDiffusion
 
 from ...envs import multi_card, require_gptqmodel, require_optimum, require_vlm_env
-from ...helpers import get_captions_dataset_path, get_model_path, transformers_version
+from ...helpers import get_model_path, transformers_version
 
 
 class TestAutoRound:
@@ -44,7 +44,7 @@ class TestAutoRound:
             iters=0,
             disable_opt_rtn=True,
             num_inference_steps=2,
-            dataset=get_captions_dataset_path(),
+            dataset="coco2014",
         )
         # skip model saving since it takes much time
         autoround.quantize()
@@ -55,10 +55,10 @@ class TestAutoRound:
             iters=1,
             nsamples=1,
             num_inference_steps=2,
-            dataset=get_captions_dataset_path(),
+            dataset="coco2014",
         )
         # skip model saving since it takes much time
-        autoround.quantize_and_save("tmp_path")
+        autoround.quantize_and_save(tmp_path)
 
     @require_optimum
     def test_diffusion_tune(self, tiny_flux_model_path, tmp_path):
@@ -90,7 +90,7 @@ class TestAutoRound:
             nsamples=1,
             num_inference_steps=2,
             layer_config=layer_config,
-            dataset=get_captions_dataset_path(),
+            dataset="coco2014",
         )
         # skip model saving since it takes much time
         autoround.quantize_and_save(tmp_path)
@@ -135,7 +135,7 @@ class TestAutoRound:
             nsamples=1,
             num_inference_steps=2,
             layer_config=layer_config,
-            dataset=get_captions_dataset_path(),
+            dataset="coco2014",
             device_map="0,1",
         )
         # skip model saving since it takes much time

--- a/test/test_cuda/models/test_diffusion.py
+++ b/test/test_cuda/models/test_diffusion.py
@@ -49,6 +49,17 @@ class TestAutoRound:
         # skip model saving since it takes much time
         autoround.quantize()
 
+    def test_z_image_tune(self, tiny_z_image_model_path, tmp_path):
+        autoround = AutoRoundDiffusion(
+            tiny_z_image_model_path,
+            iters=1,
+            nsamples=1,
+            num_inference_steps=2,
+            dataset=get_captions_dataset_path(),
+        )
+        # skip model saving since it takes much time
+        autoround.quantize_and_save("tmp_path")
+
     @require_optimum
     def test_diffusion_tune(self, tiny_flux_model_path, tmp_path):
         from diffusers import AutoPipelineForText2Image


### PR DESCRIPTION
## Description

This pull request introduces support for testing and handling a new diffusion model, "Z-Image", and makes improvements to model file renaming and test fixture setup. The main changes include adding a test fixture and test case for the Z-Image model, updating the weights file renaming logic, and refining how model modules are loaded in tests.

**Support for Z-Image diffusion model:**

* Added a new pytest fixture `tiny_z_image_model_path` in `test/fixtures.py` to create and clean up a minimal Z-Image model for testing, with custom configuration overrides.
* Introduced a new test `test_z_image_tune` in `test/test_cuda/models/test_diffusion.py` to verify quantization and saving for the Z-Image model using the new fixture.

**Model file handling improvements:**

* Updated `rename_weights_files` in `auto_round/utils/model.py` to handle the case where there is only one `.safetensors` file by renaming it directly, avoiding unnecessary enumeration.

**Test utilities and module loading:**

* Modified `_get_module` in `test/helpers.py` to directly set reduced modules for specific model attributes, improving how models with nested modules are handled in test environments.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please specify):

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.

<!-- Optional: Tag reviewers or add extra notes below -->
