### PR TITLE
Fix special-model predefined ignore layer filtering

### DIFF
--- a/auto_round/compressors/base.py
+++ b/auto_round/compressors/base.py
@@ -560,10 +560,12 @@ class BaseCompressor(object):
             predefined_ignore_layers = get_predefined_ignore_layers(self.model_context.model)
             if predefined_ignore_layers and self.quant_block_list:
                 block_prefixes = [block for group in self.quant_block_list for block in group]
+                # Only filter layers that are full paths clearly inside a block.
                 predefined_ignore_layers = [
                     name
                     for name in predefined_ignore_layers
                     if any(name.startswith(prefix) for prefix in block_prefixes)
+                    or not any(prefix.startswith(name.split(".")[0]) for prefix in block_prefixes)
                 ]
             predefined_ignore_layers = compress_layer_names(predefined_ignore_layers)
             if predefined_ignore_layers:

--- a/test/test_cpu/utils/test_utils.py
+++ b/test/test_cpu/utils/test_utils.py
@@ -69,8 +69,7 @@ def test_preserve_original_mllm_language_block_name():
 
 
 class TestPredefinedIgnoreLayersBlockFilter:
-    """Test the block-prefix filter in configure_layer_config.
-    """
+    """Test the block-prefix filter in configure_layer_config."""
 
     @staticmethod
     def _make_compressor_stub(predefined_ignore_layers, quant_block_list):
@@ -112,12 +111,12 @@ class TestPredefinedIgnoreLayersBlockFilter:
         )
         stub.configure_layer_config()
 
-        assert "vision_tower" in stub.ignore_layers, (
-            f"vision_tower should be in ignore_layers, got: '{stub.ignore_layers}'"
-        )
-        assert "mm_projector" in stub.ignore_layers, (
-            f"mm_projector should be in ignore_layers, got: '{stub.ignore_layers}'"
-        )
+        assert (
+            "vision_tower" in stub.ignore_layers
+        ), f"vision_tower should be in ignore_layers, got: '{stub.ignore_layers}'"
+        assert (
+            "mm_projector" in stub.ignore_layers
+        ), f"mm_projector should be in ignore_layers, got: '{stub.ignore_layers}'"
 
     @patch("auto_round.compressors.base.get_predefined_ignore_layers")
     @patch("auto_round.compressors.base.set_layer_config")
@@ -135,9 +134,7 @@ class TestPredefinedIgnoreLayersBlockFilter:
         stub.configure_layer_config()
 
         for name in predefined:
-            assert name in stub.ignore_layers, (
-                f"'{name}' should be in ignore_layers, got: '{stub.ignore_layers}'"
-            )
+            assert name in stub.ignore_layers, f"'{name}' should be in ignore_layers, got: '{stub.ignore_layers}'"
 
     @patch("auto_round.compressors.base.get_predefined_ignore_layers")
     @patch("auto_round.compressors.base.set_layer_config")
@@ -153,9 +150,7 @@ class TestPredefinedIgnoreLayersBlockFilter:
         )
         stub.configure_layer_config()
 
-        assert "classifier" in stub.ignore_layers, (
-            f"classifier should be in ignore_layers, got: '{stub.ignore_layers}'"
-        )
+        assert "classifier" in stub.ignore_layers, f"classifier should be in ignore_layers, got: '{stub.ignore_layers}'"
 
     @patch("auto_round.compressors.base.get_predefined_ignore_layers")
     @patch("auto_round.compressors.base.set_layer_config")
@@ -171,9 +166,9 @@ class TestPredefinedIgnoreLayersBlockFilter:
         )
         stub.configure_layer_config()
 
-        assert "model.layers.0.mlp" in stub.ignore_layers, (
-            f"model.layers.0.mlp should be in ignore_layers, got: '{stub.ignore_layers}'"
-        )
+        assert (
+            "model.layers.0.mlp" in stub.ignore_layers
+        ), f"model.layers.0.mlp should be in ignore_layers, got: '{stub.ignore_layers}'"
 
     @patch("auto_round.compressors.base.get_predefined_ignore_layers")
     @patch("auto_round.compressors.base.set_layer_config")

--- a/test/test_cpu/utils/test_utils.py
+++ b/test/test_cpu/utils/test_utils.py
@@ -1,7 +1,10 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 import auto_round.utils.device as auto_round_utils
 from auto_round.utils.common import (
+    compress_layer_names,
     preserve_original_visual_block_name,
     revert_checkpoint_conversion_mapping,
 )
@@ -63,3 +66,128 @@ def test_preserve_original_mllm_language_block_name():
         )
         == "model.visual.blocks,model.language_model.layers,model.layers"
     )
+
+
+class TestPredefinedIgnoreLayersBlockFilter:
+    """Test the block-prefix filter in configure_layer_config.
+    """
+
+    @staticmethod
+    def _make_compressor_stub(predefined_ignore_layers, quant_block_list):
+        """Create a minimal stub that allows calling configure_layer_config."""
+        from auto_round.compressors.base import BaseCompressor
+
+        stub = object.__new__(BaseCompressor)
+        # Minimal attributes required by configure_layer_config
+        stub.ignore_layers = ""
+        stub.quant_block_list = quant_block_list
+        stub.is_auto_scheme = False
+        stub.orig_scheme = "W4A16"
+        stub.layer_config = None
+        stub.quant_lm_head = False
+        stub.scale_dtype = "fp16"
+
+        # Mock compress_context (no gguf format)
+        stub.compress_context = MagicMock()
+        stub.compress_context.formats = None
+
+        # Mock model_context with a fake model
+        stub.model_context = MagicMock()
+        stub.model_context.model = MagicMock()
+        stub.model_context.is_mllm = False
+
+        return stub
+
+    @patch("auto_round.compressors.base.get_predefined_ignore_layers")
+    @patch("auto_round.compressors.base.set_layer_config")
+    @patch("auto_round.compressors.base._handle_special_schemes", return_value=None)
+    def test_kimi_k25_ignore_layers_preserved(self, mock_handle, mock_set_lc, mock_get_predefined):
+        """KIMI K2.5: vision_tower and mm_projector must end up in ignore_layers."""
+        mock_get_predefined.return_value = ["vision_tower", "mm_projector"]
+        mock_set_lc.return_value = ({}, False, None)
+
+        stub = self._make_compressor_stub(
+            predefined_ignore_layers=["vision_tower", "mm_projector"],
+            quant_block_list=[["model.layers"]],
+        )
+        stub.configure_layer_config()
+
+        assert "vision_tower" in stub.ignore_layers, (
+            f"vision_tower should be in ignore_layers, got: '{stub.ignore_layers}'"
+        )
+        assert "mm_projector" in stub.ignore_layers, (
+            f"mm_projector should be in ignore_layers, got: '{stub.ignore_layers}'"
+        )
+
+    @patch("auto_round.compressors.base.get_predefined_ignore_layers")
+    @patch("auto_round.compressors.base.set_layer_config")
+    @patch("auto_round.compressors.base._handle_special_schemes", return_value=None)
+    def test_step3p5_ignore_layers_preserved(self, mock_handle, mock_set_lc, mock_get_predefined):
+        """step3p5: short pattern names must not be dropped by block filter."""
+        predefined = ["g_proj", "moe.gate", "eh_proj", "shared_head", "layers.45"]
+        mock_get_predefined.return_value = predefined
+        mock_set_lc.return_value = ({}, False, None)
+
+        stub = self._make_compressor_stub(
+            predefined_ignore_layers=predefined,
+            quant_block_list=[["model.layers"]],
+        )
+        stub.configure_layer_config()
+
+        for name in predefined:
+            assert name in stub.ignore_layers, (
+                f"'{name}' should be in ignore_layers, got: '{stub.ignore_layers}'"
+            )
+
+    @patch("auto_round.compressors.base.get_predefined_ignore_layers")
+    @patch("auto_round.compressors.base.set_layer_config")
+    @patch("auto_round.compressors.base._handle_special_schemes", return_value=None)
+    def test_longcat_classifier_preserved(self, mock_handle, mock_set_lc, mock_get_predefined):
+        """Longcat: 'classifier' must not be dropped."""
+        mock_get_predefined.return_value = ["classifier"]
+        mock_set_lc.return_value = ({}, False, None)
+
+        stub = self._make_compressor_stub(
+            predefined_ignore_layers=["classifier"],
+            quant_block_list=[["model.layers"]],
+        )
+        stub.configure_layer_config()
+
+        assert "classifier" in stub.ignore_layers, (
+            f"classifier should be in ignore_layers, got: '{stub.ignore_layers}'"
+        )
+
+    @patch("auto_round.compressors.base.get_predefined_ignore_layers")
+    @patch("auto_round.compressors.base.set_layer_config")
+    @patch("auto_round.compressors.base._handle_special_schemes", return_value=None)
+    def test_glm_flash_full_path_inside_block_preserved(self, mock_handle, mock_set_lc, mock_get_predefined):
+        """GLM Flash: model.layers.0.mlp (full path inside block) must be kept."""
+        mock_get_predefined.return_value = ["model.layers.0.mlp"]
+        mock_set_lc.return_value = ({}, False, None)
+
+        stub = self._make_compressor_stub(
+            predefined_ignore_layers=["model.layers.0.mlp"],
+            quant_block_list=[["model.layers"]],
+        )
+        stub.configure_layer_config()
+
+        assert "model.layers.0.mlp" in stub.ignore_layers, (
+            f"model.layers.0.mlp should be in ignore_layers, got: '{stub.ignore_layers}'"
+        )
+
+    @patch("auto_round.compressors.base.get_predefined_ignore_layers")
+    @patch("auto_round.compressors.base.set_layer_config")
+    @patch("auto_round.compressors.base._handle_special_schemes", return_value=None)
+    def test_mllm_with_multiple_block_groups(self, mock_handle, mock_set_lc, mock_get_predefined):
+        """MLLM with vision + language blocks: ignore layers outside both are preserved."""
+        mock_get_predefined.return_value = ["vision_tower", "mm_projector"]
+        mock_set_lc.return_value = ({}, False, None)
+
+        stub = self._make_compressor_stub(
+            predefined_ignore_layers=["vision_tower", "mm_projector"],
+            quant_block_list=[["model.visual.blocks"], ["model.layers"]],
+        )
+        stub.configure_layer_config()
+
+        assert "vision_tower" in stub.ignore_layers
+        assert "mm_projector" in stub.ignore_layers


### PR DESCRIPTION
## Description

This PR fixes a regression in `configure_layer_config` where predefined ignore layers from special model handlers were filtered too aggressively when quant_block_list was present.

Some special models register short or pattern-based ignore entries such as `vision_tower`, `mm_projector`, `g_proj`, and `classifier`. These are valid ignore targets, but they are not full block-qualified paths. The previous filtering logic incorrectly dropped them, causing modules that should stay in higher precision to be quantized.

**Root Cause**

The code assumed that every predefined ignore layer should start with one of the quantized block prefixes. That assumption is invalid for special models, because many predefined ignore entries are short names or pattern-like module identifiers rather than full paths.

**Solution**

Keep block-local full-path filtering, but preserve short or pattern-based predefined ignore entries that are not block-qualified paths. This restores correct ignore-layer behavior for special models without changing the intended GGUF-related logic.

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
