### PR TITLE
enable MXFP clamp for model free

### DIFF
--- a/auto_round/compressors/model_free.py
+++ b/auto_round/compressors/model_free.py
@@ -520,7 +520,7 @@ def _quantize_weight_mxfp(
     # quant_mx returns (qdq_tensor, shared_exp, None).  We only need shared_exp
     # (the per-block log2 scale).  The element-wise rounding to the FP4/FP8 grid
     # is performed inside QuantLinear.pack via dtype casts / pack_fp4_to_uint8.
-    _, shared_exp, _ = quant_mx(weight_dev, bits=bits, group_size=group_size, data_type=data_type)
+    weight_dev, shared_exp, _ = quant_mx(weight_dev, bits=bits, group_size=group_size, data_type=data_type)
     # Reshape to (out_features, n_groups) so the on-disk weight_scale matches
     # the llm-compressor convention (and QuantLinear's registered buffer shape).
     shared_exp = shared_exp.reshape(out_features, in_features // group_size)

--- a/test/test_cpu/quantization/test_model_free.py
+++ b/test/test_cpu/quantization/test_model_free.py
@@ -351,6 +351,23 @@ class TestModelFreeMXFP:
         assert out["layer.weight_scale"].shape == (64, 4)
         assert out["layer.weight_scale"].dtype == torch.uint8
 
+    def test_mxfp8_max_value_scaling(self):
+        """Input bfloat16 weight with max value 240; after MXFP8 quantization
+        the stored FP8 values should be clamped to 448 (fp8_e4m3fn max) and
+        must NOT be NaN.
+
+        quant_mx computes shared_exp = floor(log2(240)) - emax = 7 - 8 = -1,
+        so scale = 2^-1 = 0.5.  The normalised value is 240/0.5 = 480 which
+        exceeds the FP8 max of 448 and must be clamped before the fp8 cast.
+        """
+        w_bf16 = torch.full((64, 128), 240, dtype=torch.bfloat16)
+        out = _quantize_weight_mxfp(w_bf16, "layer", bits=8, group_size=32, data_type="mx_fp")
+        assert out["layer.weight"].dtype == torch.float8_e4m3fn
+        weight_fp32 = out["layer.weight"].to(torch.float32)
+        assert not torch.isnan(weight_fp32).any(), "FP8 weight must not contain NaN"
+        max_val = torch.max(weight_fp32).item()
+        assert max_val == 448, f"Expected 448 (fp8_e4m3fn max after clamp), got {max_val}"
+
     @require_compressed_tensors
     @pytest.mark.parametrize("scheme,fmt", [("MXFP4", "mxfp4-pack-quantized"), ("MXFP8", "mxfp8-quantized")])
     def test_e2e_mxfp(self, tmp_path, scheme, fmt):


### PR DESCRIPTION
## Description

enable MXFP clamp for model free (480->448)

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
