### PR TITLE
Adapt the latest sglang integration test Engine kwargs.

### DIFF
--- a/test/test_cuda/integrations/test_sglang.py
+++ b/test/test_cuda/integrations/test_sglang.py
@@ -1,5 +1,5 @@
-import gc
 import dataclasses
+import gc
 import json
 import multiprocessing.resource_tracker
 import shutil

--- a/test/test_cuda/integrations/test_sglang.py
+++ b/test/test_cuda/integrations/test_sglang.py
@@ -1,4 +1,5 @@
 import gc
+import dataclasses
 import json
 import multiprocessing.resource_tracker
 import shutil
@@ -64,9 +65,27 @@ class TestAutoRound:
                         )
             except Exception:
                 pass
-        llm = sgl.Engine(
-            model_path=str(model_path), mem_fraction_static=0.5, disable_piecewise_cuda_graph=True, cuda_graph_bs=[1]
-        )
+
+        def _server_arg_fields():
+            try:
+                from sglang.srt.server_args import ServerArgs
+
+                return {f.name for f in dataclasses.fields(ServerArgs)}
+            except Exception:
+                return set()
+
+        engine_kwargs = {"model_path": str(model_path), "mem_fraction_static": 0.5}
+        fields = _server_arg_fields()
+        if "disable_piecewise_cuda_graph" in fields:
+            engine_kwargs["disable_piecewise_cuda_graph"] = True
+            if "cuda_graph_bs" in fields:
+                engine_kwargs["cuda_graph_bs"] = [1]
+        elif "disable_cuda_graph" in fields:
+            engine_kwargs["disable_cuda_graph"] = True
+            if "cuda_graph_bs_decode" in fields:
+                engine_kwargs["cuda_graph_bs_decode"] = [1]
+
+        llm = sgl.Engine(**engine_kwargs)
         try:
             prompts = ["Hello, my name is"]
             sampling_params = {"temperature": 0.6, "top_p": 0.95}


### PR DESCRIPTION
## Description

Root cause: sglang 0.5.14 removed legacy Engine/ServerArgs kwargs (disable_piecewise_cuda_graph, cuda_graph_bs) in favor of the new CUDA graph config fields, so the old test arguments became invalid.

I improved ut as following.

- Fix sglang integration test by adapting Engine kwargs to ServerArgs changes in newer sglang.
- Use legacy args when available, otherwise fall back to new args (disable_cuda_graph / cuda_graph_bs_decode).
- Keeps backward compatibility and restores test_ar_format_sglang on sglang 0.5.14.


## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

https://github.com/intel/auto-round/issues/1961
<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
