### PR TITLE
Support Exporting Block-Wise FP8 AR Format

### DIFF
--- a/auto_round/formats.py
+++ b/auto_round/formats.py
@@ -104,7 +104,8 @@ def _check_compatibility(formats: list[str], ar: BaseCompressor):
 
     if isinstance(ar.group_size, tuple) and any(["auto_round" in f.lower() for f in formats]):
         logger.warning(
-            "auto_round:fp8 format only supports vLLM inference for now. We recommend using the FP8 format via `--format fp8` instead."
+            "auto_round:fp8 format only supports vLLM inference for now. "
+            "We recommend using the FP8 format via `--format fp8` instead."
         )
 
     return formats

--- a/auto_round/formats.py
+++ b/auto_round/formats.py
@@ -104,7 +104,7 @@ def _check_compatibility(formats: list[str], ar: BaseCompressor):
 
     if isinstance(ar.group_size, tuple) and any(["auto_round" in f.lower() for f in formats]):
         logger.warning(
-            "auto_round:fp8 format only supports vLLM inference for now. We recommend using the FP8 format via --format fp8 instead."
+            "auto_round:fp8 format only supports vLLM inference for now. We recommend using the FP8 format via `--format fp8` instead."
         )
 
     return formats

--- a/auto_round/formats.py
+++ b/auto_round/formats.py
@@ -102,6 +102,11 @@ def _check_compatibility(formats: list[str], ar: BaseCompressor):
             )
             formats = tmp_format_name.split(",")
 
+    if isinstance(ar.group_size, tuple) and any(["auto_round" in f.lower() for f in formats]):
+        logger.warning(
+            "auto_round:fp8 format only supports vLLM inference for now. We recommend using the FP8 format via --format fp8 instead."
+        )
+
     return formats
 
 

--- a/auto_round/formats.py
+++ b/auto_round/formats.py
@@ -1068,7 +1068,6 @@ class FP8Format(OutputFormat):
                     ignored_layers.append(layer_name)
             if len(ignored_layers) > 0:
                 serialization_dict["ignored_layers"] = ignored_layers
-                serialization_dict["modules_to_not_convert"] = ignored_layers
 
         return save_quantized_as_autoround(
             output_dir=output_dir,

--- a/auto_round/formats.py
+++ b/auto_round/formats.py
@@ -101,11 +101,7 @@ def _check_compatibility(formats: list[str], ar: BaseCompressor):
                 f"since scheme {gguf_format_name} can only be exported to format {gguf_format_name.lower()} or fake"
             )
             formats = tmp_format_name.split(",")
-    if isinstance(ar.group_size, tuple) and any(["auto_round" in f.lower() for f in formats]):
-        logger.warning(
-            "`auto_round` format can't be used for deploying block-wise fp8 quantization now, use `fp8` instead."
-        )
-        formats = ["fp8" if "auto_round" in f.lower() else f for f in formats]
+
     return formats
 
 
@@ -1063,8 +1059,7 @@ class FP8Format(OutputFormat):
 
         backend = self.get_backend_name()
 
-        # weight_block_size & ignored_layers are required by fp8 format, skip them in auto_round:fp8 format
-        if isinstance(serialization_dict["group_size"], tuple) and "auto_round" not in backend:
+        if isinstance(serialization_dict["group_size"], tuple):
             serialization_dict["weight_block_size"] = serialization_dict["group_size"]
 
             ignored_layers = []
@@ -1073,6 +1068,7 @@ class FP8Format(OutputFormat):
                     ignored_layers.append(layer_name)
             if len(ignored_layers) > 0:
                 serialization_dict["ignored_layers"] = ignored_layers
+                serialization_dict["modules_to_not_convert"] = ignored_layers
 
         return save_quantized_as_autoround(
             output_dir=output_dir,

--- a/test/test_cuda/export/test_auto_round_format.py
+++ b/test/test_cuda/export/test_auto_round_format.py
@@ -153,8 +153,7 @@ class TestAutoRound:
             eval_generated_prompt(quantized_model_path, device="cuda:0")
 
     def test_fp8_block_autoround_format(self):
-        # model_name = "Qwen/Qwen3-0.6B"
-        model_name = "/models/Qwen3-0.6B"
+        model_name = "Qwen/Qwen3-0.6B"
 
         autoround = AutoRound(
             model_name,

--- a/test/test_cuda/export/test_auto_round_format.py
+++ b/test/test_cuda/export/test_auto_round_format.py
@@ -1,9 +1,10 @@
-import copy
+import json
+import os
 import shutil
 
 import pytest
 import torch
-import transformers
+from safetensors import safe_open
 from transformers import AutoModelForCausalLM, AutoRoundConfig, AutoTokenizer
 
 from auto_round import AutoRound
@@ -150,3 +151,46 @@ class TestAutoRound:
         assert compressed_model.config.quantization_config["weight_block_size"] == (128, 128)
         if is_cuda_support_fp8():
             eval_generated_prompt(quantized_model_path, device="cuda:0")
+
+    def test_fp8_block_autoround_format(self):
+        # model_name = "Qwen/Qwen3-0.6B"
+        model_name = "/models/Qwen3-0.6B"
+
+        autoround = AutoRound(
+            model_name,
+            scheme="FP8_BLOCK",
+            iters=0,
+            disable_opt_rtn=True,
+            seqlen=2,
+        )
+        quantized_model_path = self.save_dir
+        compressed_model, quantized_model_path = autoround.quantize_and_save(
+            output_dir=quantized_model_path,
+            format="auto_round",
+        )
+
+        tmp_layer = compressed_model.model.layers[1].self_attn.q_proj
+        assert hasattr(tmp_layer, "weight_scale_inv")
+        assert tmp_layer.weight.dtype is torch.float8_e4m3fn
+        assert list(tmp_layer.weight_scale_inv.shape) == [16, 8]
+
+        in_memory_qconfig = compressed_model.config.quantization_config
+        assert in_memory_qconfig["quant_method"] == "auto_round:fp8"
+        assert in_memory_qconfig["weight_block_size"] == (128, 128)
+        assert in_memory_qconfig["activation_scheme"] == "dynamic"
+        assert in_memory_qconfig["fmt"] == "e4m3"
+
+        with open(os.path.join(quantized_model_path, "quantization_config.json"), "r", encoding="utf-8") as f:
+            quantization_config = json.load(f)
+
+        assert quantization_config["quant_method"] == "auto_round:fp8"
+        assert quantization_config["weight_block_size"] == [128, 128]
+        assert quantization_config["activation_scheme"] == "dynamic"
+        assert quantization_config["fmt"] == "e4m3"
+
+        weight_key = "model.layers.1.self_attn.q_proj.weight"
+        scale_key = "model.layers.1.self_attn.q_proj.weight_scale_inv"
+        with safe_open(os.path.join(quantized_model_path, "model.safetensors"), framework="pt") as f:
+            assert scale_key in f.keys()
+            assert f.get_tensor(weight_key).dtype == torch.float8_e4m3fn
+            assert list(f.get_tensor(scale_key).shape) == [16, 8]


### PR DESCRIPTION
## Related Issues

https://github.com/intel/auto-round/issues/1536

## Type of Change

New feature

## Test

```python
auto-round --model /models/Llama-3.1-8B --scheme FP8_BLOCK --iters 0 --format auto_round
```
Output Model:
<img width="1640" height="1607" alt="image" src="https://github.com/user-attachments/assets/71a252b0-c467-4dbc-952a-d946ca5a77b4" />


