### PR TITLE
Enhance CI workflow

### DIFF
--- a/.azure-pipelines/scripts/check_cuda_trigger.py
+++ b/.azure-pipelines/scripts/check_cuda_trigger.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import json
+from urllib.request import Request, urlopen
+
+def main():
+    repo_path = os.environ.get("REPO_PATH", "")
+    pr_number_str = os.environ.get("PR_NUMBER", "")
+    sha = os.environ.get("CURRENT_SHA", "")
+    token = os.environ.get("GITHUB_TOKEN", "")
+
+    if not repo_path or "/" not in repo_path or not pr_number_str:
+        print("Missing required environment variables (REPO_PATH, PR_NUMBER).", file=sys.stderr)
+        sys.exit(1)
+
+    owner, name = repo_path.split("/")
+    pr = int(pr_number_str)
+
+    query = """
+    query($owner: String!, $name: String!, $pr: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $pr) {
+          timelineItems(last: 50, itemTypes: [ISSUE_COMMENT, PULL_REQUEST_COMMIT]) {
+            nodes {
+              __typename
+              ... on IssueComment {
+                 body
+              }
+              ... on PullRequestCommit {
+                 commit {
+                   oid
+                 }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    req = Request(
+        "https://api.github.com/graphql",
+        data=json.dumps({"query": query, "variables": {"owner": owner, "name": name, "pr": pr}}).encode("utf-8"),
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    )
+
+    try:
+        with urlopen(req) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            nodes = data["data"]["repository"]["pullRequest"]["timelineItems"]["nodes"]
+    except Exception as e:
+        print("GraphQL Error:", e, file=sys.stderr)
+        sys.exit(1)
+
+    target = "/azp run Unit-Test-CUDA-AutoRound"
+    
+    # Traverse nodes in reverse (from newest to oldest)
+    for node in reversed(nodes):
+        if node.get("__typename") == "IssueComment":
+            if target in node.get("body", ""):
+                # Target comment found before we reached the current commit.
+                # It means a comment has already been posted to trigger CI for this commit state.
+                sys.exit(0)
+        elif node.get("__typename") == "PullRequestCommit":
+            if node.get("commit", {}).get("oid") == sha:
+                # We reached the tip commit of this trigger before finding any trigger comment.
+                # Therefore, we need to post a new comment to trigger CI.
+                break
+
+    # Exit 1 means we break the loop (commit reached) without calling sys.exit(0)
+    # The bash script catching exit 1 means "proceed to post the comment".
+    sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/.azure-pipelines/scripts/check_cuda_trigger.py
+++ b/.azure-pipelines/scripts/check_cuda_trigger.py
@@ -1,7 +1,8 @@
+import json
 import os
 import sys
-import json
 from urllib.request import Request, urlopen
+
 
 def main():
     repo_path = os.environ.get("REPO_PATH", "")
@@ -41,7 +42,7 @@ def main():
     req = Request(
         "https://api.github.com/graphql",
         data=json.dumps({"query": query, "variables": {"owner": owner, "name": name, "pr": pr}}).encode("utf-8"),
-        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
     )
 
     try:
@@ -53,7 +54,7 @@ def main():
         sys.exit(1)
 
     target = "/azp run Unit-Test-CUDA-AutoRound"
-    
+
     # Traverse nodes in reverse (from newest to oldest)
     for node in reversed(nodes):
         if node.get("__typename") == "IssueComment":
@@ -70,6 +71,7 @@ def main():
     # Exit 1 means we break the loop (commit reached) without calling sys.exit(0)
     # The bash script catching exit 1 means "proceed to post the comment".
     sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/.azure-pipelines/scripts/ut/run_ut.sh
+++ b/.azure-pipelines/scripts/ut/run_ut.sh
@@ -67,7 +67,7 @@ function run_unit_test() {
     auto_round_path=$(python -c 'import auto_round; print(auto_round.__path__[0])')
 
     # Split test files into 5 parts
-    find ./test_cpu -name "test*.py" | grep -Ev "test_llmc|test_inc" | sort > all_tests.txt
+    find ./test_cpu/core -name "test*.py" | grep -Ev "test_llmc|test_inc" | sort > all_tests.txt
     total_lines=$(wc -l < all_tests.txt)
     NUM_CHUNKS=5
     q=$(( total_lines / NUM_CHUNKS ))
@@ -149,10 +149,10 @@ function collect_log() {
 function main() {
     setup_environment
     run_unit_test
-    if [ "$test_part" -eq 5 ]; then
-        run_inc_unit_test
-        run_llmc_unit_test
-    fi
+    # if [ "$test_part" -eq 5 ]; then
+    #     run_inc_unit_test
+    #     run_llmc_unit_test
+    # fi
     collect_log
     check_storage_usage
     print_summary

--- a/.azure-pipelines/scripts/ut/run_ut.sh
+++ b/.azure-pipelines/scripts/ut/run_ut.sh
@@ -55,10 +55,10 @@ function print_summary() {
 function check_storage_usage() {
     echo "##[group]check storage usage..."
     df -h
-    du -sh /auto-round
-    du -sh /home/hostuser/.cache/huggingface
-    du -sh /home/hostuser/.cache/huggingface/hub/*
-    du -sh /home/hostuser/.venv
+    du -sh /auto-round || true
+    du -sh /home/hostuser/.cache/huggingface || true
+    du -sh /home/hostuser/.cache/huggingface/hub/* || true
+    du -sh /home/hostuser/.venv || true
     echo "##[endgroup]"
 }
 

--- a/.azure-pipelines/scripts/ut/run_ut.sh
+++ b/.azure-pipelines/scripts/ut/run_ut.sh
@@ -67,7 +67,7 @@ function run_unit_test() {
     auto_round_path=$(python -c 'import auto_round; print(auto_round.__path__[0])')
 
     # Split test files into 5 parts
-    find ./test_cpu/core -name "test*.py" | grep -Ev "test_llmc|test_inc" | sort > all_tests.txt
+    find ./test_cpu -name "test*.py" | grep -Ev "test_llmc|test_inc" | sort > all_tests.txt
     total_lines=$(wc -l < all_tests.txt)
     NUM_CHUNKS=5
     q=$(( total_lines / NUM_CHUNKS ))
@@ -149,10 +149,10 @@ function collect_log() {
 function main() {
     setup_environment
     run_unit_test
-    # if [ "$test_part" -eq 5 ]; then
-    #     run_inc_unit_test
-    #     run_llmc_unit_test
-    # fi
+    if [ "$test_part" -eq 5 ]; then
+        run_inc_unit_test
+        run_llmc_unit_test
+    fi
     collect_log
     check_storage_usage
     print_summary

--- a/.azure-pipelines/unit-test-cuda.yml
+++ b/.azure-pipelines/unit-test-cuda.yml
@@ -155,13 +155,6 @@ stages:
                   fi
                 displayName: "Run GPU Tests"
 
-              - task: PublishPipelineArtifact@1
-                condition: succeededOrFailed()
-                inputs:
-                  targetPath: $(Build.SourcesDirectory)/ut_log_dir
-                  artifact: PART_${{ pair.value.PART }}_logs
-                  publishLocation: "pipeline"
-
               - script: |
                   cd .azure-pipelines/scripts/cuda_unit_test
                   uv run monitor_gpu.py stop

--- a/.azure-pipelines/unit-test.yml
+++ b/.azure-pipelines/unit-test.yml
@@ -121,3 +121,40 @@ stages:
           - task: PublishCodeCoverageResults@2
             inputs:
               summaryFileLocation: $(Build.SourcesDirectory)/log_dir/coverage_PR/coverage.xml
+
+  - stage: Trigger_CUDA_CI
+    displayName: "Trigger CUDA CI"
+    pool:
+      vmImage: "ubuntu-latest"
+    dependsOn: [Coverage]
+    condition: and(succeeded('Coverage'), eq(variables['Build.Reason'], 'PullRequest'))
+    jobs:
+      - job: CommentCudaTrigger
+        displayName: "Comment to trigger CUDA CI"
+        steps:
+          - task: Bash@3
+            displayName: "Post /azp run comment to PR"
+            env:
+              GITHUB_TOKEN: $(GITHUB_TOKEN)
+            inputs:
+              targetType: "inline"
+              script: |
+                set -euo pipefail
+
+                pr_number="${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-}"
+                if [ -z "${pr_number}" ]; then
+                  echo "PR number not found."
+                  exit 0
+                fi
+
+                repo_path="${BUILD_REPOSITORY_URI#https://github.com/}"
+                repo_path="${repo_path%.git}"
+
+                curl -fsS -X POST \
+                  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Content-Type: application/json" \
+                  -d '{"body":"/azp run Unit-Test-CUDA-AutoRound"}' \
+                  "https://api.github.com/repos/${repo_path}/issues/${pr_number}/comments"
+
+                echo "CUDA trigger comment posted to PR #${pr_number}."

--- a/.azure-pipelines/unit-test.yml
+++ b/.azure-pipelines/unit-test.yml
@@ -149,7 +149,16 @@ stages:
 
                 repo_path="${BUILD_REPOSITORY_URI#https://github.com/}"
                 repo_path="${repo_path%.git}"
+                export REPO_PATH="${repo_path}"
+                export PR_NUMBER="${pr_number}"
+                export CURRENT_SHA="${SYSTEM_PULLREQUEST_SOURCECOMMITID:-${BUILD_SOURCEVERSION:-unknown}}"
 
+                if python "$(Build.SourcesDirectory)/.azure-pipelines/scripts/check_cuda_trigger.py"; then
+                  echo "CUDA CI already triggered after commit ${CURRENT_SHA}. Skipping."
+                  exit 0
+                fi
+
+                echo "Triggering CUDA CI for commit ${CURRENT_SHA}..."
                 if ! curl -fsS -X POST \
                   -H "Authorization: Bearer ${GITHUB_TOKEN}" \
                   -H "Accept: application/vnd.github+json" \

--- a/.azure-pipelines/unit-test.yml
+++ b/.azure-pipelines/unit-test.yml
@@ -150,11 +150,14 @@ stages:
                 repo_path="${BUILD_REPOSITORY_URI#https://github.com/}"
                 repo_path="${repo_path%.git}"
 
-                curl -fsS -X POST \
+                if ! curl -fsS -X POST \
                   -H "Authorization: Bearer ${GITHUB_TOKEN}" \
                   -H "Accept: application/vnd.github+json" \
                   -H "Content-Type: application/json" \
                   -d '{"body":"/azp run Unit-Test-CUDA-AutoRound"}' \
-                  "https://api.github.com/repos/${repo_path}/issues/${pr_number}/comments"
+                  "https://api.github.com/repos/${repo_path}/issues/${pr_number}/comments"; then
+                  echo "Failed to post CUDA trigger comment (non-blocking)."
+                  exit 0
+                fi
 
                 echo "CUDA trigger comment posted to PR #${pr_number}."


### PR DESCRIPTION
## Description

1. Remove `PublishPipelineArtifact` in Cuda CI to avoid `Artifact PART_0_logs already exists` error in CI retrigger.   
https://dev.azure.com/lpot-inc/neural-compressor/_build/results?buildId=64035&view=logs&j=c77707d2-3a2f-50e1-61f8-85cd2ed9a159&t=2fa11ed4-0ae4-5dbf-ff74-a2c1787fb323&s=39c409e8-0b17-56a3-b644-e1413236024d  
2. Auto trigger cuda UT after cpu UT pass.  
- Case 1: new commit push or PR open, if CPU ut test pass, Cuda ut will be auto triggered.  
https://dev.azure.com/lpot-inc/neural-compressor/_build/results?buildId=64094&view=logs&j=21324654-9778-557c-60ca-6ae928c29cbc&s=8f43afac-54dc-50a6-b913-ba02a23e21cd&t=b819ab4c-8180-57a4-2690-771681b0b38b&l=59  
- Case 2: new commit push or PR open, if Cuda ut manually triggered by `/azp run xxx` user comments, it won't be duplicated triggered after CPU ut test pass for the same commit.  
https://dev.azure.com/lpot-inc/neural-compressor/_build/results?buildId=64094&view=logs&j=c492a500-95bb-533e-ef84-eead9e94ceeb&t=da088006-2fe2-5d12-a361-dd7d9968d50d&l=12   
- Case 3: new commit push or PR open, if CPU ut test failed, Cuda ut won't be auto triggered, but can be triggered by user comments. 

## Type of Change

Validation
