### PR TITLE
Fix SIGSEGV in pack-weight unpack/GEMM on malformed blob

### DIFF
--- a/auto_round_extension/ark/auto_round_kernel/__init__.py
+++ b/auto_round_extension/ark/auto_round_kernel/__init__.py
@@ -343,19 +343,13 @@ def _validate_packed_blob(
         raise TypeError(f"blob must be a torch.Tensor, got {type(blob).__name__}")
 
     if blob.device.type not in ("cpu", "xpu"):
-        raise ValueError(
-            f"blob must reside on cpu or xpu, got {blob.device.type}"
-        )
+        raise ValueError(f"blob must reside on cpu or xpu, got {blob.device.type}")
 
     if blob.dtype != torch.int8:
-        raise ValueError(
-            f"blob must have dtype torch.int8, got {blob.dtype}"
-        )
+        raise ValueError(f"blob must have dtype torch.int8, got {blob.dtype}")
 
     if blob.dim() != 1:
-        raise ValueError(
-            f"blob must be a 1-D tensor, got {blob.dim()}-D"
-        )
+        raise ValueError(f"blob must be a 1-D tensor, got {blob.dim()}-D")
 
     if not isinstance(n, (int,)) or n <= 0:
         raise ValueError(f"n must be a positive integer, got {n!r}")
@@ -366,8 +360,21 @@ def _validate_packed_blob(
     if not isinstance(asym, bool):
         raise TypeError(f"asym must be a bool, got {type(asym).__name__}")
 
-    valid_types = {"fp32", "fp16", "bf16", "int8", "int4", "int2", "int3",
-                   "int5", "int6", "int7", "fp8_e4m3", "fp8_e5m2", "fp8_e8m0"}
+    valid_types = {
+        "fp32",
+        "fp16",
+        "bf16",
+        "int8",
+        "int4",
+        "int2",
+        "int3",
+        "int5",
+        "int6",
+        "int7",
+        "fp8_e4m3",
+        "fp8_e5m2",
+        "fp8_e8m0",
+    }
     if compute_type not in valid_types:
         raise ValueError(f"compute_type must be one of {valid_types}, got {compute_type!r}")
     if weight_type not in valid_types:

--- a/auto_round_extension/ark/auto_round_kernel/__init__.py
+++ b/auto_round_extension/ark/auto_round_kernel/__init__.py
@@ -96,15 +96,11 @@ def get_stream(A: torch.Tensor) -> int:
 def _normalize_tensor_layout(tensor_layout: str) -> str:
     layout = tensor_layout.upper()
     if layout not in ("HND", "NHD"):
-        raise ValueError(
-            f"tensor_layout must be either 'HND' or 'NHD', got {tensor_layout!r}"
-        )
+        raise ValueError(f"tensor_layout must be either 'HND' or 'NHD', got {tensor_layout!r}")
     return layout
 
 
-def _attention_shape(
-    tensor: torch.Tensor, tensor_layout: str
-) -> tuple[int, int, int, int]:
+def _attention_shape(tensor: torch.Tensor, tensor_layout: str) -> tuple[int, int, int, int]:
     layout = _normalize_tensor_layout(tensor_layout)
     if layout == "HND":
         batch, num_heads, seq_len, head_dim = tensor.shape
@@ -113,9 +109,7 @@ def _attention_shape(
     return batch, num_heads, seq_len, head_dim
 
 
-def _attention_strides_qko(
-    tensor: torch.Tensor, tensor_layout: str
-) -> tuple[int, int, int, int]:
+def _attention_strides_qko(tensor: torch.Tensor, tensor_layout: str) -> tuple[int, int, int, int]:
     layout = _normalize_tensor_layout(tensor_layout)
     if layout == "HND":
         batch_stride, head_stride, seq_stride, dim_stride = tensor.stride()
@@ -124,9 +118,7 @@ def _attention_strides_qko(
     return seq_stride, dim_stride, head_stride, batch_stride
 
 
-def _attention_strides_v(
-    tensor: torch.Tensor, tensor_layout: str
-) -> tuple[int, int, int, int]:
+def _attention_strides_v(tensor: torch.Tensor, tensor_layout: str) -> tuple[int, int, int, int]:
     layout = _normalize_tensor_layout(tensor_layout)
     if layout == "HND":
         batch_stride, head_stride, seq_stride, dim_stride = tensor.stride()
@@ -149,13 +141,9 @@ def _validate_attention_tensor(
 
     qko_strides = _attention_strides_qko(tensor, tensor_layout)
     if qko_strides[1] != 1:
-        raise ValueError(
-            f"{name} must be contiguous along the head-dim axis; got stride {qko_strides[1]}"
-        )
+        raise ValueError(f"{name} must be contiguous along the head-dim axis; got stride {qko_strides[1]}")
     if any(stride <= 0 for stride in qko_strides):
-        raise ValueError(
-            f"{name} must have positive non-zero strides, got {tensor.stride()}"
-        )
+        raise ValueError(f"{name} must have positive non-zero strides, got {tensor.stride()}")
 
     return _attention_shape(tensor, tensor_layout)
 
@@ -171,11 +159,7 @@ def _empty_attention_output(
     tensor_layout: str,
 ) -> torch.Tensor:
     layout = _normalize_tensor_layout(tensor_layout)
-    shape = (
-        (batch, num_heads, seq_len, head_dim)
-        if layout == "HND"
-        else (batch, seq_len, num_heads, head_dim)
-    )
+    shape = (batch, num_heads, seq_len, head_dim) if layout == "HND" else (batch, seq_len, num_heads, head_dim)
     return torch.empty(shape, device=device, dtype=dtype)
 
 
@@ -272,9 +256,7 @@ def igemm_s8s8s32(A: torch.Tensor, B: torch.Tensor):
 
 # A: mxk:DT,  B: nxk:s8, scaleB: n:DT
 # return: mxn:DT
-def woqgemm_s8(
-    A: torch.Tensor, B: torch.Tensor, scaleB: torch.Tensor, bias: torch.Tensor
-):
+def woqgemm_s8(A: torch.Tensor, B: torch.Tensor, scaleB: torch.Tensor, bias: torch.Tensor):
     m = A.shape[0]
     n = B.shape[0]
     k = B.shape[1]
@@ -312,9 +294,7 @@ def woqgemm(
     scale_type,
     asym,
 ):
-    _validate_packed_blob(
-        B, n, k, groupsize, compute_type, weight_type, scale_type, asym
-    )
+    _validate_packed_blob(B, n, k, groupsize, compute_type, weight_type, scale_type, asym)
     m = A.shape[0]
     lib = get_lib(A)
     ct = cvtstr_dtype(compute_type)
@@ -397,13 +377,9 @@ def _validate_packed_blob(
     }
     valid_compute_types = valid_types | {"auto"}
     if compute_type not in valid_compute_types:
-        raise ValueError(
-            f"compute_type must be one of {valid_compute_types}, got {compute_type!r}"
-        )
+        raise ValueError(f"compute_type must be one of {valid_compute_types}, got {compute_type!r}")
     if weight_type not in valid_types:
-        raise ValueError(
-            f"weight_type must be one of {valid_types}, got {weight_type!r}"
-        )
+        raise ValueError(f"weight_type must be one of {valid_types}, got {weight_type!r}")
     if scale_type not in valid_types:
         raise ValueError(f"scale_type must be one of {valid_types}, got {scale_type!r}")
 
@@ -465,9 +441,7 @@ def _unpack_weight_core(
     scale_type,
     asym,
 ):
-    _validate_packed_blob(
-        blob, n, k, groupsize, compute_type, weight_type, scale_type, asym
-    )
+    _validate_packed_blob(blob, n, k, groupsize, compute_type, weight_type, scale_type, asym)
     lib = get_lib(blob)
     stream = get_stream(blob)
     ct = cvtstr_dtype(compute_type)
@@ -524,17 +498,11 @@ def sdpa(
     if query.dtype not in (torch.float16, torch.bfloat16):
         raise ValueError(f"Q must be float16 or bfloat16, got {query.dtype}")
     if key.dtype != query.dtype or value.dtype != query.dtype:
-        raise ValueError(
-            f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}"
-        )
+        raise ValueError(f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}")
 
     B, Hq, Sq, D = _validate_attention_tensor(query, "Q", tensor_layout)
-    Bk, Hkv, Skv, Dk = _validate_attention_tensor(
-        key, "K", tensor_layout, expected_dtype=query.dtype
-    )
-    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(
-        value, "V", tensor_layout, expected_dtype=query.dtype
-    )
+    Bk, Hkv, Skv, Dk = _validate_attention_tensor(key, "K", tensor_layout, expected_dtype=query.dtype)
+    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(value, "V", tensor_layout, expected_dtype=query.dtype)
 
     if Bk != B or Bv != B:
         raise ValueError("Batch size mismatch between Q/K/V")
@@ -546,9 +514,7 @@ def sdpa(
         raise ValueError(f"Unsupported head_dim={D}; supported: 64, 128, 96, 192")
 
     if dropout_p != 0.0:
-        raise NotImplementedError(
-            f"dropout_p must be 0.0 (got {dropout_p}); dropout is not supported"
-        )
+        raise NotImplementedError(f"dropout_p must be 0.0 (got {dropout_p}); dropout is not supported")
 
     if attn_mask is not None:
         if attn_mask.device.type != "xpu":
@@ -556,14 +522,10 @@ def sdpa(
         if not attn_mask.is_contiguous():
             raise ValueError("attn_mask must be contiguous")
         if attn_mask.dtype != torch.float32:
-            raise ValueError(
-                f"attn_mask must be float32 (additive bias), got {attn_mask.dtype}"
-            )
+            raise ValueError(f"attn_mask must be float32 (additive bias), got {attn_mask.dtype}")
         expected_mask_shape = (B, 1, Sq, Skv)
         if attn_mask.shape != expected_mask_shape:
-            raise ValueError(
-                f"attn_mask shape must be {expected_mask_shape}, got {tuple(attn_mask.shape)}"
-            )
+            raise ValueError(f"attn_mask shape must be {expected_mask_shape}, got {tuple(attn_mask.shape)}")
 
     lib = get_lib(query)
     stream = get_stream(query)
@@ -730,14 +692,8 @@ def sage_pvi8(
     """
     if query.device.type != "xpu":
         raise NotImplementedError("sage_pvi8 is only supported on XPU")
-    if (
-        query.dtype != torch.int8
-        or key.dtype != torch.int8
-        or value.dtype != torch.int8
-    ):
-        raise ValueError(
-            f"Q/K/V must be int8, got Q={query.dtype}, K={key.dtype}, V={value.dtype}"
-        )
+    if query.dtype != torch.int8 or key.dtype != torch.int8 or value.dtype != torch.int8:
+        raise ValueError(f"Q/K/V must be int8, got Q={query.dtype}, K={key.dtype}, V={value.dtype}")
     if out_dtype != torch.float16:
         raise ValueError(f"sage_pvi8 output must be float16, got {out_dtype}")
     if qscale is None or kscale is None or vscale is None:
@@ -858,17 +814,11 @@ def sagev1(
     if query.dtype not in (torch.float16, torch.bfloat16):
         raise ValueError(f"Q must be float16 or bfloat16, got {query.dtype}")
     if key.dtype != query.dtype or value.dtype != query.dtype:
-        raise ValueError(
-            f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}"
-        )
+        raise ValueError(f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}")
 
     B, Hq, Sq, D = _validate_attention_tensor(query, "Q", tensor_layout)
-    Bk, Hkv, Skv, Dk = _validate_attention_tensor(
-        key, "K", tensor_layout, expected_dtype=query.dtype
-    )
-    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(
-        value, "V", tensor_layout, expected_dtype=query.dtype
-    )
+    Bk, Hkv, Skv, Dk = _validate_attention_tensor(key, "K", tensor_layout, expected_dtype=query.dtype)
+    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(value, "V", tensor_layout, expected_dtype=query.dtype)
 
     if Bk != B or Bv != B:
         raise ValueError("Batch size mismatch between Q/K/V")
@@ -955,17 +905,11 @@ def sagev1_pvi8(
     if query.dtype not in (torch.float16, torch.bfloat16):
         raise ValueError(f"Q must be float16 or bfloat16, got {query.dtype}")
     if key.dtype != query.dtype or value.dtype != query.dtype:
-        raise ValueError(
-            f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}"
-        )
+        raise ValueError(f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}")
 
     B, Hq, Sq, D = _validate_attention_tensor(query, "Q", tensor_layout)
-    Bk, Hkv, Skv, Dk = _validate_attention_tensor(
-        key, "K", tensor_layout, expected_dtype=query.dtype
-    )
-    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(
-        value, "V", tensor_layout, expected_dtype=query.dtype
-    )
+    Bk, Hkv, Skv, Dk = _validate_attention_tensor(key, "K", tensor_layout, expected_dtype=query.dtype)
+    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(value, "V", tensor_layout, expected_dtype=query.dtype)
 
     if Bk != B or Bv != B:
         raise ValueError("Batch size mismatch between Q/K/V")
@@ -1057,9 +1001,7 @@ def sageattn(
     elif kernel == "v1_pvi8":
         impl = sagev1_pvi8
     else:
-        raise ValueError(
-            f"Unsupported sageattn kernel={kernel!r}; supported: 'v1_pvhalf', 'v1_pvi8'"
-        )
+        raise ValueError(f"Unsupported sageattn kernel={kernel!r}; supported: 'v1_pvhalf', 'v1_pvi8'")
 
     return impl(
         query=q,
@@ -1226,9 +1168,7 @@ def moe_gemm(
         raise ValueError("weights dtype must match activations dtype")
 
     if activations.ndim != 2 or weights.ndim != 3:
-        raise ValueError(
-            "activations must be 2D [total_tokens, K], weights must be 3D [num_experts, K, N]"
-        )
+        raise ValueError("activations must be 2D [total_tokens, K], weights must be 3D [num_experts, K, N]")
 
     if not activations.is_contiguous() or not weights.is_contiguous():
         raise ValueError("activations and weights must be contiguous")
@@ -1246,22 +1186,16 @@ def moe_gemm(
         raise ValueError(f"K dimension mismatch: activations K={K}, weights K={K_w}")
 
     if num_tokens_per_expert.shape[0] != num_experts:
-        raise ValueError(
-            f"num_tokens_per_expert length {num_tokens_per_expert.shape[0]} != num_experts {num_experts}"
-        )
+        raise ValueError(f"num_tokens_per_expert length {num_tokens_per_expert.shape[0]} != num_experts {num_experts}")
 
     # Validate total tokens
     expected_total = int(num_tokens_per_expert.sum().item())
     if expected_total != total_tokens:
-        raise ValueError(
-            f"Sum of num_tokens_per_expert ({expected_total}) != total_tokens ({total_tokens})"
-        )
+        raise ValueError(f"Sum of num_tokens_per_expert ({expected_total}) != total_tokens ({total_tokens})")
 
     lib = get_lib(activations)
     stream = get_stream(activations)
-    outputs = torch.empty(
-        (total_tokens, N), device=activations.device, dtype=activations.dtype
-    )
+    outputs = torch.empty((total_tokens, N), device=activations.device, dtype=activations.dtype)
 
     scales_ptr = scales.data_ptr() if scales is not None else 0
 
@@ -1341,19 +1275,14 @@ def repack_quantized_weight(*args, **kwargs):
         else:
             weight_type, compute_type = a4, a5
     else:
-        raise TypeError(
-            "repack_quantized_weight() expects 8 or 9 positional arguments; "
-            f"got {len(args)}"
-        )
+        raise TypeError("repack_quantized_weight() expects 8 or 9 positional arguments; " f"got {len(args)}")
 
     # Some native paths may still expect a valid zp pointer even when asym=False.
     if (zp is None) or (isinstance(zp, torch.Tensor) and zp.numel() == 0):
         if not bool(asym):
             k = QB.shape[0]
             n = QB.shape[1]
-            zp = torch.zeros(
-                (k // int(groupsize), n), dtype=torch.int8, device=QB.device
-            )
+            zp = torch.zeros((k // int(groupsize), n), dtype=torch.int8, device=QB.device)
         else:
             zp = torch.empty(0, dtype=torch.int8, device=QB.device)
 
@@ -1380,14 +1309,10 @@ def unpack_weight(
     scale_type,
     asym,
 ):
-    return _unpack_weight_core(
-        blob, out_dtype, n, k, groupsize, compute_type, weight_type, scale_type, asym
-    )
+    return _unpack_weight_core(blob, out_dtype, n, k, groupsize, compute_type, weight_type, scale_type, asym)
 
 
-def packed_weight_size(
-    A: torch.Tensor, n, k, groupsize, compute_type, weight_type, scale_type, asym
-):
+def packed_weight_size(A: torch.Tensor, n, k, groupsize, compute_type, weight_type, scale_type, asym):
     # Keep signature convenient for Python callers; native library needs a stream.
     lib = get_lib(A)
     stream = get_stream(A)
@@ -1445,11 +1370,7 @@ if __name__ == "__main__":
         else:
             A = torch.rand(m, k, dtype=dt, device=device) - 0.5
             B = torch.rand(k, n, dtype=dt, device=device) - 0.5
-            bias = (
-                torch.rand(1, n, dtype=dt, device=device)
-                if has_bias
-                else torch.empty(0)
-            )
+            bias = torch.rand(1, n, dtype=dt, device=device) if has_bias else torch.empty(0)
             C = matmul(A, B, bias)
         ref = torch.matmul(A, B.T)
         if has_bias:
@@ -1483,9 +1404,7 @@ if __name__ == "__main__":
         B = torch.randint(-8, 7, (k, n), dtype=torch.int8, device=device)
         zp = torch.randint(-8, 7, (k // groupsize, n), dtype=torch.int8, device=device)
         scaleB = torch.rand(k // groupsize, n, dtype=dt, device=device) / 100
-        blob = repack_quantized_weight(
-            B, scaleB, zp, groupsize, "fp32", "int4", "fp32", False
-        )
+        blob = repack_quantized_weight(B, scaleB, zp, groupsize, "fp32", "int4", "fp32", False)
         dq = unpack_weight(blob, dt, n, k, groupsize, "fp32", "int4", "fp32", False)
         print(blob, dq)
         scale_re = scaleB.repeat_interleave(repeats=groupsize, dim=0).to(dt)

--- a/auto_round_extension/ark/auto_round_kernel/__init__.py
+++ b/auto_round_extension/ark/auto_round_kernel/__init__.py
@@ -96,11 +96,15 @@ def get_stream(A: torch.Tensor) -> int:
 def _normalize_tensor_layout(tensor_layout: str) -> str:
     layout = tensor_layout.upper()
     if layout not in ("HND", "NHD"):
-        raise ValueError(f"tensor_layout must be either 'HND' or 'NHD', got {tensor_layout!r}")
+        raise ValueError(
+            f"tensor_layout must be either 'HND' or 'NHD', got {tensor_layout!r}"
+        )
     return layout
 
 
-def _attention_shape(tensor: torch.Tensor, tensor_layout: str) -> tuple[int, int, int, int]:
+def _attention_shape(
+    tensor: torch.Tensor, tensor_layout: str
+) -> tuple[int, int, int, int]:
     layout = _normalize_tensor_layout(tensor_layout)
     if layout == "HND":
         batch, num_heads, seq_len, head_dim = tensor.shape
@@ -109,7 +113,9 @@ def _attention_shape(tensor: torch.Tensor, tensor_layout: str) -> tuple[int, int
     return batch, num_heads, seq_len, head_dim
 
 
-def _attention_strides_qko(tensor: torch.Tensor, tensor_layout: str) -> tuple[int, int, int, int]:
+def _attention_strides_qko(
+    tensor: torch.Tensor, tensor_layout: str
+) -> tuple[int, int, int, int]:
     layout = _normalize_tensor_layout(tensor_layout)
     if layout == "HND":
         batch_stride, head_stride, seq_stride, dim_stride = tensor.stride()
@@ -118,7 +124,9 @@ def _attention_strides_qko(tensor: torch.Tensor, tensor_layout: str) -> tuple[in
     return seq_stride, dim_stride, head_stride, batch_stride
 
 
-def _attention_strides_v(tensor: torch.Tensor, tensor_layout: str) -> tuple[int, int, int, int]:
+def _attention_strides_v(
+    tensor: torch.Tensor, tensor_layout: str
+) -> tuple[int, int, int, int]:
     layout = _normalize_tensor_layout(tensor_layout)
     if layout == "HND":
         batch_stride, head_stride, seq_stride, dim_stride = tensor.stride()
@@ -141,9 +149,13 @@ def _validate_attention_tensor(
 
     qko_strides = _attention_strides_qko(tensor, tensor_layout)
     if qko_strides[1] != 1:
-        raise ValueError(f"{name} must be contiguous along the head-dim axis; got stride {qko_strides[1]}")
+        raise ValueError(
+            f"{name} must be contiguous along the head-dim axis; got stride {qko_strides[1]}"
+        )
     if any(stride <= 0 for stride in qko_strides):
-        raise ValueError(f"{name} must have positive non-zero strides, got {tensor.stride()}")
+        raise ValueError(
+            f"{name} must have positive non-zero strides, got {tensor.stride()}"
+        )
 
     return _attention_shape(tensor, tensor_layout)
 
@@ -159,7 +171,11 @@ def _empty_attention_output(
     tensor_layout: str,
 ) -> torch.Tensor:
     layout = _normalize_tensor_layout(tensor_layout)
-    shape = (batch, num_heads, seq_len, head_dim) if layout == "HND" else (batch, seq_len, num_heads, head_dim)
+    shape = (
+        (batch, num_heads, seq_len, head_dim)
+        if layout == "HND"
+        else (batch, seq_len, num_heads, head_dim)
+    )
     return torch.empty(shape, device=device, dtype=dtype)
 
 
@@ -256,7 +272,9 @@ def igemm_s8s8s32(A: torch.Tensor, B: torch.Tensor):
 
 # A: mxk:DT,  B: nxk:s8, scaleB: n:DT
 # return: mxn:DT
-def woqgemm_s8(A: torch.Tensor, B: torch.Tensor, scaleB: torch.Tensor, bias: torch.Tensor):
+def woqgemm_s8(
+    A: torch.Tensor, B: torch.Tensor, scaleB: torch.Tensor, bias: torch.Tensor
+):
     m = A.shape[0]
     n = B.shape[0]
     k = B.shape[1]
@@ -294,7 +312,9 @@ def woqgemm(
     scale_type,
     asym,
 ):
-    _validate_packed_blob(B, n, k, groupsize, compute_type, weight_type, scale_type, asym)
+    _validate_packed_blob(
+        B, n, k, groupsize, compute_type, weight_type, scale_type, asym
+    )
     m = A.shape[0]
     lib = get_lib(A)
     ct = cvtstr_dtype(compute_type)
@@ -375,10 +395,15 @@ def _validate_packed_blob(
         "fp8_e5m2",
         "fp8_e8m0",
     }
-    if compute_type not in valid_types:
-        raise ValueError(f"compute_type must be one of {valid_types}, got {compute_type!r}")
+    valid_compute_types = valid_types | {"auto"}
+    if compute_type not in valid_compute_types:
+        raise ValueError(
+            f"compute_type must be one of {valid_compute_types}, got {compute_type!r}"
+        )
     if weight_type not in valid_types:
-        raise ValueError(f"weight_type must be one of {valid_types}, got {weight_type!r}")
+        raise ValueError(
+            f"weight_type must be one of {valid_types}, got {weight_type!r}"
+        )
     if scale_type not in valid_types:
         raise ValueError(f"scale_type must be one of {valid_types}, got {scale_type!r}")
 
@@ -440,7 +465,9 @@ def _unpack_weight_core(
     scale_type,
     asym,
 ):
-    _validate_packed_blob(blob, n, k, groupsize, compute_type, weight_type, scale_type, asym)
+    _validate_packed_blob(
+        blob, n, k, groupsize, compute_type, weight_type, scale_type, asym
+    )
     lib = get_lib(blob)
     stream = get_stream(blob)
     ct = cvtstr_dtype(compute_type)
@@ -497,11 +524,17 @@ def sdpa(
     if query.dtype not in (torch.float16, torch.bfloat16):
         raise ValueError(f"Q must be float16 or bfloat16, got {query.dtype}")
     if key.dtype != query.dtype or value.dtype != query.dtype:
-        raise ValueError(f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}")
+        raise ValueError(
+            f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}"
+        )
 
     B, Hq, Sq, D = _validate_attention_tensor(query, "Q", tensor_layout)
-    Bk, Hkv, Skv, Dk = _validate_attention_tensor(key, "K", tensor_layout, expected_dtype=query.dtype)
-    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(value, "V", tensor_layout, expected_dtype=query.dtype)
+    Bk, Hkv, Skv, Dk = _validate_attention_tensor(
+        key, "K", tensor_layout, expected_dtype=query.dtype
+    )
+    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(
+        value, "V", tensor_layout, expected_dtype=query.dtype
+    )
 
     if Bk != B or Bv != B:
         raise ValueError("Batch size mismatch between Q/K/V")
@@ -513,7 +546,9 @@ def sdpa(
         raise ValueError(f"Unsupported head_dim={D}; supported: 64, 128, 96, 192")
 
     if dropout_p != 0.0:
-        raise NotImplementedError(f"dropout_p must be 0.0 (got {dropout_p}); dropout is not supported")
+        raise NotImplementedError(
+            f"dropout_p must be 0.0 (got {dropout_p}); dropout is not supported"
+        )
 
     if attn_mask is not None:
         if attn_mask.device.type != "xpu":
@@ -521,10 +556,14 @@ def sdpa(
         if not attn_mask.is_contiguous():
             raise ValueError("attn_mask must be contiguous")
         if attn_mask.dtype != torch.float32:
-            raise ValueError(f"attn_mask must be float32 (additive bias), got {attn_mask.dtype}")
+            raise ValueError(
+                f"attn_mask must be float32 (additive bias), got {attn_mask.dtype}"
+            )
         expected_mask_shape = (B, 1, Sq, Skv)
         if attn_mask.shape != expected_mask_shape:
-            raise ValueError(f"attn_mask shape must be {expected_mask_shape}, got {tuple(attn_mask.shape)}")
+            raise ValueError(
+                f"attn_mask shape must be {expected_mask_shape}, got {tuple(attn_mask.shape)}"
+            )
 
     lib = get_lib(query)
     stream = get_stream(query)
@@ -691,8 +730,14 @@ def sage_pvi8(
     """
     if query.device.type != "xpu":
         raise NotImplementedError("sage_pvi8 is only supported on XPU")
-    if query.dtype != torch.int8 or key.dtype != torch.int8 or value.dtype != torch.int8:
-        raise ValueError(f"Q/K/V must be int8, got Q={query.dtype}, K={key.dtype}, V={value.dtype}")
+    if (
+        query.dtype != torch.int8
+        or key.dtype != torch.int8
+        or value.dtype != torch.int8
+    ):
+        raise ValueError(
+            f"Q/K/V must be int8, got Q={query.dtype}, K={key.dtype}, V={value.dtype}"
+        )
     if out_dtype != torch.float16:
         raise ValueError(f"sage_pvi8 output must be float16, got {out_dtype}")
     if qscale is None or kscale is None or vscale is None:
@@ -813,11 +858,17 @@ def sagev1(
     if query.dtype not in (torch.float16, torch.bfloat16):
         raise ValueError(f"Q must be float16 or bfloat16, got {query.dtype}")
     if key.dtype != query.dtype or value.dtype != query.dtype:
-        raise ValueError(f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}")
+        raise ValueError(
+            f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}"
+        )
 
     B, Hq, Sq, D = _validate_attention_tensor(query, "Q", tensor_layout)
-    Bk, Hkv, Skv, Dk = _validate_attention_tensor(key, "K", tensor_layout, expected_dtype=query.dtype)
-    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(value, "V", tensor_layout, expected_dtype=query.dtype)
+    Bk, Hkv, Skv, Dk = _validate_attention_tensor(
+        key, "K", tensor_layout, expected_dtype=query.dtype
+    )
+    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(
+        value, "V", tensor_layout, expected_dtype=query.dtype
+    )
 
     if Bk != B or Bv != B:
         raise ValueError("Batch size mismatch between Q/K/V")
@@ -904,11 +955,17 @@ def sagev1_pvi8(
     if query.dtype not in (torch.float16, torch.bfloat16):
         raise ValueError(f"Q must be float16 or bfloat16, got {query.dtype}")
     if key.dtype != query.dtype or value.dtype != query.dtype:
-        raise ValueError(f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}")
+        raise ValueError(
+            f"K/V dtype must match Q dtype, got K={key.dtype}, V={value.dtype}, Q={query.dtype}"
+        )
 
     B, Hq, Sq, D = _validate_attention_tensor(query, "Q", tensor_layout)
-    Bk, Hkv, Skv, Dk = _validate_attention_tensor(key, "K", tensor_layout, expected_dtype=query.dtype)
-    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(value, "V", tensor_layout, expected_dtype=query.dtype)
+    Bk, Hkv, Skv, Dk = _validate_attention_tensor(
+        key, "K", tensor_layout, expected_dtype=query.dtype
+    )
+    Bv, Hkv2, Skv2, Dv = _validate_attention_tensor(
+        value, "V", tensor_layout, expected_dtype=query.dtype
+    )
 
     if Bk != B or Bv != B:
         raise ValueError("Batch size mismatch between Q/K/V")
@@ -1000,7 +1057,9 @@ def sageattn(
     elif kernel == "v1_pvi8":
         impl = sagev1_pvi8
     else:
-        raise ValueError(f"Unsupported sageattn kernel={kernel!r}; supported: 'v1_pvhalf', 'v1_pvi8'")
+        raise ValueError(
+            f"Unsupported sageattn kernel={kernel!r}; supported: 'v1_pvhalf', 'v1_pvi8'"
+        )
 
     return impl(
         query=q,
@@ -1167,7 +1226,9 @@ def moe_gemm(
         raise ValueError("weights dtype must match activations dtype")
 
     if activations.ndim != 2 or weights.ndim != 3:
-        raise ValueError("activations must be 2D [total_tokens, K], weights must be 3D [num_experts, K, N]")
+        raise ValueError(
+            "activations must be 2D [total_tokens, K], weights must be 3D [num_experts, K, N]"
+        )
 
     if not activations.is_contiguous() or not weights.is_contiguous():
         raise ValueError("activations and weights must be contiguous")
@@ -1185,16 +1246,22 @@ def moe_gemm(
         raise ValueError(f"K dimension mismatch: activations K={K}, weights K={K_w}")
 
     if num_tokens_per_expert.shape[0] != num_experts:
-        raise ValueError(f"num_tokens_per_expert length {num_tokens_per_expert.shape[0]} != num_experts {num_experts}")
+        raise ValueError(
+            f"num_tokens_per_expert length {num_tokens_per_expert.shape[0]} != num_experts {num_experts}"
+        )
 
     # Validate total tokens
     expected_total = int(num_tokens_per_expert.sum().item())
     if expected_total != total_tokens:
-        raise ValueError(f"Sum of num_tokens_per_expert ({expected_total}) != total_tokens ({total_tokens})")
+        raise ValueError(
+            f"Sum of num_tokens_per_expert ({expected_total}) != total_tokens ({total_tokens})"
+        )
 
     lib = get_lib(activations)
     stream = get_stream(activations)
-    outputs = torch.empty((total_tokens, N), device=activations.device, dtype=activations.dtype)
+    outputs = torch.empty(
+        (total_tokens, N), device=activations.device, dtype=activations.dtype
+    )
 
     scales_ptr = scales.data_ptr() if scales is not None else 0
 
@@ -1274,14 +1341,19 @@ def repack_quantized_weight(*args, **kwargs):
         else:
             weight_type, compute_type = a4, a5
     else:
-        raise TypeError("repack_quantized_weight() expects 8 or 9 positional arguments; " f"got {len(args)}")
+        raise TypeError(
+            "repack_quantized_weight() expects 8 or 9 positional arguments; "
+            f"got {len(args)}"
+        )
 
     # Some native paths may still expect a valid zp pointer even when asym=False.
     if (zp is None) or (isinstance(zp, torch.Tensor) and zp.numel() == 0):
         if not bool(asym):
             k = QB.shape[0]
             n = QB.shape[1]
-            zp = torch.zeros((k // int(groupsize), n), dtype=torch.int8, device=QB.device)
+            zp = torch.zeros(
+                (k // int(groupsize), n), dtype=torch.int8, device=QB.device
+            )
         else:
             zp = torch.empty(0, dtype=torch.int8, device=QB.device)
 
@@ -1308,10 +1380,14 @@ def unpack_weight(
     scale_type,
     asym,
 ):
-    return _unpack_weight_core(blob, out_dtype, n, k, groupsize, compute_type, weight_type, scale_type, asym)
+    return _unpack_weight_core(
+        blob, out_dtype, n, k, groupsize, compute_type, weight_type, scale_type, asym
+    )
 
 
-def packed_weight_size(A: torch.Tensor, n, k, groupsize, compute_type, weight_type, scale_type, asym):
+def packed_weight_size(
+    A: torch.Tensor, n, k, groupsize, compute_type, weight_type, scale_type, asym
+):
     # Keep signature convenient for Python callers; native library needs a stream.
     lib = get_lib(A)
     stream = get_stream(A)
@@ -1369,7 +1445,11 @@ if __name__ == "__main__":
         else:
             A = torch.rand(m, k, dtype=dt, device=device) - 0.5
             B = torch.rand(k, n, dtype=dt, device=device) - 0.5
-            bias = torch.rand(1, n, dtype=dt, device=device) if has_bias else torch.empty(0)
+            bias = (
+                torch.rand(1, n, dtype=dt, device=device)
+                if has_bias
+                else torch.empty(0)
+            )
             C = matmul(A, B, bias)
         ref = torch.matmul(A, B.T)
         if has_bias:
@@ -1403,7 +1483,9 @@ if __name__ == "__main__":
         B = torch.randint(-8, 7, (k, n), dtype=torch.int8, device=device)
         zp = torch.randint(-8, 7, (k // groupsize, n), dtype=torch.int8, device=device)
         scaleB = torch.rand(k // groupsize, n, dtype=dt, device=device) / 100
-        blob = repack_quantized_weight(B, scaleB, zp, groupsize, "fp32", "int4", "fp32", False)
+        blob = repack_quantized_weight(
+            B, scaleB, zp, groupsize, "fp32", "int4", "fp32", False
+        )
         dq = unpack_weight(blob, dt, n, k, groupsize, "fp32", "int4", "fp32", False)
         print(blob, dq)
         scale_re = scaleB.repeat_interleave(repeats=groupsize, dim=0).to(dt)

--- a/auto_round_extension/ark/auto_round_kernel/__init__.py
+++ b/auto_round_extension/ark/auto_round_kernel/__init__.py
@@ -294,6 +294,7 @@ def woqgemm(
     scale_type,
     asym,
 ):
+    _validate_packed_blob(B, n, k, groupsize, compute_type, weight_type, scale_type, asym)
     m = A.shape[0]
     lib = get_lib(A)
     ct = cvtstr_dtype(compute_type)
@@ -316,8 +317,63 @@ def woqgemm(
         wt,
         st,
         asym,
+        B.numel(),
     )
     return C
+
+
+def _validate_packed_blob(
+    blob: torch.Tensor,
+    n: int,
+    k: int,
+    groupsize: int,
+    compute_type: str,
+    weight_type: str,
+    scale_type: str,
+    asym: bool,
+) -> None:
+    """Validate a packed-weight blob before passing it to native code.
+
+    Raises ``TypeError`` or ``ValueError`` if any check fails, preventing
+    out-of-bounds memory access in the native ``unpack_weight`` /
+    ``woqgemm`` path when the blob is malformed or the parameters are
+    inconsistent with the blob contents.
+    """
+    if not isinstance(blob, torch.Tensor):
+        raise TypeError(f"blob must be a torch.Tensor, got {type(blob).__name__}")
+
+    if blob.device.type not in ("cpu", "xpu"):
+        raise ValueError(
+            f"blob must reside on cpu or xpu, got {blob.device.type}"
+        )
+
+    if blob.dtype != torch.int8:
+        raise ValueError(
+            f"blob must have dtype torch.int8, got {blob.dtype}"
+        )
+
+    if blob.dim() != 1:
+        raise ValueError(
+            f"blob must be a 1-D tensor, got {blob.dim()}-D"
+        )
+
+    if not isinstance(n, (int,)) or n <= 0:
+        raise ValueError(f"n must be a positive integer, got {n!r}")
+    if not isinstance(k, (int,)) or k <= 0:
+        raise ValueError(f"k must be a positive integer, got {k!r}")
+    if not isinstance(groupsize, (int,)) or groupsize <= 0:
+        raise ValueError(f"groupsize must be a positive integer, got {groupsize!r}")
+    if not isinstance(asym, bool):
+        raise TypeError(f"asym must be a bool, got {type(asym).__name__}")
+
+    valid_types = {"fp32", "fp16", "bf16", "int8", "int4", "int2", "int3",
+                   "int5", "int6", "int7", "fp8_e4m3", "fp8_e5m2", "fp8_e8m0"}
+    if compute_type not in valid_types:
+        raise ValueError(f"compute_type must be one of {valid_types}, got {compute_type!r}")
+    if weight_type not in valid_types:
+        raise ValueError(f"weight_type must be one of {valid_types}, got {weight_type!r}")
+    if scale_type not in valid_types:
+        raise ValueError(f"scale_type must be one of {valid_types}, got {scale_type!r}")
 
 
 # QB: k*n:int8,  scaleB: k/blocksize*n:DT
@@ -332,6 +388,12 @@ def _repack_quantized_weight_core(
     scale_type,
     asym,
 ):
+    if not isinstance(QB, torch.Tensor) or QB.dim() != 2:
+        raise ValueError(f"QB must be a 2-D tensor, got shape {QB.shape!r}")
+    if not isinstance(scaleB, torch.Tensor) or scaleB.dim() != 2:
+        raise ValueError(f"scaleB must be a 2-D tensor, got shape {scaleB.shape!r}")
+    if not isinstance(zp, torch.Tensor):
+        raise TypeError(f"zp must be a torch.Tensor, got {type(zp).__name__}")
     k = QB.shape[0]
     n = QB.shape[1]
     lib = get_lib(QB)
@@ -371,6 +433,7 @@ def _unpack_weight_core(
     scale_type,
     asym,
 ):
+    _validate_packed_blob(blob, n, k, groupsize, compute_type, weight_type, scale_type, asym)
     lib = get_lib(blob)
     stream = get_stream(blob)
     ct = cvtstr_dtype(compute_type)
@@ -391,6 +454,7 @@ def _unpack_weight_core(
         wt,
         st,
         asym,
+        blob.numel(),
     )
     if blob.device.type == "cpu":
         return out.T

--- a/auto_round_extension/ark/auto_round_kernel/ark.cpp
+++ b/auto_round_extension/ark/auto_round_kernel/ark.cpp
@@ -55,13 +55,15 @@ static void woqgemm_s8(torch_ptr stream, int m, int n, int k, torch_ptr A, int A
 }
 
 static void woqgemm(torch_ptr stream, int m, int n, int k, torch_ptr A, int ACdt, torch_ptr BlobB, torch_ptr C,
-                    torch_ptr bias, int blocksize, int compute_type, int weight_type, int scale_type, bool asym) {
+                    torch_ptr bias, int blocksize, int compute_type, int weight_type, int scale_type, bool asym,
+                    int blob_numel = 0) {
   QuantParam param{n, k, blocksize, compute_type, weight_type, scale_type, asym};
+  size_t bc = static_cast<size_t>(blob_numel);
 #ifdef ARK_XPU
   XpuWrapper::woq_gemm(m, (void*)A, (void*)BlobB, (void*)C, (void*)bias, (BTLA_DTYPE)ACdt, &param,
-                       (sycl::queue*)stream);
+                       (sycl::queue*)stream, bc);
 #else
-  CpuWrapper::woq_gemm(m, (void*)A, (void*)BlobB, (void*)C, (void*)bias, (BTLA_DTYPE)ACdt, &param);
+  CpuWrapper::woq_gemm(m, (void*)A, (void*)BlobB, (void*)C, (void*)bias, (BTLA_DTYPE)ACdt, &param, bc);
 #endif
 }
 
@@ -77,12 +79,13 @@ static void repack_quantized_weight(torch_ptr stream, torch_ptr raws8, torch_ptr
 }
 
 static void unpack_weight(torch_ptr stream, torch_ptr blob, torch_ptr output, int out_type, int n, int k, int blocksize,
-                          int compute_type, int weight_type, int scale_type, bool asym) {
+                          int compute_type, int weight_type, int scale_type, bool asym, int blob_numel = 0) {
   QuantParam param{n, k, blocksize, compute_type, weight_type, scale_type, asym};
+  size_t bc = static_cast<size_t>(blob_numel);
 #ifdef ARK_XPU
-  XpuWrapper::unpackq((BTLA_DTYPE)out_type, (int8_t*)blob, (void*)output, &param, (sycl::queue*)stream);
+  XpuWrapper::unpackq((BTLA_DTYPE)out_type, (int8_t*)blob, (void*)output, &param, (sycl::queue*)stream, bc);
 #else
-  CpuWrapper::unpackq((BTLA_DTYPE)out_type, (int8_t*)blob, (void*)output, &param);
+  CpuWrapper::unpackq((BTLA_DTYPE)out_type, (int8_t*)blob, (void*)output, &param, bc);
 #endif
 }
 

--- a/auto_round_extension/ark/auto_round_kernel/wrapper/include/cpu_wrapper.hpp
+++ b/auto_round_extension/ark/auto_round_kernel/wrapper/include/cpu_wrapper.hpp
@@ -348,6 +348,9 @@ static inline void _validate_storage_weight(const storage::gemm::StorageWeightNI
   }
 }
 
+// Forward declaration for the 4-arg overload used by the 3-arg compatibility wrapper.
+static inline void BTLAGemmUnpack(void* B, float* DQB, void* ThreadPool, size_t blob_count);
+
 static inline void BTLAGemmUnpack(void* B, float* DQB, void* ThreadPool) {
   BTLAGemmUnpack(B, DQB, ThreadPool, 0);
 }

--- a/auto_round_extension/ark/auto_round_kernel/wrapper/include/cpu_wrapper.hpp
+++ b/auto_round_extension/ark/auto_round_kernel/wrapper/include/cpu_wrapper.hpp
@@ -291,7 +291,68 @@ static inline void BTLAGemmPackQB(void* PackedBuf, const int8_t* QB, const float
   }
 }
 
+/// Validate a deserialized StorageWeightNInt to guard against corrupted metadata.
+/// Throws std::runtime_error if any field is inconsistent or out of bounds.
+static inline void _validate_storage_weight(const storage::gemm::StorageWeightNInt& stor,
+                                            size_t blob_count) {
+  using namespace bestla;
+  // --- dimension sanity --------------------------------------------------
+  if (stor.info_.n_ <= 0) {
+    throw std::runtime_error("Corrupt packed weight: n must be positive");
+  }
+  if (stor.info_.k_ <= 0) {
+    throw std::runtime_error("Corrupt packed weight: k must be positive");
+  }
+  constexpr int MAX_DIM = 1 << 24;  // 16M — far beyond any realistic matrix
+  if (stor.info_.n_ > MAX_DIM || stor.info_.k_ > MAX_DIM) {
+    throw std::runtime_error("Corrupt packed weight: dimensions exceed sane maximum");
+  }
+  if (stor.info_.npad_ < stor.info_.n_) {
+    throw std::runtime_error("Corrupt packed weight: npad < n");
+  }
+  if (stor.info_.kpad_ < stor.info_.k_) {
+    throw std::runtime_error("Corrupt packed weight: kpad < k");
+  }
+  if (stor.info_.npad_ > MAX_DIM || stor.info_.kpad_ > MAX_DIM) {
+    throw std::runtime_error("Corrupt packed weight: padded dimensions exceed sane maximum");
+  }
+
+  // --- block size ---------------------------------------------------------
+  if (stor.block_ <= 0) {
+    throw std::runtime_error("Corrupt packed weight: block size must be positive");
+  }
+  if (stor.block_ > stor.info_.k_) {
+    throw std::runtime_error("Corrupt packed weight: block size > k");
+  }
+  int expected_nblk = (stor.info_.kpad_ + stor.block_ - 1) / stor.block_;
+  if (stor.n_block_ != expected_nblk) {
+    throw std::runtime_error("Corrupt packed weight: n_block inconsistent with kpad/block");
+  }
+
+  // --- layout -------------------------------------------------------------
+  if (stor.info_.layout_ != storage::gemm::Layout::NPack) {
+    throw std::runtime_error("Corrupt packed weight: expected NPack layout");
+  }
+
+  // --- buffer sizes against available data --------------------------------
+  if (blob_count > 0) {
+    // The serialised header sits at the start of the blob; data_ptr points
+    // right after the header (offset = misc_size_ bytes from start).
+    // After set_buffers the data occupies stor.buf_size_ bytes.
+    auto off = stor.misc_size_;
+    if (off + stor.buf_size_ > blob_count) {
+      throw std::runtime_error("Corrupt packed weight: declared data size exceeds blob size (" +
+                               std::to_string(off) + " + " + std::to_string(stor.buf_size_) + " > " +
+                               std::to_string(blob_count) + ")");
+    }
+  }
+}
+
 static inline void BTLAGemmUnpack(void* B, float* DQB, void* ThreadPool) {
+  BTLAGemmUnpack(B, DQB, ThreadPool, 0);
+}
+
+static inline void BTLAGemmUnpack(void* B, float* DQB, void* ThreadPool, size_t blob_count) {
   GetCPUDevice();
   using namespace bestla;
   auto prologue = storage::CollectionParser::parse_prologue_id(B);
@@ -300,6 +361,8 @@ static inline void BTLAGemmUnpack(void* B, float* DQB, void* ThreadPool) {
       auto stor_ptr = (int8_t*)(B);
       storage::gemm::StorageWeightNInt stor;
       auto data_ptr = stor.deserialize(stor_ptr);
+      // Validate deserialised metadata BEFORE calling set_buffers().
+      _validate_storage_weight(stor, blob_count);
       stor.set_buffers(data_ptr);
       auto& id = stor.info_.core_id_;
       if (id == tAVX512_VNNI::ID) {
@@ -436,7 +499,8 @@ static inline size_t BTLAGemmNPackBSize(int N, int K, BTLA_DTYPE dt) {
   return 0;
 }
 
-static inline size_t BTLAWOQGemmForwardWorkspace(void* B, int M, int N, int K, int lda, int ldc) {
+static inline size_t BTLAWOQGemmForwardWorkspace(void* B, int M, int N, int K, int lda, int ldc,
+                                                size_t blob_count = 0) {
   GetCPUDevice();
   using namespace bestla;
   auto prologue = storage::CollectionParser::parse_prologue_id(B);
@@ -445,6 +509,7 @@ static inline size_t BTLAWOQGemmForwardWorkspace(void* B, int M, int N, int K, i
       storage::gemm::StorageWeightNInt stor;
       auto stor_ptr = (int8_t*)(B);
       auto data_ptr = stor.deserialize(stor_ptr);
+      _validate_storage_weight(stor, blob_count);
       stor.set_buffers(data_ptr);
       auto& id = stor.info_.core_id_;
       if (id == tAVX512_VNNI_KBlock::ID) {
@@ -478,7 +543,8 @@ static inline size_t BTLAWOQGemmForwardWorkspace(void* B, int M, int N, int K, i
 }
 
 static inline void BTLAWOQGemmFp32Forward(void* B, const float* A, float* C, const float* bias, int M, int N, int K,
-                                          int lda, int ldc, void* ws_ptr, parallel::IThreading* ThreadPool) {
+                                          int lda, int ldc, void* ws_ptr, parallel::IThreading* ThreadPool,
+                                          size_t blob_count = 0) {
   GetCPUDevice();
   using namespace bestla;
   auto prologue = storage::CollectionParser::parse_prologue_id(B);
@@ -487,6 +553,7 @@ static inline void BTLAWOQGemmFp32Forward(void* B, const float* A, float* C, con
       auto stor_ptr = (int8_t*)(B);
       storage::gemm::StorageWeightNInt stor;
       auto data_ptr = stor.deserialize(stor_ptr);
+      _validate_storage_weight(stor, blob_count);
       stor.set_buffers(data_ptr);
       auto& id = stor.info_.core_id_;
       if (id == tAVX512_VNNI::ID) {
@@ -536,9 +603,9 @@ class CpuWrapper {
     bestla::BTLAGemmPackQB(blob, raws8, scaleptr, p->asym ? zp : nullptr, coreid, p, get_threading());
   }
 
-  static void unpackq(BTLA_DTYPE outt, int8_t* blob, void* optr, QuantParam* p) {
+  static void unpackq(BTLA_DTYPE outt, int8_t* blob, void* optr, QuantParam* p, size_t blob_count = 0) {
     assert(outt == BTLA_DTYPE::F32);
-    bestla::BTLAGemmUnpack(blob, (float*)optr, get_threading());
+    bestla::BTLAGemmUnpack(blob, (float*)optr, get_threading(), blob_count);
   }
 
   static void gemm(int m, int n, int k, const void* A, BTLA_DTYPE dt, const void* B, bool BT, float* C,
@@ -558,11 +625,12 @@ class CpuWrapper {
     bestla::BTLAGemmNPackBForward(dt, A, bptr, C, bias, m, n, k, k, n, packwptr, thd);
   }
 
-  static void woq_gemm(int m, const void* a, const void* b, void* c, const void* bias, BTLA_DTYPE acdt, QuantParam* p) {
-    auto wssize = bestla::BTLAWOQGemmForwardWorkspace((void*)b, m, p->n, p->k, p->k, p->n);
+  static void woq_gemm(int m, const void* a, const void* b, void* c, const void* bias, BTLA_DTYPE acdt, QuantParam* p,
+                       size_t blob_count = 0) {
+    auto wssize = bestla::BTLAWOQGemmForwardWorkspace((void*)b, m, p->n, p->k, p->k, p->n, blob_count);
     auto ptr = DnnlContext::Instance()->get_scratch_mem(wssize, 0, nullptr);
     bestla::BTLAWOQGemmFp32Forward((void*)b, (const float*)a, (float*)c, (const float*)bias, m, p->n, p->k, p->k, p->n,
-                                   ptr, get_threading());
+                                   ptr, get_threading(), blob_count);
   }
 };
 

--- a/auto_round_extension/ark/auto_round_kernel/wrapper/include/xpu_wrapper.hpp
+++ b/auto_round_extension/ark/auto_round_kernel/wrapper/include/xpu_wrapper.hpp
@@ -343,7 +343,15 @@ class XpuWrapper {
     packzp(zpptr, blob, p, q);
   }
 
-  static void unpackq(BTLA_DTYPE outt, int8_t* blob, void* optr, QuantParam* p, sycl::queue* q) {
+  static void unpackq(BTLA_DTYPE outt, int8_t* blob, void* optr, QuantParam* p, sycl::queue* q,
+                      size_t blob_count = 0) {
+    if (blob_count > 0) {
+      auto expected = get_packw_size(p);
+      if (blob_count < expected) {
+        throw std::runtime_error("Corrupt packed weight: blob size (" + std::to_string(blob_count) +
+                                 ") less than expected (" + std::to_string(expected) + ")");
+      }
+    }
     using namespace bestla;
     using namespace bestla::sycl_prologue_b;
     auto qptr = (uint8_t*)blob;
@@ -678,7 +686,14 @@ class XpuWrapper {
   }
 
   static void woq_gemm(int m, const void* a, const void* b, void* c, const void* bias, BTLA_DTYPE acdt, QuantParam* p,
-                       sycl::queue* q) {
+                       sycl::queue* q, size_t blob_count = 0) {
+    if (blob_count > 0) {
+      auto expected = get_packw_size(p);
+      if (blob_count < expected) {
+        throw std::runtime_error("Corrupt packed weight: blob size (" + std::to_string(blob_count) +
+                                 ") less than expected (" + std::to_string(expected) + ")");
+      }
+    }
     auto ret = woq_gemv(q, m, p, a, b, c, bias, acdt);
     if (ret) {
       auto dnnl_dt = to_dt(acdt);


### PR DESCRIPTION
## Summary

Add C++-level validation after BestLA blob deserialization to reject corrupted/metadata-tampered packed-weight blobs before they can cause out-of-bounds memory access (SIGSEGV).

## Background

A vulnerability was reported where a malformed packed weight blob (e.g., one byte flipped at offset 64) causes a segmentation fault in `auto_round_kernel.unpack_weight()`. The BestLA packed format embeds metadata (dimensions, block size, buffer offsets, etc.) in the blob itself. If those fields are corrupted, the deserialized pointers become invalid, leading to out-of-bounds reads.

## Changes

### `cpu_wrapper.hpp` — CPU (BestLA) path
- Added `_validate_storage_weight()` that validates all deserialized metadata before `set_buffers()`:
  - `n, k > 0` and `≤ 16M`
  - `npad ≥ n, kpad ≥ k`
  - `block > 0` and `block ≤ k`
  - `n_block` consistent with `kpad / block`
  - Layout must be `NPack`
  - `misc_size + buf_size ≤ blob_count` (if available)
- Called in `BTLAGemmUnpack`, `BTLAWOQGemmForwardWorkspace`, `BTLAWOQGemmFp32Forward`.

### `xpu_wrapper.hpp` — XPU path
- `unpackq()` and `woq_gemm()` validate `blob_count ≥ get_packw_size()`.

### `ark.cpp` — Binding layer
- `unpack_weight()` and `woqgemm()` accept and forward `blob_numel`.

### `__init__.py` — Python API
- Added `_validate_packed_blob()` for parameter type validation.
- `_unpack_weight_core()` and `woqgemm()` pass `blob.numel()` / `B.numel()` to native calls.
- `_repack_quantized_weight_core()` validates input tensor shapes.
