### PR TITLE
Fix block name discovery for audio modules

### DIFF
--- a/auto_round/utils/model.py
+++ b/auto_round/utils/model.py
@@ -874,7 +874,7 @@ def get_block_names(model, quant_vision=False):
                 block_names[i].append(target_m[0] + "." + n)
         return block_names
 
-    def _get_vlm_block_names(model, quant_vision=False):
+    def _get_vlm_block_names(model, quant_vision=False, ignore_audio=True):
         if (
             hasattr(model, "config")
             and hasattr(model.config, "model_type")
@@ -884,10 +884,13 @@ def get_block_names(model, quant_vision=False):
         block_names = []
         target_modules = []
         vision_blocks_tuple = ("vision", "visual", "image", "img")
+        audio_blocks_tuple = ("audio", "speech", "wav", "waveform")
         target_modules = _search_block("", model)
 
         for i, target_m in enumerate(target_modules):
             if quant_vision or all(key not in target_m[0].lower() for key in (vision_blocks_tuple)):
+                if ignore_audio and any(key in target_m[0].lower() for key in audio_blocks_tuple):
+                    continue
                 block_names.append([])
                 for n, m in target_m[1].named_children():
                     block_names[-1].append(target_m[0] + "." + n)


### PR DESCRIPTION
## Summary
- skip audio-related module lists when get_block_names(..., quant_vision=False) walks multimodal models
- keep audio blocks included when quant_vision=True

## Why
On the patch branch, block discovery could include audio blocks even when non-vision/non-audio calibration was intended. This aligns the patch branch behavior with main for the relevant get_block_names logic.

## Testing
- python3 -m py_compile auto_round/utils/model.py
- git diff --check