### PR TITLE
fix: guard zero-division in GGUF quant kernels to avoid NaN block scales

### DIFF
--- a/auto_round/export/export_to_gguf/packing.py
+++ b/auto_round/export/export_to_gguf/packing.py
@@ -194,7 +194,9 @@ def make_qx_quants_chunk(data, bits, rmse_type=0, qw=None, split_num=1, v=0):
         # Compute sumlx and suml2 using the pre-allocated L buffer
         sumlx = (w * chunk * L).sum(dim=-1)
         suml2 = (w * L * L).sum(dim=-1)
-        scales = sumlx / suml2
+        # Guard the all-zero group case (suml2 == 0): 0/0 would produce a NaN
+        # scale that ends up as a NaN fp16 `d` in the exported GGUF block.
+        scales = sumlx * get_reciprocal(suml2)
 
         if return_early:
             iscales_inv = (1 / iscales).reshape(iscales.shape[:2])
@@ -488,7 +490,7 @@ def make_qp_quants(nmax, data, quant_weights):
         if n_changed == 0:
             break
 
-    return sumlx / suml2, L
+    return sumlx * get_reciprocal(suml2), L
 
 
 @register_qtype("bf16")

--- a/test/test_cpu/export/test_gguf_format.py
+++ b/test/test_cpu/export/test_gguf_format.py
@@ -344,3 +344,33 @@ class TestGGUF:
         assert tensor_types["blk.0.attn_k.weight"] == "Q4_K"
         assert tensor_types["blk.0.ffn_down_exps.weight"] == "Q5_0"
         assert tensor_types["blk.0.ffn_up_exps.weight"] == "Q2_K"
+
+
+class TestGGUFZeroBlock:
+    """All-zero blocks (e.g. padded/unused vocab rows in an embedding tensor) must
+    quantize with scale d=0.0, not NaN. A single NaN fp16 `d` in an exported GGUF
+    makes llama.cpp return NaN logits for any batch touching those rows."""
+
+    def test_q6_k_all_zero_block_no_nan(self):
+        from auto_round.data_type.gguf import quant_tensor_gguf_sym_dq
+
+        tensor = torch.zeros(2, 256)
+        tensor[1] = torch.randn(256)
+        qdq, scales, _ = quant_tensor_gguf_sym_dq(tensor, bits=6, scale_dtype=torch.float32)
+        assert not torch.isnan(scales["scale"]).any(), "Q6_K sub-scales contain NaN for all-zero block"
+        assert not torch.isnan(scales["d_scale"]).any(), "Q6_K d_scale contains NaN for all-zero block"
+        assert not torch.isnan(qdq).any()
+        assert torch.equal(qdq[0], torch.zeros(256)), "all-zero block must reconstruct exactly to zeros"
+
+    def test_q6_k_all_zero_block_packs_zero_d(self):
+        import numpy as np
+
+        from auto_round.export.export_to_gguf.packing import ggml_quant
+
+        tensor = torch.zeros(2, 256)
+        tensor[1] = torch.randn(256)
+        packed = ggml_quant(tensor, "q6_k", device="cpu")
+        # Q6_K block layout: [ql(128), qh(64), scales(16), d(fp16)]
+        d = np.ascontiguousarray(packed.reshape(2, 210)[:, -2:]).view(np.float16)
+        assert not np.isnan(d).any(), f"packed Q6_K d scales contain NaN: {d}"
+        assert d[0] == 0.0


### PR DESCRIPTION
Fixes #1908

## Problem

GGUF Q6_K export writes NaN fp16 `d` block scales for blocks whose source weights are all zero (e.g. padded/unused vocab rows in `token_embd.weight`). One NaN scale is enough to make llama.cpp return NaN logits/PPL for any batch touching those rows. Full analysis in #1908.

## Root cause

`make_qx_quants_chunk` divides without a zero guard:

```python
scales = sumlx / suml2   # 0/0 = NaN for an all-zero group (w = chunk**2 = 0, L = 0)
```

The NaN then slips through `torch.where(torch.abs(scale) < 1e-30, ...)` in `quant_tensor_gguf_sym_dq` (NaN compares false), propagates through `double_quant_tensor_sym_rtn` (argmax picks the NaN), and is written as the block's fp16 `d`.

The original non-chunked `make_qx_quants` already guards this with `sumlx * get_reciprocal(suml2)`; the chunked rewrite dropped the guard.

## Fix

- `make_qx_quants_chunk`: `scales = sumlx * get_reciprocal(suml2)` — matches the non-chunked implementation and llama.cpp's own `make_qx_quants` zero-amax handling. All-zero blocks now get `d = 0.0` (exact reconstruction).
- `make_qp_quants`: same guard applied to the identical unguarded `return sumlx / suml2, L`.

## Test

Added `TestGGUFZeroBlock` (no model download needed):
- `quant_tensor_gguf_sym_dq` on an all-zero 256-weight block → no NaN in sub-scales / `d_scale`, qdq reconstructs to exact zeros.
- `ggml_quant(..., "q6_k")` end-to-end → packed fp16 `d` is `0.0`, not NaN.

Both tests fail on `main` and pass with this change. Verified separately that patching the 17 NaN scales to 0.0 in an affected gemma-4-26B GGUF restores normal perplexity.
