### PR TITLE
[Fix Accuracy] fix layer name mismatch of VLM(qwen3.5-2B) in hf loading

### DIFF
--- a/auto_round/inference/convert_model.py
+++ b/auto_round/inference/convert_model.py
@@ -210,6 +210,9 @@ def _remap_paths_for_text_model(model, quant_block_list, extra_config):
         if text_model_type:
             mapping = get_checkpoint_conversion_mapping(text_model_type)
 
+    if not mapping:
+        return quant_block_list, extra_config
+
     # Accept any mapping type that has source_patterns and target_patterns
     renamings = [r for r in mapping if hasattr(r, "source_patterns") and hasattr(r, "target_patterns")]
     if not renamings:

--- a/auto_round/inference/convert_model.py
+++ b/auto_round/inference/convert_model.py
@@ -188,7 +188,7 @@ def get_available_devices():
 def _remap_paths_for_text_model(model, quant_block_list, extra_config):
     """Remap quantization paths when a composite model checkpoint is loaded as its text sub-model.
 
-    Uses Transformers' conversion_mapping WeightRenaming rules (e.g. "model.language_model" -> "model")
+    Uses Transformers' conversion_mapping rules (WeightRenaming, PrefixChange, etc.)
     to fix path mismatches. Returns (remapped_block_list, remapped_extra_config).
     """
     try:
@@ -201,7 +201,17 @@ def _remap_paths_for_text_model(model, quant_block_list, extra_config):
         return quant_block_list, extra_config
 
     mapping = get_checkpoint_conversion_mapping(model_type)
-    renamings = [r for r in mapping if type(r).__name__ == "WeightRenaming"]
+
+    # For composite models (e.g. VLMs), the composite model_type may not have a mapping,
+    # but the text sub-model type does.
+    if not mapping:
+        text_config = getattr(getattr(model, "config", None), "text_config", None)
+        text_model_type = getattr(text_config, "model_type", None)
+        if text_model_type:
+            mapping = get_checkpoint_conversion_mapping(text_model_type)
+
+    # Accept any mapping type that has source_patterns and target_patterns
+    renamings = [r for r in mapping if hasattr(r, "source_patterns") and hasattr(r, "target_patterns")]
     if not renamings:
         return quant_block_list, extra_config
 
@@ -313,6 +323,14 @@ def get_layer_config(model, quantization_config):
 
     # Load extra configuration if available
     extra_config = getattr(quantization_config, "extra_config", {})
+
+    # Remap extra_config keys using conversion mapping (e.g. composite VLM paths to text sub-model paths)
+    if checkpoint_conversion_mapping and extra_config:
+        remapped_extra_config = {}
+        for key, value in extra_config.items():
+            new_key = apply_checkpoint_conversion_mapping(key, checkpoint_conversion_mapping)
+            remapped_extra_config[new_key] = value
+        extra_config = remapped_extra_config
 
     # When a composite model (e.g. VLM) is loaded as its text sub-model via AutoModelForCausalLM,
     # block_name_to_quantize may still reference composite-level paths (e.g. "model.language_model.layers")

--- a/auto_round/utils/common.py
+++ b/auto_round/utils/common.py
@@ -1090,6 +1090,15 @@ def get_checkpoint_conversion_mapping(model):
         )
 
         conversion_mappings = transformers_get_checkpoint_conversion_mapping(model.config.model_type)
+
+        # For composite models (e.g. VLMs) loaded as text sub-models via AutoModelForCausalLM,
+        # the composite model_type may not have a mapping, but the text sub-model type does.
+        if conversion_mappings is None:
+            text_config = getattr(getattr(model, "config", None), "text_config", None)
+            text_model_type = getattr(text_config, "model_type", None)
+            if text_model_type:
+                conversion_mappings = transformers_get_checkpoint_conversion_mapping(text_model_type)
+
         if conversion_mappings is not None:
             for conversion_mapping in conversion_mappings:
                 for source_pattern in conversion_mapping.source_patterns:


### PR DESCRIPTION
## Description

Root Cause
Qwen3.5 is a composite VLM (vision + language). The quantize config stores paths with the composite prefix (model.language_model.layers), but when loaded via AutoModelForCausalLM, the actual module paths are model.layers.* (text sub-model only).

The conversion mapping that remaps model.language_model.X  -> model.X is registered under the text sub-model type (qwen3_5_text), not the composite type (qwen3_5). The existing code only checked the composite type -> found no mapping -> no remapping ?? quantized layers never created ?? weights reported as UNEXPECTED.

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #1784

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
