### PR TITLE
Fix slow startup time of pytest coverage for unit tests

### DIFF
--- a/.azure-pipelines/scripts/ut/run_ut.sh
+++ b/.azure-pipelines/scripts/ut/run_ut.sh
@@ -16,6 +16,7 @@ function setup_environment() {
     export HF_HUB_DISABLE_PROGRESS_BARS=1
 
     uv pip install pytest-cov pytest-html
+    uv pip install -U chardet
     uv pip list
 
     # install latest gguf for ut test

--- a/.azure-pipelines/scripts/ut/run_ut_cuda.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_cuda.sh
@@ -96,7 +96,7 @@ function run_unit_test() {
     uv pip install 'git+https://github.com/ggml-org/llama.cpp.git#subdirectory=gguf-py'
     uv pip install -r test_cuda/requirements.txt
     uv pip install -r test_cuda/requirements_diffusion.txt
-    uv pip install -U transformers
+    uv pip install -U transformers chardet
     uv pip uninstall torch torchvision
     uv pip install torch==2.12.0 torchvision torchao --index-url https://download.pytorch.org/whl/cu126
     cd ${REPO_PATH} && uv pip install . && cd ${REPO_PATH}/test
@@ -138,6 +138,7 @@ function run_unit_test_vlm() {
     uv pip install -r test_cuda/requirements_vlm.txt \
         --extra-index-url https://download.pytorch.org/whl/cu126 \
         --index-strategy unsafe-best-match
+    uv pip install -U chardet
     cd ${REPO_PATH} && uv pip install . && cd ${REPO_PATH}/test
 
     pip list > ${LOG_DIR}/vlm_ut_pip_list.txt
@@ -171,6 +172,7 @@ function run_unit_test_llmc() {
     cd ${REPO_PATH}/test
     rm -rf .coverage* *.xml *.html
     BUILD_TYPE="nightly" uv pip install -r test_cuda/requirements_llmc.txt --extra-index-url https://download.pytorch.org/whl/cu126 --index-strategy unsafe-best-match
+    uv pip install -U chardet
     cd ${REPO_PATH} && uv pip install . && cd ${REPO_PATH}/test
 
     pip list > ${LOG_DIR}/llmc_ut_pip_list.txt
@@ -240,6 +242,7 @@ function run_unit_test_vllm() {
         --extra-index-url https://wheels.vllm.ai/${vllm_version}/cu129 \
         --extra-index-url https://download.pytorch.org/whl/cu126 \
         --index-strategy unsafe-best-match
+    uv pip install -U chardet
     cd ${REPO_PATH} && uv pip install . && cd ${REPO_PATH}/test
 
     pip list > ${LOG_DIR}/vllm_ut_pip_list.txt


### PR DESCRIPTION
`chardet` v6.0.0 introduces significant import or initialization overhead when used under pytest-cov. Older (v5.2.0) and newer (v7.0.0) versions do not suffer from this penalty.

```
time pytest --cov="/home/sdp/auto-round/auto_round" --cov-report= --cov-append -vs --disable-warnings core/test_init.py`

# chardet v6.0.0
real    0m58.329s
user    1m16.432s
sys     0m2.164s

# chardet v5.2.0
real    0m17.036s
user    0m35.034s
sys     0m3.371s

# chardet v7.0.0
real    0m14.917s
user    0m33.170s
sys     0m3.395s
```

Root Cause: The upstream dependency `mbstrdecoder` introduced a change in commit [c797333](https://github.com/thombashi/mbstrdecoder/commit/c7973334b72d7ef7113aa5e23eda20bcf25d922d) that pins or restricts `chardet` to versions below 7.0.0 (use of `chardet` 6.x). 

Dependency of `lm_eval`:
```
absl-py==2.4.0
    # via rouge-score
aiohappyeyeballs==2.6.2
    # via aiohttp
aiohttp==3.14.1
    # via fsspec
aiosignal==1.4.0
    # via aiohttp
annotated-doc==0.0.4
    # via typer
anyio==4.13.0
    # via httpx
attrs==26.1.0
    # via aiohttp
certifi==2026.5.20
    # via
    #   httpcore
    #   httpx
    #   requests
chardet==6.0.0.post1
    # via mbstrdecoder
charset-normalizer==3.4.7
    # via requests
click==8.4.1
    # via
    #   huggingface-hub
    #   nltk
    #   typer
colorama==0.4.6
    # via sacrebleu
dataproperty==1.1.1
    # via
    #   pytablewriter
    #   tabledata
datasets==5.0.0
    # via
    #   evaluate
    #   lm-eval
dill==0.4.1
    # via
    #   datasets
    #   evaluate
    #   lm-eval
    #   multiprocess
evaluate==0.4.6
    # via lm-eval
filelock==3.29.1
    # via
    #   datasets
    #   huggingface-hub
frozenlist==1.8.0
    # via
    #   aiohttp
    #   aiosignal
fsspec==2026.4.0
    # via
    #   datasets
    #   evaluate
    #   huggingface-hub
h11==0.16.0
    # via httpcore
hf-xet==1.5.1
    # via huggingface-hub
httpcore==1.0.9
    # via httpx
httpx==0.28.1
    # via
    #   datasets
    #   huggingface-hub
huggingface-hub==1.18.0
    # via
    #   datasets
    #   evaluate
idna==3.18
    # via
    #   anyio
    #   httpx
    #   requests
    #   yarl
jinja2==3.1.6
    # via lm-eval
joblib==1.5.3
    # via
    #   nltk
    #   scikit-learn
lm-eval==0.4.12
    # via -r requirements.txt
lxml==6.1.1
    # via sacrebleu
markdown-it-py==4.2.0
    # via rich
markupsafe==3.0.3
    # via jinja2
mbstrdecoder==1.1.5
    # via
    #   dataproperty
    #   pytablewriter
    #   typepy
mdurl==0.1.2
    # via markdown-it-py
more-itertools==11.1.0
    # via lm-eval
multidict==6.7.1
    # via
    #   aiohttp
    #   yarl
multiprocess==0.70.19
    # via
    #   datasets
    #   evaluate
narwhals==2.22.1
    # via scikit-learn
nltk==3.9.4
    # via rouge-score
numpy==2.4.6
    # via
    #   datasets
    #   evaluate
    #   lm-eval
    #   pandas
    #   rouge-score
    #   sacrebleu
    #   scikit-learn
    #   scipy
packaging==26.2
    # via
    #   datasets
    #   evaluate
    #   huggingface-hub
    #   typepy
pandas==3.0.3
    # via
    #   datasets
    #   evaluate
pathvalidate==3.3.1
    # via pytablewriter
portalocker==3.2.0
    # via sacrebleu
propcache==0.5.2
    # via
    #   aiohttp
    #   yarl
pyarrow==24.0.0
    # via datasets
pygments==2.20.0
    # via rich
pytablewriter==1.2.1
    # via lm-eval
python-dateutil==2.9.0.post0
    # via
    #   pandas
    #   typepy
pytz==2026.2
    # via typepy
pyyaml==6.0.3
    # via
    #   datasets
    #   huggingface-hub
regex==2026.5.9
    # via
    #   nltk
    #   sacrebleu
requests==2.34.2
    # via
    #   datasets
    #   evaluate
rich==15.0.0
    # via typer
rouge-score==0.1.2
    # via lm-eval
sacrebleu==2.6.0
    # via lm-eval
scikit-learn==1.9.0
    # via lm-eval
scipy==1.17.1
    # via scikit-learn
setuptools==82.0.1
    # via pytablewriter
shellingham==1.5.4
    # via typer
six==1.17.0
    # via
    #   python-dateutil
    #   rouge-score
sqlitedict==2.1.0
    # via lm-eval
tabledata==1.3.5
    # via pytablewriter
tabulate==0.10.0
    # via sacrebleu
tcolorpy==0.1.7
    # via pytablewriter
threadpoolctl==3.6.0
    # via scikit-learn
tqdm==4.68.1
    # via
    #   datasets
    #   evaluate
    #   huggingface-hub
    #   lm-eval
    #   nltk
typepy==1.3.5
    # via
    #   dataproperty
    #   pytablewriter
    #   tabledata
typer==0.25.1
    # via huggingface-hub
typing-extensions==4.15.0
    # via
    #   aiohttp
    #   aiosignal
    #   anyio
    #   huggingface-hub
    #   lm-eval
urllib3==2.7.0
    # via requests
word2number==1.1
    # via lm-eval
xxhash==3.7.0
    # via
    #   datasets
    #   evaluate
yarl==1.24.2
    # via aiohttp
```

