### PR TITLE
fix: preserve FP8 llmc metadata for mxfp8

### DIFF
--- a/auto_round/export/export_to_llmcompressor/export_to_fp.py
+++ b/auto_round/export/export_to_llmcompressor/export_to_fp.py
@@ -50,6 +50,13 @@ from auto_round.utils import (
 from auto_round.wrapper import WrapperWALayer
 
 from .config import check_compressed_tensors_supported
+from .export_to_static_fp import (
+    _append_attention_group,
+    _configure_gaudi2_fp8_dtype,
+    _construct_kv_scheme,
+    _use_fp8_attention,
+    _use_fp8_kv,
+)
 
 __all__ = [
     "pack_layer",
@@ -144,7 +151,16 @@ def _get_group_format(bits, data_type):
     return "float-quantized"
 
 
-def _build_mixed_fp_quantization_config(scheme_groups, layer_config, ignore, global_bits, global_data_type):
+def _build_mixed_fp_quantization_config(
+    scheme_groups,
+    layer_config,
+    ignore,
+    global_bits,
+    global_data_type,
+    model,
+    static_kv_dtype=None,
+    static_attention_dtype=None,
+):
     """Build a quantization config dict for mixed-precision scenarios.
 
     Creates multiple config groups with per-group format strings using compressed_tensors
@@ -185,7 +201,17 @@ def _build_mixed_fp_quantization_config(scheme_groups, layer_config, ignore, glo
         config_groups[group_name] = tmp_quantization_config
         group_formats[group_name] = _get_group_format(lbits, ldata_type)
 
-    quantization_config = initialize_quantization(scheme=None, config_groups=config_groups, ignore=ignore)
+    use_fp8_attention = _use_fp8_attention(static_attention_dtype)
+    if use_fp8_attention:
+        _append_attention_group(config_groups, model)
+    quantization_config = initialize_quantization(
+        scheme=None,
+        config_groups=config_groups,
+        kv_cache_scheme=_construct_kv_scheme()
+        if (_use_fp8_kv(static_kv_dtype) or use_fp8_attention)
+        else None,
+        ignore=ignore,
+    )
     quantization_config = quantization_config.to_dict()
 
     # Set per-group format and top-level mixed-precision format
@@ -193,6 +219,7 @@ def _build_mixed_fp_quantization_config(scheme_groups, layer_config, ignore, glo
     for group_name, fmt in group_formats.items():
         quantization_config["config_groups"][group_name]["format"] = fmt
     quantization_config["provider"] = "auto-round"
+    _configure_gaudi2_fp8_dtype(quantization_config)
 
     return quantization_config
 
@@ -291,19 +318,41 @@ def save_quantized_as_fp(
 
     is_mixed = len(scheme_groups) > 1
 
+    use_fp8_attention = _use_fp8_attention(serialization_dict.get("static_attention_dtype", None))
+    kv_cache_scheme = (
+        _construct_kv_scheme()
+        if (_use_fp8_kv(serialization_dict.get("static_kv_dtype", None)) or use_fp8_attention)
+        else None
+    )
+
     if is_mixed:
-        quantization_config = _build_mixed_fp_quantization_config(scheme_groups, layer_config, ignore, bits, data_type)
+        quantization_config = _build_mixed_fp_quantization_config(
+            scheme_groups,
+            layer_config,
+            ignore,
+            bits,
+            data_type,
+            model,
+            static_kv_dtype=serialization_dict.get("static_kv_dtype", None),
+            static_attention_dtype=serialization_dict.get("static_attention_dtype", None),
+        )
     else:
         scheme = _get_scheme(bits, data_type)
         if scheme is None:
             raise ValueError(f"Unsupported combination of data_type={data_type} and bits={bits}.")
 
         format = _get_group_format(bits, data_type)
-        quantization_config = initialize_quantization(scheme=scheme)
+        quantization_config = initialize_quantization(
+            scheme=scheme,
+            kv_cache_scheme=kv_cache_scheme,
+            ignore=ignore,
+        )
+        if use_fp8_attention:
+            _append_attention_group(quantization_config.config_groups, model)
         setattr(quantization_config, "format", format)
-        setattr(quantization_config, "ignore", ignore)
         quantization_config = quantization_config.to_dict()
         quantization_config["provider"] = "auto-round"
+        _configure_gaudi2_fp8_dtype(quantization_config)
     if hasattr(model, "config"):
         model.config.quantization_config = quantization_config
     if output_dir is None:

--- a/auto_round/export/export_to_llmcompressor/export_to_fp.py
+++ b/auto_round/export/export_to_llmcompressor/export_to_fp.py
@@ -207,9 +207,7 @@ def _build_mixed_fp_quantization_config(
     quantization_config = initialize_quantization(
         scheme=None,
         config_groups=config_groups,
-        kv_cache_scheme=_construct_kv_scheme()
-        if (_use_fp8_kv(static_kv_dtype) or use_fp8_attention)
-        else None,
+        kv_cache_scheme=_construct_kv_scheme() if (_use_fp8_kv(static_kv_dtype) or use_fp8_attention) else None,
         ignore=ignore,
     )
     quantization_config = quantization_config.to_dict()

--- a/test/test_cpu/export/test_llmc_format.py
+++ b/test/test_cpu/export/test_llmc_format.py
@@ -128,6 +128,79 @@ class TestLLMC:
             and quantization_config["ignore"] == ["lm_head"]
         ), f"Invalid MXFP8 quantization configuration: {quantization_config}"
 
+    def test_mxfp8_llmcompressor_kv_config(self, tiny_opt_model_path, tmp_path):
+        ar = AutoRound(
+            model=tiny_opt_model_path,
+            iters=0,
+            disable_opt_rtn=True,
+            scheme="mxfp8",
+            static_kv_dtype="fp8",
+        )
+        _, quantized_model_path = ar.quantize_and_save(output_dir=tmp_path, format="llm_compressor")
+
+        with open(os.path.join(quantized_model_path, "config.json")) as f:
+            config = json.load(f)
+
+        kv_cache_scheme = config["quantization_config"]["kv_cache_scheme"]
+        assert kv_cache_scheme is not None
+        assert kv_cache_scheme["num_bits"] == 8
+        assert kv_cache_scheme["type"] == "float"
+        assert kv_cache_scheme["strategy"] == "tensor"
+        assert kv_cache_scheme["dynamic"] is False
+        assert kv_cache_scheme["symmetric"] is True
+
+    def test_mxfp8_llmcompressor_attention_config(self, tiny_opt_model_path, tmp_path):
+        ar = AutoRound(
+            model=tiny_opt_model_path,
+            iters=0,
+            disable_opt_rtn=True,
+            scheme="mxfp8",
+            static_attention_dtype="fp8",
+        )
+        compressed_model, quantized_model_path = ar.quantize_and_save(output_dir=tmp_path, format="llm_compressor")
+
+        with open(os.path.join(quantized_model_path, "config.json")) as f:
+            saved_config = json.load(f)
+
+        saved_groups = saved_config["quantization_config"]["config_groups"]
+        attention_group = None
+        for group in saved_groups.values():
+            if "Linear" not in group["targets"]:
+                attention_group = group
+                break
+
+        assert attention_group is not None
+        assert attention_group["targets"] == [compressed_model.model.decoder.layers[0].self_attn.__class__.__name__]
+        assert attention_group["weights"] is None
+        assert attention_group["input_activations"]["num_bits"] == 8
+        assert attention_group["input_activations"]["type"] == "float"
+        assert attention_group["input_activations"]["strategy"] == "tensor"
+        assert attention_group["input_activations"]["dynamic"] is False
+        assert attention_group["input_activations"]["symmetric"] is True
+        assert saved_config["quantization_config"]["kv_cache_scheme"] is not None
+
+        quantization_config = transformers.AutoConfig.from_pretrained(
+            quantized_model_path, trust_remote_code=True
+        ).quantization_config
+        config_groups = quantization_config["config_groups"]
+        attention_group = None
+        for group in config_groups.values():
+            targets = group["targets"]
+            if "Linear" not in targets:
+                attention_group = group
+                break
+
+        assert attention_group is not None
+        assert attention_group["targets"] == [compressed_model.model.decoder.layers[0].self_attn.__class__.__name__]
+        assert attention_group["weights"] is None
+        assert attention_group["input_activations"]["num_bits"] == 8
+        assert attention_group["input_activations"]["type"] == "float"
+        assert attention_group["input_activations"]["strategy"] == "tensor"
+        assert attention_group["input_activations"]["dynamic"] is False
+        assert attention_group["input_activations"]["symmetric"] is True
+        assert quantization_config["kv_cache_scheme"] is not None
+        assert getattr(compressed_model.model.decoder.layers[0].self_attn, "q_scale", None) is not None
+
     def test_mixed_precision_llmcompressor_format(self, tiny_opt_model_path, tmp_path):
         scheme = AutoScheme(
             avg_bits=7,


### PR DESCRIPTION
Fix https://github.com/intel/auto-round/issues/1751

https://github.com/intel/auto-round/pull/1752 only cover the FP8_STATIC exporter path

## Summary
- preserve FP8 KV-cache metadata in the MXFP/NVFP llm-compressor export path
- add FP8 static-attention config-group export for MXFP8 llm-compressor saves
- add targeted CPU tests for MXFP8 static KV and static attention export metadata

## Verification
- `/home/yiliu7/workspace/venvs/ar/bin/python -m py_compile auto_round/export/export_to_llmcompressor/export_to_fp.py test/test_cpu/export/test_llmc_format.py`
- `/home/yiliu7/workspace/venvs/ar/bin/python` targeted MXFP8 export checks for `static_kv_dtype="fp8"` and `static_attention_dtype="fp8"`, confirming non-null `kv_cache_scheme`, persisted attention config groups, and exported attention scales
