### PR TITLE
Update auto-round-lib release package build

### DIFF
--- a/.azure-pipelines/ark-unit-test.yml
+++ b/.azure-pipelines/ark-unit-test.yml
@@ -24,7 +24,7 @@ parameters:
     displayName: "Torch versions"
     type: string
     # Comma-separated list to align with pythonVersions runtime input style.
-    default: "2.11.0"
+    default: "2.12.0"
   - name: publishTarget
     displayName: "Publish wheels to"
     type: string

--- a/.azure-pipelines/ark-unit-test.yml
+++ b/.azure-pipelines/ark-unit-test.yml
@@ -117,7 +117,7 @@ stages:
               targetType: inline
               script: |
                 set -euxo pipefail
-                rm -rf "$(Pipeline.Workspace)/dist"
+                rm -rf "$(Pipeline.Workspace)/dist" "$(Pipeline.Workspace)/wheelhouse" || true
                 mkdir -p "$(Pipeline.Workspace)/dist"
 
           - ${{ each pythonVersion in split(parameters.pythonVersions, ',') }}:

--- a/.azure-pipelines/ark-unit-test.yml
+++ b/.azure-pipelines/ark-unit-test.yml
@@ -157,5 +157,4 @@ stages:
                   twine upload --repository-url https://test.pypi.org/legacy/ $(Pipeline.Workspace)/dist/*
                 else
                   twine upload $(Pipeline.Workspace)/dist/*
-                  
                 fi

--- a/.azure-pipelines/ark-unit-test.yml
+++ b/.azure-pipelines/ark-unit-test.yml
@@ -19,11 +19,13 @@ parameters:
     displayName: "Python versions"
     type: string
     # Comma-separated list to avoid YAML float parsing in runtime inputs.
+    # For example, "3.10,3.11,3.12,3.13,3.14"
     default: "3.12"
   - name: torchVersions
     displayName: "Torch versions"
     type: string
     # Comma-separated list to align with pythonVersions runtime input style.
+    # For example, "2.11.0,2.12.0"
     default: "2.12.0"
   - name: publishTarget
     displayName: "Publish wheels to"
@@ -98,35 +100,41 @@ stages:
                         exit 1
                     fi
 
-  - stage: PublishWheels
-    displayName: Publish wheels (${{ parameters.publishTarget }})
+  - stage: PublishDist
+    displayName: Publish dist (${{ parameters.publishTarget }})
     dependsOn: TestArk
     condition: and(succeeded(), ne('${{ parameters.publishTarget }}', 'none'))
     jobs:
-      - job: PublishWheels
-        displayName: Publish all wheels to ${{ parameters.publishTarget }}
+      - job: PublishDist
+        displayName: Publish all dist to ${{ parameters.publishTarget }}
         pool: B60
         steps:
           - checkout: none
 
           - task: Bash@3
-            displayName: Clean wheel download directory
+            displayName: Clean dist download directory
             inputs:
               targetType: inline
               script: |
                 set -euxo pipefail
-                rm -rf "$(Pipeline.Workspace)/wheels"
-                mkdir -p "$(Pipeline.Workspace)/wheels"
+                rm -rf "$(Pipeline.Workspace)/dist"
+                mkdir -p "$(Pipeline.Workspace)/dist"
 
           - ${{ each pythonVersion in split(parameters.pythonVersions, ',') }}:
             - task: DownloadPipelineArtifact@2
               displayName: Download wheel (py${{ trim(pythonVersion) }})
               inputs:
                 artifact: auto-round-lib-wheel-cp${{ replace(trim(pythonVersion), '.', '') }}
-                path: $(Pipeline.Workspace)/wheels
+                path: $(Pipeline.Workspace)/dist
+          
+          - task: DownloadPipelineArtifact@2
+            displayName: Download source dist
+            inputs:
+              artifact: auto-round-lib-dist
+              path: $(Pipeline.Workspace)/dist
 
           - task: Bash@3
-            displayName: Upload wheels to ${{ parameters.publishTarget }}
+            displayName: Upload dist to ${{ parameters.publishTarget }}
             env:
               TWINE_USERNAME: "__token__"
               ${{ if eq(parameters.publishTarget, 'pypi') }}:
@@ -146,7 +154,8 @@ stages:
                 pip install --upgrade twine
                 PUBLISH_TARGET="${{ parameters.publishTarget }}"
                 if [ "${PUBLISH_TARGET}" == "testpypi" ]; then
-                  twine upload --repository-url https://test.pypi.org/legacy/ $(Pipeline.Workspace)/wheels/*.whl
+                  twine upload --repository-url https://test.pypi.org/legacy/ $(Pipeline.Workspace)/dist/*
                 else
-                  twine upload $(Pipeline.Workspace)/wheels/*.whl
+                  twine upload $(Pipeline.Workspace)/dist/*
+                  
                 fi

--- a/.azure-pipelines/template/lib-build-template.yml
+++ b/.azure-pipelines/template/lib-build-template.yml
@@ -134,3 +134,45 @@ stages:
                       bash -c "source venv/bin/activate \
                       && python -m pip install --upgrade twine \
                       && twine upload --repository-url https://test.pypi.org/legacy/ wheelhouse/*.whl"
+
+  - stage: BuildARKDist
+    displayName: Build ARK dist
+    dependsOn:
+      - ${{ if eq(parameters.enableChangeDetection, true) }}:
+        - DetectArkChanges
+    ${{ if eq(parameters.enableChangeDetection, true) }}:
+      variables:
+        BUILD_ARK_WHEEL: $[ stageDependencies.DetectArkChanges.Detect.outputs['SetArkWheelFlag.BUILD_ARK_WHEEL'] ]
+    dependsOn: BuildArkWheel
+    jobs:
+      - job: BuildDist
+        displayName: Build ARK source distribution
+        pool: GAUDI
+        timeoutInMinutes: 30
+        steps:
+          - checkout: self
+            clean: true
+
+          - task: Bash@3
+            displayName: Build source distribution in manylinux container
+            inputs:
+              targetType: inline
+              script: |
+                set -euxo pipefail
+                docker run --rm \
+                  --user "$(id -u):$(id -g)" \
+                  -e HOME=/tmp \
+                  -v $(Build.SourcesDirectory):/auto-round \
+                  -w /auto-round/auto_round_extension/ark \
+                  quay.io/pypa/manylinux_2_28_x86_64 \
+                  bash -c "pip install -U pip build cmake setuptools \
+                  && export BUILD_MODE=release \
+                  && python -m build --sdist --no-isolation \
+                  && ls -lah dist"
+
+          - task: PublishPipelineArtifact@1
+            displayName: Publish dist artifact
+            inputs:
+              targetPath: $(Build.SourcesDirectory)/auto_round_extension/ark/dist
+              artifact: auto-round-lib-dist
+              publishLocation: pipeline

--- a/.azure-pipelines/template/lib-build-template.yml
+++ b/.azure-pipelines/template/lib-build-template.yml
@@ -100,13 +100,24 @@ stages:
                     && export BUILD_MODE=${{ parameters.buildMode }} \
                     && python -m build --wheel --no-isolation \
                     && auditwheel repair dist/*.whl --exclude lib* -w wheelhouse/ \
-                    && ls -lah wheelhouse"
-
+                    && ls -lah wheelhouse" \
+                    && if [[ "$python_version_fix" == "312" ]] && [[ "${{ parameters.buildMode }}" == "release" ]]; then \
+                      rm -rf dist/* && python -m build --sdist --no-isolation && ls -lah dist; \
+                    fi
+            
             - task: PublishPipelineArtifact@1
               displayName: Publish wheel artifact
               inputs:
                 targetPath: $(Build.SourcesDirectory)/auto_round_extension/ark/wheelhouse
                 artifact: auto-round-lib-wheel-cp${{ replace(trim(pythonVersion), '.', '') }}
+                publishLocation: pipeline
+            
+            - task: PublishPipelineArtifact@1
+              condition: and(succeeded(), eq('${{ parameters.buildMode }}', 'release'), eq('${{ replace(trim(pythonVersion), ".", "") }}', '312'))
+              displayName: Publish dist artifact
+              inputs:
+                targetPath: $(Build.SourcesDirectory)/auto_round_extension/ark/dist
+                artifact: auto-round-lib-dist
                 publishLocation: pipeline
 
             - ${{ if eq(parameters.publishToTestPyPI, true) }}:
@@ -134,43 +145,3 @@ stages:
                       bash -c "source venv/bin/activate \
                       && python -m pip install --upgrade twine \
                       && twine upload --repository-url https://test.pypi.org/legacy/ wheelhouse/*.whl"
-
-  - stage: BuildArkDist
-    displayName: Build ark dist
-    ${{ if eq(parameters.buildMode, 'release') }}:
-    jobs:
-      - job: BuildDist
-        displayName: Build ark source distribution
-        pool: GAUDI
-        timeoutInMinutes: 30
-        steps:  
-          - checkout: self
-            clean: true
-
-          - task: Bash@3
-            displayName: Build source distribution in manylinux container
-            inputs:
-              targetType: inline
-              script: |
-                set -euxo pipefail
-                docker run --rm \
-                  --user "$(id -u):$(id -g)" \
-                  -e HOME=/tmp \
-                  -v $(Build.SourcesDirectory):/auto-round \
-                  -v /opt/intel/oneapi:/opt/intel/oneapi \
-                  -w /auto-round/auto_round_extension/ark \
-                  quay.io/pypa/manylinux_2_28_x86_64 \
-                  bash -c "/opt/python/cp312-cp312/bin/python -m venv venv \
-                  && source venv/bin/activate \
-                  && source /opt/intel/oneapi/setvars.sh \
-                  && pip install -U pip build cmake setuptools \
-                  && export BUILD_MODE=release \
-                  && python -m build --sdist --no-isolation \
-                  && ls -lah dist"
-
-          - task: PublishPipelineArtifact@1
-            displayName: Publish dist artifact
-            inputs:
-              targetPath: $(Build.SourcesDirectory)/auto_round_extension/ark/dist
-              artifact: auto-round-lib-dist
-              publishLocation: pipeline

--- a/.azure-pipelines/template/lib-build-template.yml
+++ b/.azure-pipelines/template/lib-build-template.yml
@@ -143,13 +143,12 @@ stages:
     ${{ if eq(parameters.enableChangeDetection, true) }}:
       variables:
         BUILD_ARK_WHEEL: $[ stageDependencies.DetectArkChanges.Detect.outputs['SetArkWheelFlag.BUILD_ARK_WHEEL'] ]
-    dependsOn: BuildArkWheel
     jobs:
       - job: BuildDist
         displayName: Build ARK source distribution
         pool: GAUDI
         timeoutInMinutes: 30
-        steps:
+        steps:  
           - checkout: self
             clean: true
 

--- a/.azure-pipelines/template/lib-build-template.yml
+++ b/.azure-pipelines/template/lib-build-template.yml
@@ -100,10 +100,10 @@ stages:
                     && export BUILD_MODE=${{ parameters.buildMode }} \
                     && python -m build --wheel --no-isolation \
                     && auditwheel repair dist/*.whl --exclude lib* -w wheelhouse/ \
-                    && ls -lah wheelhouse" \
-                    && if [[ "$python_version_fix" == "312" ]] && [[ "${{ parameters.buildMode }}" == "release" ]]; then \
+                    && ls -lah wheelhouse \
+                    && if [[ "$python_version_fix" == "312" ]] && [[ "$BUILD_MODE" == "release" ]]; then \
                       rm -rf dist/* && python -m build --sdist --no-isolation && ls -lah dist; \
-                    fi
+                    fi"
             
             - task: PublishPipelineArtifact@1
               displayName: Publish wheel artifact

--- a/.azure-pipelines/template/lib-build-template.yml
+++ b/.azure-pipelines/template/lib-build-template.yml
@@ -137,7 +137,7 @@ stages:
 
   - stage: BuildArkDist
     displayName: Build ark dist
-    # TODO depend-on
+    ${{ if eq(parameters.buildMode, 'release') }}:
     jobs:
       - job: BuildDist
         displayName: Build ark source distribution

--- a/.azure-pipelines/template/lib-build-template.yml
+++ b/.azure-pipelines/template/lib-build-template.yml
@@ -101,7 +101,7 @@ stages:
                     && python -m build --wheel --no-isolation \
                     && auditwheel repair dist/*.whl --exclude lib* -w wheelhouse/ \
                     && ls -lah wheelhouse \
-                    && if [[ "$python_version_fix" == "312" ]] && [[ "$BUILD_MODE" == "release" ]]; then \
+                    && if [[ "$python_version_fix" == "312" ]] && [[ "\$BUILD_MODE" == "release" ]]; then \
                       rm -rf dist/* && python -m build --sdist --no-isolation && ls -lah dist; \
                     fi"
             

--- a/.azure-pipelines/template/lib-build-template.yml
+++ b/.azure-pipelines/template/lib-build-template.yml
@@ -164,7 +164,9 @@ stages:
                   -v $(Build.SourcesDirectory):/auto-round \
                   -w /auto-round/auto_round_extension/ark \
                   quay.io/pypa/manylinux_2_28_x86_64 \
-                  bash -c "pip install -U pip build cmake setuptools \
+                  bash -c "/opt/python/cp312-cp312/bin/python -m venv venv \
+                  && source venv/bin/activate \
+                  && pip install -U pip build setuptools \
                   && export BUILD_MODE=release \
                   && python -m build --sdist --no-isolation \
                   && ls -lah dist"

--- a/.azure-pipelines/template/lib-build-template.yml
+++ b/.azure-pipelines/template/lib-build-template.yml
@@ -113,7 +113,7 @@ stages:
                 publishLocation: pipeline
             
             - task: PublishPipelineArtifact@1
-              condition: and(succeeded(), eq('${{ parameters.buildMode }}', 'release'), eq('${{ replace(trim(pythonVersion), ".", "") }}', '312'))
+              condition: and(succeeded(), eq('${{ parameters.buildMode }}', 'release'), eq('${{ replace(trim(pythonVersion), '.', '') }}', '312'))
               displayName: Publish dist artifact
               inputs:
                 targetPath: $(Build.SourcesDirectory)/auto_round_extension/ark/dist

--- a/.azure-pipelines/template/lib-build-template.yml
+++ b/.azure-pipelines/template/lib-build-template.yml
@@ -135,17 +135,12 @@ stages:
                       && python -m pip install --upgrade twine \
                       && twine upload --repository-url https://test.pypi.org/legacy/ wheelhouse/*.whl"
 
-  - stage: BuildARKDist
-    displayName: Build ARK dist
-    dependsOn:
-      - ${{ if eq(parameters.enableChangeDetection, true) }}:
-        - DetectArkChanges
-    ${{ if eq(parameters.enableChangeDetection, true) }}:
-      variables:
-        BUILD_ARK_WHEEL: $[ stageDependencies.DetectArkChanges.Detect.outputs['SetArkWheelFlag.BUILD_ARK_WHEEL'] ]
+  - stage: BuildArkDist
+    displayName: Build ark dist
+    # TODO depend-on
     jobs:
       - job: BuildDist
-        displayName: Build ARK source distribution
+        displayName: Build ark source distribution
         pool: GAUDI
         timeoutInMinutes: 30
         steps:  
@@ -162,11 +157,13 @@ stages:
                   --user "$(id -u):$(id -g)" \
                   -e HOME=/tmp \
                   -v $(Build.SourcesDirectory):/auto-round \
+                  -v /opt/intel/oneapi:/opt/intel/oneapi \
                   -w /auto-round/auto_round_extension/ark \
                   quay.io/pypa/manylinux_2_28_x86_64 \
                   bash -c "/opt/python/cp312-cp312/bin/python -m venv venv \
                   && source venv/bin/activate \
-                  && pip install -U pip build setuptools \
+                  && source /opt/intel/oneapi/setvars.sh \
+                  && pip install -U pip build cmake setuptools \
                   && export BUILD_MODE=release \
                   && python -m build --sdist --no-isolation \
                   && ls -lah dist"

--- a/auto_round_extension/ark/MANIFEST.in
+++ b/auto_round_extension/ark/MANIFEST.in
@@ -1,0 +1,11 @@
+include LICENSE
+include README.md
+include requirements.txt
+
+graft auto_round_kernel
+graft tools
+graft test
+
+prune build
+prune xbuild
+global-exclude __pycache__ *.py[cod] *.so *.pyd


### PR DESCRIPTION
## Description

Update auto-round-lib release package build including source code distribute. 
Update default pytorch test version into v2.12.0. 


## Type of Change

CI update

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
