### PR TITLE
update llama-cpp-python installation for CUDA CI

### DIFF
--- a/.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh
+++ b/.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh
@@ -63,7 +63,7 @@ function run_unit_test() {
     echo "##[group]set up UT env..."
     cd "${BUILD_SOURCESDIRECTORY}" || exit 1
     uv pip install torch==2.12.0 torchvision torchao --index-url https://download.pytorch.org/whl/cu130
-    uv pip install https://github.com/XuehaoSun/llama-cpp-python/releases/download/v0.3.23/llama_cpp_python-0.3.23-py3-none-linux_x86_64.whl
+    uv pip install llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu130
     uv pip install 'git+https://github.com/ggml-org/llama.cpp.git#subdirectory=gguf-py'
     uv pip install -r test/test_cuda/requirements.txt
     uv pip install -r test/test_cuda/requirements_diffusion.txt
@@ -168,7 +168,6 @@ function run_unit_test_vllm() {
     rm -rf /root/.venv
     uv venv --python=3.12 /root/.venv
     uv pip install -U pytest-cov pytest-html
-    vllm_version=$(curl -s https://api.github.com/repos/vllm-project/vllm/releases/latest | jq -r .tag_name | sed 's/^v//')
     uv pip install -r test/test_cuda/requirements_vllm.txt \
         --extra-index-url https://download.pytorch.org/whl/cu130 \
         --index-strategy unsafe-best-match

--- a/.azure-pipelines/scripts/ut/collect_result.py
+++ b/.azure-pipelines/scripts/ut/collect_result.py
@@ -39,18 +39,22 @@ class LogAnalyzer:
         "unittest_",
     )
 
+    # pytest test logic failures: test ran but assertion/expectation failed
     FAILURE_MARKERS = (
         "FAILED",
         "== FAILURES ==",
         " failures",
-        "Killed",
         "AssertionError",
-        "Error:",
-        "core dumped",
-        "Segmentation fault",
     )
 
+    # runtime/system errors: process crashed, setup/teardown failed, or unhandled exception
     ERROR_MARKERS = (
+        "Aborted",
+        "Killed",
+        "Segmentation fault",
+        "core dumped",
+        "error:",
+        "Error:",
         "ERROR:",
         "== ERRORS ==",
         " errors:",

--- a/.azure-pipelines/scripts/ut/collect_result.py
+++ b/.azure-pipelines/scripts/ut/collect_result.py
@@ -53,7 +53,6 @@ class LogAnalyzer:
         "Killed",
         "Segmentation fault",
         "core dumped",
-        "error:",
         "Error:",
         "ERROR:",
         "== ERRORS ==",

--- a/.azure-pipelines/scripts/ut/run_ut_cuda.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_cuda.sh
@@ -92,7 +92,7 @@ function run_unit_test() {
     rm -rf .coverage* *.xml *.html
 
     uv pip install torch==2.12.0 torchvision torchao --index-url https://download.pytorch.org/whl/cu126
-    uv pip install https://github.com/XuehaoSun/llama-cpp-python/releases/download/v0.3.23/llama_cpp_python-0.3.23+cu128-py3-none-linux_x86_64.whl
+    uv pip install llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu125
     uv pip install 'git+https://github.com/ggml-org/llama.cpp.git#subdirectory=gguf-py'
     uv pip install -r test_cuda/requirements.txt
     uv pip install -r test_cuda/requirements_diffusion.txt


### PR DESCRIPTION
## Description

This pull request updates the CUDA unit test setup scripts and improves the log analysis for test results. The main changes focus on modernizing dependency installation for `llama-cpp-python`, cleaning up unused code, and refining error classification in log analysis.

Dependency installation improvements:
* Updated the installation method for `llama-cpp-python` in both `.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh` and `.azure-pipelines/scripts/ut/run_ut_cuda.sh` to use the official extra index URL instead of downloading specific wheel files. This makes dependency management more robust and maintainable. [[1]](diffhunk://#diff-aeaf3986a1a0811c31823572fc115d5b13ea35705b0f4b6d56a9f423a486ef19L66-R66) [[2]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L95-R95)

Log analysis enhancements:
* Refined the classification of test failures and errors in `LogAnalyzer` by distinguishing between assertion failures and runtime/system errors. Several markers (e.g., "Killed", "Segmentation fault") were moved from failure to error markers, and additional error markers were added for more accurate reporting.

Code cleanup:
* Removed an unused line that fetched the latest `vllm` version in the `run_unit_test_vllm` function, simplifying the script.