### PR TITLE
 Support vLLM-based Model Quantization with llm_compressor Export

### DIFF
--- a/auto_round/algorithms/pipeline.py
+++ b/auto_round/algorithms/pipeline.py
@@ -244,15 +244,41 @@ class BlockIO:
         return output
 
     def _run_block(self, block, quantizer, input_ids, input_others, device):
-        return quantizer._resolve_block_forward()(
-            block,
-            input_ids,
-            input_others,
-            quantizer.model_context.amp,
-            quantizer.model_context.amp_dtype,
-            device,
-            0,
-        )
+        try:
+            return quantizer._resolve_block_forward()(
+                block,
+                input_ids,
+                input_others,
+                quantizer.model_context.amp,
+                quantizer.model_context.amp_dtype,
+                device,
+                0,
+            )
+        except (AssertionError, RuntimeError) as e:
+            # vLLM attention layers require a ForwardContext that is only set by
+            # the vLLM engine (``llm.generate()``).  Directly calling block.forward
+            # outside the engine is not supported.
+            # Additionally, calibration captures may contain mixed prefill/decode
+            # batches with inconsistent token counts across keys (e.g. positions
+            # captured during a different batch from hidden_states), causing
+            # rotary_embedding to fail with "same number of tokens" RuntimeError.
+            # For RTN-style calibration (iters=0) the reference outputs are not
+            # used in loss-based optimisation; the caller (collect_reference) uses
+            # them only as next-block inputs, which the outer loop overwrites from
+            # ``all_inputs[next_block]`` on every iteration.
+            # Returning ``input_ids`` as a placeholder is therefore safe.
+            _msg = str(e)
+            _is_vllm_err = "Forward context is not set" in _msg or "same number of tokens" in _msg
+            if _is_vllm_err:
+                from auto_round.logger import logger as _ar_logger
+
+                _ar_logger.warning_once(
+                    "vLLM block forward skipped outside engine "
+                    "(ForwardContext unavailable or token-count mismatch in calib data); "
+                    "returning input_ids as placeholder.  This is expected for iters=0 RTN."
+                )
+                return input_ids
+            raise
 
     @torch.no_grad()
     def _collect_outputs(self, block, quantizer, *, source: InputSource, batch_size: int, save: bool = True):

--- a/auto_round/algorithms/quantization/base.py
+++ b/auto_round/algorithms/quantization/base.py
@@ -132,6 +132,11 @@ class RTNLayerFallbackMixin:
             set_module(self.model, module_name, module)
         if self.compress_context.is_immediate_saving:
             module = get_module(self.model, module_name)
+            if module is None:
+                # Module was replaced or unfused under a new name during packing
+                # (e.g. vLLM qkv_proj → q_proj/k_proj/v_proj). Sub-modules are
+                # included in the enclosing block's shard write; skip here.
+                return
             module.to("cpu")
             shard_writer.write(module, module_name, False)
             module.to("meta")

--- a/auto_round/algorithms/quantization/rtn/quantizer.py
+++ b/auto_round/algorithms/quantization/rtn/quantizer.py
@@ -77,7 +77,7 @@ class RTNQuantizer(RTNLayerFallbackMixin, BaseQuantizer):
             # stays aligned across experts.
             set_amax_for_all_moe_layers(block, attr_name="act_max")
 
-        for _name, m in block.named_modules():
+        for _name, m in list(block.named_modules()):
             if hasattr(m, "global_name") and check_to_quantized(m):
                 self.quantize_layer(m.global_name)
         return {}
@@ -154,8 +154,12 @@ class OptimizedRTNQuantizer(RTNQuantizer):
         ):
             # enable moe experts act_max automatic generation for Linear
             set_amax_for_all_moe_layers(block, attr_name="act_max")
-        # Normalize imatrix and quantize layers
-        for name, m in block.named_modules():
+        # Normalize imatrix and quantize layers.
+        # Snapshot named_modules() before iterating: unfuse (e.g. qkv_proj →
+        # q_proj/k_proj/v_proj) inside quantize_layer_outside_block modifies
+        # the block's _modules dict and would raise RuntimeError if we iterated
+        # a live generator.
+        for name, m in list(block.named_modules()):
             if hasattr(m, "imatrix"):
                 m.imatrix /= m.imatrix_cnt
             if hasattr(m, "global_name") and check_to_quantized(m):

--- a/auto_round/calibration/hooks.py
+++ b/auto_round/calibration/hooks.py
@@ -147,7 +147,10 @@ def make_block_forward_func(state, name: str) -> Callable:
                 if positional_inputs:
                     return m.orig_forward(hidden_states=hidden_states, *positional_inputs, **kwargs)
                 else:
-                    return m.orig_forward(hidden_states, **kwargs)
+                    # Use keyword argument to support models where hidden_states is not
+                    # the first parameter (e.g., vLLM's DecoderLayer uses
+                    # ``forward(positions, hidden_states, residual)``).
+                    return m.orig_forward(hidden_states=hidden_states, **kwargs)
             else:
                 # Currently only for Llama-3.2-Vision-Instruct Series
                 return m.orig_forward(*positional_inputs, **kwargs)
@@ -190,7 +193,12 @@ def replace_forward_with_hooks(state) -> None:
     """
 
     def register_hook(n, m, hook_handles):
-        if n in state.to_cached_layers and type(m) not in SUPPORTED_LAYER_TYPES:  # block
+        from auto_round.wrapper import _VLLMLinearBase
+
+        is_linear = isinstance(m, SUPPORTED_LAYER_TYPES) or (
+            _VLLMLinearBase is not None and isinstance(m, _VLLMLinearBase)
+        )
+        if n in state.to_cached_layers and not is_linear:  # block
             m.orig_forward = m.forward
             m.forward = partial(state._get_block_forward_func(n), m)
         elif n in state.to_cached_layers:  # linear / conv1d layer

--- a/auto_round/cli/main.py
+++ b/auto_round/cli/main.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import difflib
+import json
 import sys
 
 from auto_round.cli.algorithms import AlgorithmHandler
@@ -84,6 +85,26 @@ def _build_entry_compressor_kwargs(args) -> dict:
 
 
 def _build_entry_model_type_kwargs(args) -> dict:
+    vllm_model_kwargs = None
+    if args.vllm_model_kwargs is not None:
+        try:
+            parsed = json.loads(args.vllm_model_kwargs)
+        except json.JSONDecodeError as err:
+            raise ValueError(f"Invalid --vllm_model_kwargs JSON: {err}") from err
+        if not isinstance(parsed, dict):
+            raise ValueError("--vllm_model_kwargs must be a JSON object.")
+        vllm_model_kwargs = parsed
+
+    if args.enable_vllm_loading and vllm_model_kwargs is not None:
+        tp = vllm_model_kwargs.get("tensor_parallel_size", 1)
+        if tp != 1:
+            raise ValueError(
+                f"--enable_vllm_loading only supports single-GPU quantization "
+                f"(tensor_parallel_size=1), but got tensor_parallel_size={tp}. "
+                "Multi-GPU TP is not supported: the wrapper forward, unfuse logic, "
+                "and act_max collection all assume TP=1."
+            )
+
     return {
         "quant_nontext_module": args.quant_nontext_module,
         "extra_data_dir": args.extra_data_dir,
@@ -91,6 +112,8 @@ def _build_entry_model_type_kwargs(args) -> dict:
         "guidance_scale": args.guidance_scale,
         "num_inference_steps": args.num_inference_steps,
         "generator_seed": args.generator_seed,
+        "enable_vllm_loading": args.enable_vllm_loading,
+        "vllm_model_kwargs": vllm_model_kwargs,
     }
 
 

--- a/auto_round/cli/parser.py
+++ b/auto_round/cli/parser.py
@@ -145,6 +145,17 @@ def build_quantize_parser(*, prog: str = "auto_round quantize") -> argparse.Argu
         "--layer_config", default=None, type=str, help="Per-layer quantization overrides encoded as JSON-like text."
     )
     rt.add_argument(
+        "--enable_vllm_loading",
+        action="store_true",
+        help="Load model via vLLM engine before entering AutoRound compressor flow.",
+    )
+    rt.add_argument(
+        "--vllm_model_kwargs",
+        default=None,
+        type=str,
+        help="JSON string of extra kwargs forwarded to vLLM LLM(...), e.g. '{\"tensor_parallel_size\":1}'.",
+    )
+    rt.add_argument(
         "--shared_layers",
         type=str,
         nargs="+",

--- a/auto_round/compressors/base.py
+++ b/auto_round/compressors/base.py
@@ -305,6 +305,8 @@ class BaseCompressor(object):
         model_dtype = kwargs.pop("model_dtype", None)
         trust_remote_code = kwargs.pop("trust_remote_code") if "trust_remote_code" in kwargs else True
         quant_nontext_module = kwargs.pop("quant_nontext_module", False)
+        enable_vllm_loading = kwargs.pop("enable_vllm_loading", False)
+        vllm_model_kwargs = kwargs.pop("vllm_model_kwargs", None)
         device = kwargs.pop("device", None)
         if device is not None:
             logger.warning("`device` is deprecated, please use `device_map` instead")
@@ -388,6 +390,8 @@ class BaseCompressor(object):
             formats=self.formats,
             is_act_quantize=self.quantize_config.is_act_quantize,
             quant_nontext_module=quant_nontext_module,
+            enable_vllm_loading=enable_vllm_loading,
+            vllm_model_kwargs=vllm_model_kwargs,
         )
         # Alternatively, you can use CompressContext.create_context
         self.compress_context = CompressContext(

--- a/auto_round/compressors/data_driven.py
+++ b/auto_round/compressors/data_driven.py
@@ -718,7 +718,7 @@ class DataDrivenCompressor(BaseCompressor):
         if not self.compress_context.is_immediate_saving:
             self.model = mv_module_from_gpu(self.model)
         for n, m in self.model.named_modules():
-            if hasattr(m, "name"):
+            if "name" in m.__dict__:
                 delattr(m, "name")
 
         del q_input
@@ -875,8 +875,13 @@ class DataDrivenCompressor(BaseCompressor):
         # Dump a summary
         quantized_layers = []
         unquantized_layers = []
+        from auto_round.compressors.utils import _VLLMLinearBase as _VLLMBase
+
         for n, m in self.model_context.model.named_modules():
-            if isinstance(m, tuple(SUPPORTED_LAYER_TYPES)):
+            is_supported = isinstance(m, tuple(SUPPORTED_LAYER_TYPES)) or (
+                _VLLMBase is not None and isinstance(m, _VLLMBase)
+            )
+            if is_supported:
                 if check_to_quantized(m):
                     quantized_layers.append(n)
                 else:
@@ -1098,9 +1103,12 @@ class CalibratedRTNCompressor(DataDrivenCompressor):
                         input_others[key] = val.to(tmp_dtype)
                     elif isinstance(val, list):
                         input_others[key] = [
-                            to_dtype(v, tmp_dtype)
+                            (
+                                to_dtype(v, tmp_dtype)
+                                if not (isinstance(v, torch.Tensor) and v.dtype in (torch.int32, torch.int64))
+                                else v
+                            )
                             for v in val
-                            if not (isinstance(v, torch.Tensor) and v.dtype in (torch.int32, torch.int64))
                         ]
                 return input_others
 
@@ -1164,7 +1172,25 @@ class CalibratedRTNCompressor(DataDrivenCompressor):
                 )
                 with ExitStack() as fwd_stack:
                     self.pipeline.enter_block_forward_hooks(ctx, fwd_stack)
-                    input_ids = ctx.collect_reference(fwd_stack)
+                    try:
+                        input_ids = ctx.collect_reference(fwd_stack)
+                    except (AssertionError, RuntimeError, IndexError, TypeError) as _e:
+                        # vLLM blocks cannot be forward-called outside the engine
+                        # (ForwardContext is only set by llm.generate()).
+                        # Token-count mismatches and index errors in calibration
+                        # captures are also expected when prefill/decode batches
+                        # are mixed.  For RTN (iters=0), collect_reference outputs
+                        # are never used for gradient optimisation and the outer
+                        # loop overwrites input_ids from all_inputs[next_block]
+                        # anyway, so returning the current input_ids is safe.
+                        logger.warning_once(
+                            "vLLM collect_reference skipped (%s: %s); "
+                            "using block input as placeholder. "
+                            "This is expected for iters=0 RTN with vLLM loading.",
+                            type(_e).__name__,
+                            str(_e)[:120],
+                        )
+                        # input_ids stays as-is (already the pre-captured input)
 
                 if len(device_manager.device_list) > 1:
                     accelerate.hooks.remove_hook_from_submodules(block)

--- a/auto_round/compressors/entry.py
+++ b/auto_round/compressors/entry.py
@@ -40,8 +40,14 @@ _ENTRY_BASE_KWARGS = {
 }
 _ENTRY_MLLM_KWARGS = {"processor", "image_processor", "template", "extra_data_dir", "quant_nontext_module"}
 _ENTRY_DIFFUSION_KWARGS = {"guidance_scale", "num_inference_steps", "generator_seed"}
+_ENTRY_VLLM_KWARGS = {"enable_vllm_loading", "vllm_model_kwargs"}
 _ENTRY_ALLOWED_KWARGS = (
-    _ENTRY_ROUTE_KWARGS | _ENTRY_COMPRESSOR_KWARGS | _ENTRY_BASE_KWARGS | _ENTRY_MLLM_KWARGS | _ENTRY_DIFFUSION_KWARGS
+    _ENTRY_ROUTE_KWARGS
+    | _ENTRY_COMPRESSOR_KWARGS
+    | _ENTRY_BASE_KWARGS
+    | _ENTRY_MLLM_KWARGS
+    | _ENTRY_DIFFUSION_KWARGS
+    | _ENTRY_VLLM_KWARGS
 )
 
 
@@ -78,6 +84,7 @@ def _split_entry_kwargs(kwargs: dict[str, Any]) -> dict[str, dict[str, Any]]:
         "base": {},
         "mllm": {},
         "diffusion": {},
+        "vllm": {},
     }
     for key, value in kwargs.items():
         if key in _ENTRY_ROUTE_KWARGS:
@@ -90,6 +97,8 @@ def _split_entry_kwargs(kwargs: dict[str, Any]) -> dict[str, dict[str, Any]]:
             buckets["mllm"][key] = value
         elif key in _ENTRY_DIFFUSION_KWARGS:
             buckets["diffusion"][key] = value
+        elif key in _ENTRY_VLLM_KWARGS:
+            buckets["vllm"][key] = value
     return buckets
 
 
@@ -179,6 +188,10 @@ def _get_compressor_class(model_type: str, base_cls: type) -> type:
         from auto_round.compressors.diffusion_mixin import DiffusionMixin
 
         mixin = DiffusionMixin
+    elif model_type == "vllm":
+        from auto_round.compressors.vllm_mixin import VLLMMixin
+
+        mixin = VLLMMixin
     else:
         return base_cls
     combined = type(f"{model_type.capitalize()}{base_cls.__name__}", (mixin, base_cls), {})
@@ -233,12 +246,26 @@ def _resolve_quant_config_for_routing(alg_configs) -> tuple[list, list, Quantiza
     )
 
 
-def _build_model_type_ctor_kwargs(model, base_kwargs, mllm_kwargs, diffusion_kwargs) -> tuple[str, dict[str, Any]]:
+def _build_model_type_ctor_kwargs(
+    model,
+    base_kwargs,
+    mllm_kwargs,
+    diffusion_kwargs,
+    vllm_kwargs,
+) -> tuple[str, dict[str, Any]]:
     from auto_round.utils.model import detect_model_type
 
-    model_type = detect_model_type(model)
+    enable_vllm_loading = bool(vllm_kwargs.get("enable_vllm_loading", False))
+    detected_model_type = detect_model_type(model)
+    if enable_vllm_loading and detected_model_type in {"mllm", "diffusion"}:
+        raise ValueError(
+            "`enable_vllm_loading=True` conflicts with detected model type "
+            f"`{detected_model_type}`. Please disable vllm loading for multimodal/diffusion models."
+        )
+
+    model_type = "vllm" if enable_vllm_loading else detected_model_type
     has_multimodal_assets = mllm_kwargs.get("processor") is not None or mllm_kwargs.get("image_processor") is not None
-    if has_multimodal_assets and model_type != "mllm":
+    if has_multimodal_assets and not enable_vllm_loading and model_type != "mllm":
         model_type = "mllm"
 
     ctor_kwargs = dict(base_kwargs)
@@ -246,6 +273,8 @@ def _build_model_type_ctor_kwargs(model, base_kwargs, mllm_kwargs, diffusion_kwa
         ctor_kwargs.update(mllm_kwargs)
     if model_type == "diffusion":
         ctor_kwargs.update(diffusion_kwargs)
+    if model_type == "vllm":
+        ctor_kwargs.update(vllm_kwargs)
     return model_type, ctor_kwargs
 
 
@@ -349,6 +378,7 @@ class AutoRound(object):
         base_kwargs = dict(split_kwargs["base"])
         mllm_kwargs = dict(split_kwargs["mllm"])
         diffusion_kwargs = dict(split_kwargs["diffusion"])
+        vllm_kwargs = dict(split_kwargs["vllm"])
 
         # Resolve string alias(es) to config instance(s) before routing.
         alg_configs = cls._resolve_config(alg_configs)
@@ -410,7 +440,13 @@ class AutoRound(object):
             seqlen=seqlen,
             **compressor_kwargs,
         )
-        model_type, ctor_kwargs = _build_model_type_ctor_kwargs(model, base_kwargs, mllm_kwargs, diffusion_kwargs)
+        model_type, ctor_kwargs = _build_model_type_ctor_kwargs(
+            model,
+            base_kwargs,
+            mllm_kwargs,
+            diffusion_kwargs,
+            vllm_kwargs,
+        )
 
         # Preprocessor algorithms (AWQ, …) require a data-driven host so that
         # the per-block preprocessor lifecycle (prepare_block_group ->
@@ -647,11 +683,16 @@ class AutoRoundCompatible:
             "num_inference_steps": kwargs.pop("num_inference_steps", 50),
             "generator_seed": kwargs.pop("generator_seed", None),
         }
+        vllm_kwargs = {
+            "enable_vllm_loading": kwargs.pop("enable_vllm_loading", False),
+            "vllm_model_kwargs": kwargs.pop("vllm_model_kwargs", None),
+        }
         return {
             "format": format_name,
             "rotation_config": rotation_config,
             **mllm_kwargs,
             **diffusion_kwargs,
+            **vllm_kwargs,
             **kwargs,
         }
 

--- a/auto_round/compressors/vllm/__init__.py
+++ b/auto_round/compressors/vllm/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/auto_round/compressors/vllm/linearized_fused_moe.py
+++ b/auto_round/compressors/vllm/linearized_fused_moe.py
@@ -1,0 +1,446 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Linearized FusedMoE replacement for vLLM quantization calibration.
+
+vLLM stores all expert weights fused into two tensors:
+
+  ``w13_weight``: ``[E, 2*intermediate, hidden]``  (gate + up, fused row-major)
+  ``w2_weight``:  ``[E, hidden, intermediate]``    (down projection)
+
+where ``E`` is the number of local experts.
+
+This module replaces ``FusedMoE`` with per-expert ``nn.Linear`` modules so
+that auto-round can calibrate activation statistics and quantize each expert
+weight independently via the standard linear-layer pipeline.
+
+The replacement module implements a simple top-k routing forward so that
+``llm.generate()`` can drive calibration through the model normally.
+
+After quantization, the individual expert weights are exported in a format
+that vLLM's weight_loader can reassemble into ``FusedMoE``.
+
+Memory efficiency
+-----------------
+Weight tensors are assigned as *views* of the original fused tensors (no
+data copy).  For a model with E experts, this avoids 2× the peak memory
+that cloning would require.  The views keep the underlying storage alive
+even after the original ``FusedMoE`` module is removed from the model.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from auto_round.logger import logger
+from auto_round.utils.common import global_state
+
+# ---------------------------------------------------------------------------
+# Activation helper
+# ---------------------------------------------------------------------------
+
+
+def _make_act_fn(activation):
+    """Return a Python callable for the gated part of a ``MoEActivation``.
+
+    Gated activations compute ``act(gate_proj(x)) * up_proj(x)``.
+    We extract just the ``act`` portion here.
+
+    Args:
+        activation: A ``MoEActivation`` enum instance or a plain string.
+
+    Returns:
+        A callable ``f(x) -> x`` implementing the activation.
+    """
+    name = activation.value if hasattr(activation, "value") else str(activation)
+    if "gelu" in name:
+        return F.gelu
+    elif "relu2" in name:
+        return lambda x: F.relu(x) ** 2
+    else:
+        # Covers "silu" (most common) and unknown activations.
+        if "silu" not in name:
+            logger.warning_once(
+                "Unknown MoE activation %r for linearized forward; falling back to SiLU.",
+                name,
+            )
+        return F.silu
+
+
+# ---------------------------------------------------------------------------
+# Projection-name extraction from expert_mapping
+# ---------------------------------------------------------------------------
+
+
+def _extract_proj_names(
+    expert_mapping,
+) -> tuple[str, str, str]:
+    """Derive checkpoint projection names from ``FusedMoE.expert_mapping``.
+
+    ``make_expert_params_mapping`` stores tuples of the form::
+
+        (param_name, weight_name, expert_id, shard_id)
+
+    where ``shard_id`` is always one of ``"w1"`` (gate), ``"w2"`` (down),
+    ``"w3"`` (up), and ``weight_name`` is the checkpoint key, e.g.
+    ``"experts.0.gate_proj"`` (Qwen3) or ``"experts.0.w1"`` (Mixtral).
+    The projection name is the third ``"."``-separated component.
+
+    Returns:
+        ``(gate_name, up_name, down_name)`` checkpoint projection names.
+    """
+    if not expert_mapping:
+        return "gate_proj", "up_proj", "down_proj"
+
+    gate_name = up_name = down_name = None
+    for _param_name, weight_name, expert_id, shard_id in expert_mapping:
+        if expert_id != 0:
+            continue
+        parts = weight_name.split(".")
+        if len(parts) < 3:
+            continue
+        proj = parts[2]  # "experts.0.<proj_name>[.base_layer]"
+        if shard_id == "w1":  # gate
+            gate_name = proj
+        elif shard_id == "w3":  # up
+            up_name = proj
+        elif shard_id == "w2":  # down
+            down_name = proj
+
+    return (
+        gate_name or "gate_proj",
+        up_name or "up_proj",
+        down_name or "down_proj",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-expert module
+# ---------------------------------------------------------------------------
+
+
+class _VLLMLinearizedExpert(nn.Module):
+    """Single MoE expert with gate / up / down as individual ``nn.Linear``.
+
+    Sub-modules are registered under the checkpoint-specific projection names
+    (e.g. ``w1`` / ``w3`` / ``w2`` for Mixtral, ``gate_proj`` / ``up_proj`` /
+    ``down_proj`` for Qwen3), so that ``model.state_dict()`` immediately
+    produces the keys expected by vLLM's weight_loader without any remapping.
+
+    Weight tensors are *views* into the parent ``FusedMoE``'s fused weight
+    buffers (see :class:`LinearizedVLLMFusedMoE`).
+    """
+
+    def __init__(
+        self,
+        gate_proj: nn.Linear,
+        up_proj: nn.Linear,
+        down_proj: nn.Linear,
+        act_fn,
+        gate_name: str = "gate_proj",
+        up_name: str = "up_proj",
+        down_name: str = "down_proj",
+    ) -> None:
+        super().__init__()
+        # Register with checkpoint-specific names so state_dict keys are correct.
+        self.add_module(gate_name, gate_proj)
+        self.add_module(up_name, up_proj)
+        self.add_module(down_name, down_proj)
+        # Store attr names for forward – avoid re-registering as nn.Module children.
+        self._gate_attr = gate_name
+        self._up_attr = up_name
+        self._down_attr = down_name
+        self._act_fn = act_fn
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate = getattr(self, self._gate_attr)(x)
+        up = getattr(self, self._up_attr)(x)
+        return getattr(self, self._down_attr)(self._act_fn(gate) * up)
+
+
+# ---------------------------------------------------------------------------
+# Linearized MoE block
+# ---------------------------------------------------------------------------
+
+
+class LinearizedVLLMFusedMoE(nn.Module):
+    """Linearized replacement for vLLM's ``FusedMoE``.
+
+    Extracts per-expert weight *views* (zero extra memory) from
+    ``w13_weight`` / ``w2_weight`` and wraps them as ``nn.Linear`` so
+    auto-round can calibrate and quantize each expert independently.
+
+    ``SharedFusedMoE`` support
+    --------------------------
+    ``SharedFusedMoE`` (used by Qwen3-MoE) inherits from ``FusedMoE`` and
+    returns a ``(shared_out, routed_out)`` tuple.  When the constructor
+    receives a ``shared_expert`` module (the sibling ``nn.Module`` in the
+    parent MoE block), the forward runs it and returns the same tuple so
+    that the parent block's forward code continues to work unchanged.
+
+    The ``shared_expert`` module is stored as a plain Python reference
+    (``self._shared_expert_ref``), *not* as a registered child, so it
+    is not double-counted in the model's parameter inventory.
+    """
+
+    def __init__(
+        self,
+        fused_moe,
+        shared_expert: nn.Module | None = None,
+    ) -> None:
+        super().__init__()
+
+        num_experts: int = fused_moe.local_num_experts
+        hidden_size: int = fused_moe.moe_config.hidden_dim
+        inter: int = fused_moe.moe_config.intermediate_size_per_partition
+
+        self.num_experts = num_experts
+        self.top_k = fused_moe.top_k
+        self.renormalize = fused_moe.renormalize
+        self.use_grouped_topk: bool = getattr(fused_moe, "use_grouped_topk", False)
+        self.num_expert_group: int | None = getattr(fused_moe, "num_expert_group", None)
+        self.topk_group: int | None = getattr(fused_moe, "topk_group", None)
+        self.scoring_func: str = getattr(fused_moe, "scoring_func", "softmax")
+        self._act_fn = _make_act_fn(fused_moe.activation)
+
+        # SharedFusedMoE detection – store as plain reference (not registered).
+        _is_shared: bool = type(fused_moe).__name__ == "SharedFusedMoE"
+        self._is_shared_moe: bool = _is_shared
+        self._shared_expert_ref: nn.Module | None = shared_expert if _is_shared else None
+
+        # Derive checkpoint projection names from the original expert_mapping so
+        # state_dict() keys match vLLM's weight_loader expectations with no
+        # post-export remapping.
+        gate_name, up_name, down_name = _extract_proj_names(getattr(fused_moe, "expert_mapping", None))
+
+        # ------------------------------------------------------------------
+        # Build per-expert nn.Linear from *views* of the fused weight tensors.
+        #
+        # w13_weight: [E, 2*inter, hidden]
+        #   rows  0 ..  inter-1  → gate weights
+        #   rows inter .. 2*inter-1 → up weights
+        #
+        # w2_weight: [E, hidden, inter] → down weights
+        #
+        # Experts are registered directly as numbered children ("0", "1", ...)
+        # on this module – NOT wrapped in a ModuleList – so the module path is
+        # ``<fused_moe_attr>.{i}.{proj}`` instead of the double
+        # ``<fused_moe_attr>.experts.{i}.{proj}`` that a ModuleList would give.
+        # ------------------------------------------------------------------
+        w13: torch.Tensor = fused_moe.w13_weight.data  # [E, 2*inter, hidden]
+        w2: torch.Tensor = fused_moe.w2_weight.data  # [E, hidden, inter]
+
+        for i in range(num_experts):
+            gate = nn.Linear(hidden_size, inter, bias=False)
+            up = nn.Linear(hidden_size, inter, bias=False)
+            down = nn.Linear(inter, hidden_size, bias=False)
+
+            # Views – contiguous slices, no allocation.
+            gate.weight = nn.Parameter(w13[i, :inter, :], requires_grad=False)
+            up.weight = nn.Parameter(w13[i, inter:, :], requires_grad=False)
+            down.weight = nn.Parameter(w2[i], requires_grad=False)
+
+            self.add_module(
+                str(i),
+                _VLLMLinearizedExpert(
+                    gate,
+                    up,
+                    down,
+                    self._act_fn,
+                    gate_name=gate_name,
+                    up_name=up_name,
+                    down_name=down_name,
+                ),
+            )
+
+        # Store original FusedMoE as a plain dict entry (NOT a registered
+        # submodule) so that vLLM model code can reach attributes like
+        # ``is_internal_router`` via __getattr__ delegation below.
+        self.__dict__["_fused_moe_ref"] = fused_moe
+
+    def __getattr__(self, name: str):
+        """Delegate unknown attributes to the original FusedMoE.
+
+        vLLM model code accesses several attributes on the ``experts`` object
+        (e.g. ``is_internal_router``) that are defined on ``FusedMoE`` but not
+        on ``LinearizedVLLMFusedMoE``.  Delegating to the original preserves
+        those semantics without requiring us to enumerate every attribute.
+        """
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            pass
+        try:
+            fused_moe = self.__dict__.get("_fused_moe_ref")
+            if fused_moe is not None:
+                return getattr(fused_moe, name)
+        except AttributeError:
+            pass
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
+    # ------------------------------------------------------------------
+    # Routing
+    # ------------------------------------------------------------------
+
+    def _route(self, router_logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute routing weights and selected expert indices.
+
+        Supports standard softmax / sigmoid scoring and grouped top-k
+        (DeepSeek-style).  For calibration purposes a close approximation
+        to the original routing is sufficient.
+
+        Args:
+            router_logits: ``[num_tokens, num_experts]``
+
+        Returns:
+            ``(routing_weights, selected_experts)`` both of shape
+            ``[num_tokens, top_k]``.
+        """
+        if self.scoring_func == "sigmoid":
+            scores = torch.sigmoid(router_logits.float())
+        else:
+            scores = torch.softmax(router_logits.float(), dim=-1)
+
+        if self.use_grouped_topk and self.num_expert_group and self.topk_group:
+            # Grouped top-k (DeepSeek): select top-topk_group scores per group,
+            # then pick top_k globally among the selected groups.
+            E = self.num_experts
+            G = self.num_expert_group
+            group_size = E // G
+
+            scores_grouped = scores.view(-1, G, group_size)
+            # Sum of top-topk_group scores per group → group importance
+            group_scores = scores_grouped.topk(self.topk_group, dim=-1)[0].sum(-1)
+            n_groups_selected = max(1, G // 2)
+            _, sel_groups = group_scores.topk(n_groups_selected, dim=-1)  # [T, n_sel]
+
+            mask = torch.zeros_like(scores)
+            for gi in range(G):
+                in_sel = (sel_groups == gi).any(dim=-1)  # [T]
+                mask[:, gi * group_size : (gi + 1) * group_size] = in_sel.unsqueeze(-1).to(mask.dtype)
+            scores = scores * mask
+
+        routing_weights, selected_experts = torch.topk(scores, self.top_k, dim=-1)
+
+        if self.renormalize:
+            routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True).clamp_min(1e-9)
+
+        return routing_weights, selected_experts
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor | None, torch.Tensor]:
+        """Run linearized top-k MoE routing and expert computation.
+
+        Args:
+            hidden_states: ``[num_tokens, hidden_size]``
+            router_logits: ``[num_tokens, num_experts]``
+
+        Returns:
+            For plain ``FusedMoE``: a tensor of shape
+            ``[num_tokens, hidden_size]``.
+
+            For ``SharedFusedMoE``: a tuple
+            ``(shared_out, routed_out)`` where *shared_out* is the output of
+            the shared expert (or ``None`` if no shared expert is present).
+        """
+        routing_weights, selected_experts = self._route(router_logits)
+        routing_weights = routing_weights.to(hidden_states.dtype)
+
+        out = torch.zeros_like(hidden_states)
+        for expert_idx in range(self.num_experts):
+            mask = selected_experts == expert_idx  # [tokens, top_k]
+            token_idx, topk_idx = mask.nonzero(as_tuple=True)
+            if token_idx.numel() == 0:
+                continue
+            expert_out = self._modules[str(expert_idx)](hidden_states[token_idx])
+            weight = routing_weights[token_idx, topk_idx].unsqueeze(-1)
+            out.index_add_(0, token_idx, (expert_out * weight).to(out.dtype))
+
+        if self._is_shared_moe:
+            shared_out = self._shared_expert_ref(hidden_states) if self._shared_expert_ref is not None else None
+            return shared_out, out
+
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Model-level linearize entry point
+# ---------------------------------------------------------------------------
+
+
+def linearize_vllm_moe(model: nn.Module) -> int:
+    """Replace all ``FusedMoE`` instances in *model* with :class:`LinearizedVLLMFusedMoE`.
+
+    Walks the module tree and replaces every ``FusedMoE`` child (including
+    ``SharedFusedMoE`` subclass instances) with a
+    :class:`LinearizedVLLMFusedMoE` that exposes per-expert ``nn.Linear``
+    modules for calibration and quantization.
+
+    Only gated MoE layers (``is_act_and_mul=True``) are processed.
+    Non-gated layers are left unchanged with a warning.
+
+    For ``SharedFusedMoE``, the function looks for a ``shared_expert``
+    attribute on the *parent* module (the sibling MoE MLP) and passes it
+    to :class:`LinearizedVLLMFusedMoE` so the forward can produce the correct
+    ``(shared_out, routed_out)`` tuple.
+
+    Args:
+        model: The vLLM model (``nn.Module``) after loading.
+
+    Returns:
+        Number of ``FusedMoE`` layers replaced.
+    """
+    try:
+        from vllm.model_executor.layers.fused_moe import FusedMoE
+    except ImportError:
+        return 0
+
+    replaced = 0
+    for parent_module in list(model.modules()):
+        for child_name, child_module in list(parent_module.named_children()):
+            if not isinstance(child_module, FusedMoE):
+                continue
+
+            if not child_module.moe_config.is_act_and_mul:
+                logger.warning_once(
+                    "Skipping FusedMoE linearization at %r: non-gated activation "
+                    "(is_act_and_mul=False) is not yet supported.",
+                    child_name,
+                )
+                continue
+
+            # For SharedFusedMoE: pass the sibling shared_expert from the parent.
+            shared_expert = getattr(parent_module, "shared_expert", None)
+
+            linearized = LinearizedVLLMFusedMoE(child_module, shared_expert=shared_expert)
+            setattr(parent_module, child_name, linearized)
+            replaced += 1
+
+    if replaced:
+        logger.info(
+            "Linearized %d FusedMoE layer(s) into per-expert nn.Linear for quantization.",
+            replaced,
+        )
+        # Inform safe_to_cpu_() that modules have been replaced so it does NOT
+        # call model.to("cpu") — vLLM models must stay on GPU.
+        global_state.replaced_module_count = replaced
+    return replaced

--- a/auto_round/compressors/vllm/linearized_fused_moe.py
+++ b/auto_round/compressors/vllm/linearized_fused_moe.py
@@ -270,6 +270,20 @@ class LinearizedVLLMFusedMoE(nn.Module):
         # ``is_internal_router`` via __getattr__ delegation below.
         self.__dict__["_fused_moe_ref"] = fused_moe
 
+    @property
+    def experts(self):
+        """Return the per-expert modules as a list.
+
+        Experts are registered as numbered children (``"0"``, ``"1"``, ...) so
+        that module paths are ``<moe>.0.gate_proj`` rather than the double-
+        nested ``<moe>.experts.0.gate_proj`` that a ModuleList would produce.
+        This property exposes them as a plain list so that
+        ``set_amax_for_all_moe_layers`` (which checks
+        ``isinstance(sub_module.experts, Iterable)``) can iterate them and fill
+        act_max for any expert that was not activated during calibration.
+        """
+        return [m for n, m in self._modules.items() if n.isdigit()]
+
     def __getattr__(self, name: str):
         """Delegate unknown attributes to the original FusedMoE.
 

--- a/auto_round/compressors/vllm/vllm_calibrator.py
+++ b/auto_round/compressors/vllm/vllm_calibrator.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""vLLM calibration strategy.
+
+Inherits the block-input collection infrastructure from ``LLMCalibrator``
+but drives calibration through the vLLM engine (``llm.generate()``) instead
+of calling the inner model directly.
+
+Why not call the model directly
+--------------------------------
+vLLM's attention layers read ``attn_metadata`` and ``kv_cache`` from a
+*global forward context* that is only populated by the vLLM engine at
+inference time.  Calling ``model(input_ids, positions)`` outside the engine
+leaves the context empty, causing the attention kernel to crash.
+
+Why ``llm.generate()`` works
+-----------------------------
+The vLLM engine sets up the full forward context (attention metadata,
+KV-cache slot mapping, etc.) before calling the model.  Block-level hooks
+installed by ``_replace_forward`` fire normally during the prefill pass,
+capturing every block's input hidden-states just as in the LLM path.
+
+Early-stop is disabled (``should_stop`` always returns ``False``) because
+the engine must be allowed to complete its own forward pass; raising
+``NotImplementedError`` inside a vLLM forward would crash the engine.
+All block inputs are therefore collected in a single prefill pass per sample.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from auto_round.calibration.llm import LLMCalibrator
+from auto_round.calibration.register import register_calibrator
+from auto_round.logger import logger
+
+
+@register_calibrator("vllm")
+class VLLMCalibrator(LLMCalibrator):
+    """Calibrator for models loaded through the vLLM engine.
+
+    Differences from ``LLMCalibrator``:
+
+    * ``calib()`` drives the model via ``llm.generate()`` so that the vLLM
+      engine correctly populates the attention forward-context.
+    * ``should_stop()`` always returns ``False`` — the engine must be allowed
+      to complete its full forward pass; all block inputs are captured in one
+      prefill per sample.
+    * CPU fallback on OOM is disabled and surfaces a clear error message.
+    """
+
+    # ── Early-stop policy ───────────────────────────────────────────────────
+
+    def should_stop(self, name: str) -> bool:
+        """Never early-stop inside a vLLM forward pass.
+
+        Raising ``NotImplementedError`` inside ``llm.generate()`` would crash
+        the engine.  All block inputs are captured during the single prefill
+        pass; there is no need to stop early.
+        """
+        return False
+
+    # ── OOM guard ───────────────────────────────────────────────────────────
+
+    def collect(self, block_names, nsamples, layer_names=None, last_cache_name=None):
+        """Block-input collection with vLLM-specific OOM guard.
+
+        vLLM models are always resident on GPU and cannot be moved to CPU
+        (paged KV-cache, CUDA kernels).  The parent's CPU-fallback path is
+        disabled; OOM surfaces as a clear error instead of a silent crash
+        deep inside accelerate.
+        """
+        try:
+            return super().collect(block_names, nsamples, layer_names, last_cache_name)
+        except torch.OutOfMemoryError as e:
+            raise torch.OutOfMemoryError(
+                "Out of memory during vLLM calibration. "
+                "CPU fallback is not supported for vLLM models. "
+                "Try lowering gpu_memory_utilization, using fewer nsamples, "
+                "or a shorter seqlen."
+            ) from e
+
+    # ── Calibration driver ──────────────────────────────────────────────────
+
+    @torch.no_grad()
+    def calib(self, nsamples: int, bs: int) -> None:
+        """Drive the model via the vLLM engine so block hooks fire.
+
+        Feeds pre-tokenized prompts to ``llm.generate()`` with
+        ``max_tokens=1`` so only a prefill pass runs.  The hooks installed by
+        ``_replace_forward`` capture each block's input hidden-states during
+        prefill, which is identical to what the LLM path captures.
+
+        For static activation quantization (e.g. NVFP4, FP8_STATIC), also
+        registers ``act_max`` collection hooks on the full model before each
+        ``llm.generate()`` call.  The block-wise reference forward used by
+        the data-driven pipeline cannot run outside the engine (vLLM attention
+        needs the engine's ForwardContext), so act_max would otherwise never be
+        collected and ``pack_layer`` would fail at the
+        ``assert hasattr(layer, "act_max")`` check.
+        """
+        from vllm import SamplingParams
+
+        from auto_round.calib_dataset import get_dataloader
+        from auto_round.compressors.utils import check_need_act_calibration
+
+        c = self.compressor
+        llm = c.model_context.llm
+        tokenizer = c.model_context.tokenizer
+
+        # vLLM hidden_states are 2-D (num_tokens, hidden_dim) — there is no
+        # explicit batch axis.  Pre-set batch_dim=0 to prevent the auto-detect
+        # heuristic in forward_capture from misidentifying the hidden_size
+        # dimension as the batch dimension and aborting with "unsupported model".
+        if hasattr(c, "quantizer") and hasattr(c.quantizer, "batch_dim"):
+            c.quantizer.batch_dim = 0
+
+        # vLLM processes one sequence per generate() call.  Each call
+        # contributes exactly one "sample" to the cached block inputs, so the
+        # quantizer must see batch_size=1.  We temporarily override it here
+        # and restore it after calib() returns.
+        _orig_batch_size = None
+        if hasattr(c, "quantizer") and hasattr(c.quantizer, "batch_size"):
+            _orig_batch_size = c.quantizer.batch_size
+            c.quantizer.batch_size = 1
+
+        if isinstance(c.dataset, str):
+            dataset_name = c.dataset.replace(" ", "")
+            c.dataloader = get_dataloader(
+                tokenizer,
+                c.seqlen,
+                dataset_name,
+                c.seed,
+                bs=1,  # one sequence at a time; vLLM batches internally
+                nsamples=nsamples,
+            )
+        else:
+            c.dataloader = c.dataset
+
+        # max_tokens=1: run prefill only, skip decode loop.
+        sampling_params = SamplingParams(max_tokens=1, temperature=0.0)
+        total_cnt = 0
+
+        # Register act_max collection hooks on the full model for static
+        # activation quantization (e.g. NVFP4).  These must be active during
+        # llm.generate() because the block-wise reference forward cannot run
+        # outside the vLLM engine.
+        act_max_handles = []
+        quantizer = getattr(c, "quantizer", None)
+        if quantizer is not None and hasattr(quantizer, "_register_act_max_hooks"):
+            act_bits = getattr(quantizer, "act_bits", 16) or 16
+            act_data_type = getattr(quantizer, "act_data_type", None)
+            act_dynamic = getattr(quantizer, "act_dynamic", True)
+            if check_need_act_calibration(act_dynamic, act_data_type, act_bits):
+                logger.info(
+                    "VLLMCalibrator: registering act_max hooks on full model "
+                    "for static activation calibration (%s).",
+                    act_data_type,
+                )
+                act_max_handles = quantizer._register_act_max_hooks(c.model_context.model)
+                if act_max_handles:
+                    logger.info(
+                        "VLLMCalibrator: registered %d act_max hook(s).",
+                        len(act_max_handles),
+                    )
+
+        try:
+            for data in c.dataloader:
+                if data is None:
+                    continue
+
+                # Extract input_ids tensor from various dataloader formats.
+                if isinstance(data, torch.Tensor):
+                    input_ids_batch = data
+                elif isinstance(data, dict) or hasattr(data, "keys"):
+                    input_ids_batch = data.get("input_ids")
+                    if input_ids_batch is None:
+                        continue
+                else:
+                    continue
+
+                if input_ids_batch.shape[-1] < c.seqlen:
+                    continue
+
+                # Feed each sequence as a pre-tokenized prompt so we skip the
+                # tokenize → detokenize roundtrip.
+                for i in range(input_ids_batch.shape[0]):
+                    token_ids = input_ids_batch[i, : c.seqlen].tolist()
+                    llm.generate(
+                        [{"prompt_token_ids": token_ids}],
+                        sampling_params,
+                        use_tqdm=False,
+                    )
+                    total_cnt += 1
+                    if total_cnt >= nsamples:
+                        break
+
+                if total_cnt >= nsamples:
+                    break
+        finally:
+            for h in act_max_handles:
+                h.remove()
+
+        if total_cnt == 0:
+            logger.error(
+                "No calibration data was captured. "
+                f"Provide data with sequence length >= {c.seqlen} "
+                "or decrease seqlen."
+            )
+            exit(-1)
+        elif total_cnt < nsamples:
+            logger.warning_once(
+                f"Insufficient calibration samples: target {nsamples}, "
+                f"captured {total_cnt}.  Quantization accuracy may be reduced."
+            )
+
+        # NOTE: Do NOT restore batch_size here.
+        # vLLM block I/O uses a flattened [n_tokens, hidden] format (no explicit
+        # batch dimension).  With batch_size > 1, _append_output would call
+        # torch.split(output, 1, dim=0) which splits individual tokens rather
+        # than samples, producing wrong reference-output shapes for the
+        # downstream collect_reference + quantize_block optimization loop.
+        # Keeping batch_size=1 for the full vLLM-loading path is correct.
+        # Reference: Fix 13 — do not restore _orig_batch_size after calib().

--- a/auto_round/compressors/vllm_mixin.py
+++ b/auto_round/compressors/vllm_mixin.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+
+class VLLMMixin:
+    """vLLM-specific initialization mixin.
+
+    This mixin threads vLLM loading options into ``BaseCompressor`` so that
+    ``ModelContext`` can initialize model/tokenizer through ``vllm_load_model``.
+    It also overrides ``configure_layer_config`` to recognise vLLM
+    ``LinearBase`` subclasses (e.g. ``QKVParallelLinear``) which are missed by
+    the exact-type matching used in the mainline ``set_layer_config``.
+    """
+
+    def __init__(
+        self,
+        *args,
+        enable_vllm_loading: bool = False,
+        vllm_model_kwargs: dict[str, Any] | None = None,
+        **kwargs,
+    ) -> None:
+        self.enable_vllm_loading = enable_vllm_loading
+        self.vllm_model_kwargs = dict(vllm_model_kwargs or {})
+
+        super().__init__(
+            *args,
+            enable_vllm_loading=self.enable_vllm_loading,
+            vllm_model_kwargs=self.vllm_model_kwargs,
+            **kwargs,
+        )
+
+    def _get_calibrator_kind(self) -> str:
+        """Select the vLLM calibration strategy.
+
+        Importing ``VLLMCalibrator`` here is intentional: the import
+        triggers ``@register_calibrator("vllm")`` so the registry entry
+        exists before ``get_calibrator("vllm")`` is called.
+        """
+        from auto_round.compressors.vllm.vllm_calibrator import VLLMCalibrator  # noqa: F401
+
+        return "vllm"
+
+    def configure_layer_config(self, enable_gguf_official_mixed: bool | None = True) -> None:
+        """Extend base layer config with vLLM LinearBase layers.
+
+        The mainline ``set_layer_config`` uses exact ``type(m) in
+        supported_types`` matching, which misses vLLM layers such as
+        ``QKVParallelLinear`` (subclass of ``LinearBase``, not registered in
+        ``SUPPORTED_LAYER_TYPES``).  After the base implementation runs, this
+        override iterates the model and adds any ``LinearBase`` instances that
+        were skipped, using the global scheme derived from the resolved scheme
+        attributes on ``self``.
+        """
+        super().configure_layer_config(enable_gguf_official_mixed)
+
+        try:
+            from vllm.model_executor.layers.linear import LinearBase
+        except ImportError:
+            return
+
+        model = self.model_context.model
+        bits = getattr(self, "bits", None)
+        if bits is None or bits >= 16:
+            return  # nothing to quantize
+
+        # Build a global scheme dict from the resolved scheme attributes.
+        scheme_keys = (
+            "bits",
+            "group_size",
+            "data_type",
+            "sym",
+            "scale_dtype",
+            "act_bits",
+            "act_group_size",
+            "act_data_type",
+            "act_sym",
+            "act_dynamic",
+        )
+        global_cfg: dict[str, Any] = {}
+        for key in scheme_keys:
+            val = getattr(self, key, None)
+            if val is not None:
+                global_cfg[key] = val
+
+        # Identify block names so we can flag outside-block layers.
+        from auto_round.utils import get_block_names
+
+        quant_block_list = getattr(self, "quant_block_list", None)
+        block_names_flat: set[str] = set(
+            name for group in (quant_block_list or get_block_names(model)) for name in group
+        )
+
+        added: list[str] = []
+        for n, m in model.named_modules():
+            if not isinstance(m, LinearBase):
+                continue
+            if n in self.layer_config:
+                continue  # already handled by super()
+
+            cfg = copy.deepcopy(global_cfg)
+            cfg["in_blocks"] = any(n == bn or n.startswith(f"{bn}.") for bn in block_names_flat)
+            if not cfg["in_blocks"]:
+                self.has_qlayer_outside_block = True
+
+            self.layer_config[n] = cfg
+            # Dispatch: set scheme attributes directly on the module so that
+            # check_to_quantized(m) and quantizer.quantize_layer() work.
+            for attr, value in cfg.items():
+                setattr(m, attr, value)
+            added.append(n)
+
+        if added:
+            from auto_round.utils import logger
+
+            logger.info(
+                f"VLLMMixin: added {len(added)} vLLM LinearBase layer(s) to " f"layer_config (first: {added[0]})"
+            )

--- a/auto_round/context/model.py
+++ b/auto_round/context/model.py
@@ -33,9 +33,11 @@ from auto_round.utils import (
     is_mllm_model,
     is_moe_model,
     is_moe_model_via_config,
+    is_vllm_model,
     llm_load_model,
     mllm_load_model,
     unsupported_meta_device,
+    vllm_load_model,
 )
 from auto_round.utils.device import _force_trim_malloc
 from auto_round.utils.device_manager import device_manager, get_ar_device
@@ -73,6 +75,7 @@ class ModelContext(BaseContext):
         self.quantized = False
         self.is_mllm = False
         self.is_diffusion = False
+        self.is_vllm = False
         self.is_model_patched = False
         self.is_moe_model = False
         # Set by CalibCompressor._replace_forward; used by recover_forward to detect
@@ -83,11 +86,12 @@ class ModelContext(BaseContext):
         self.model = model
         self.tokenizer = tokenizer
 
-        # MLLM / diffusion artifacts – always present so callers need no getattr guards.
+        # MLLM / diffusion / vLLM artifacts – always present so callers need no getattr guards.
         # _load_model() will populate the ones that are relevant to the model type.
         self.processor = None
         self.image_processor = None
         self.pipe = None
+        self.llm = None
 
         # AWQ weight-clip thresholds kept for downstream block quantizers.
         # Populated by AWQTransform when ``apply_clip`` is enabled; keyed by
@@ -104,6 +108,8 @@ class ModelContext(BaseContext):
         self.amp = amp
         self.need_calib = need_calib
         self.quant_nontext_module = quant_nontext_module
+        self.enable_vllm_loading = kwargs.pop("enable_vllm_loading", False)
+        self.vllm_model_kwargs = kwargs.pop("vllm_model_kwargs", None)
 
         # Load model and run basic initialization eagerly so the model is ready
         # by the time BaseCompressor.post_init() runs.
@@ -145,7 +151,18 @@ class ModelContext(BaseContext):
         device_manager.device = value
 
     def _load_model(self):
-        if is_mllm_model(self.model, platform=self.platform):
+        if self.enable_vllm_loading or is_vllm_model(self.model):
+            self.is_vllm = True
+            if isinstance(self.model, str):
+                vllm_kwargs = self.vllm_model_kwargs
+                if vllm_kwargs is None:
+                    vllm_kwargs = {}
+                if not isinstance(vllm_kwargs, dict):
+                    raise ValueError("`vllm_model_kwargs` must be a dict when enable_vllm_loading=True")
+                self.llm, self.model, self.tokenizer = vllm_load_model(self.model, **vllm_kwargs)
+            else:
+                self.llm, self.model, self.tokenizer = vllm_load_model(self.model)
+        elif is_mllm_model(self.model, platform=self.platform):
             self.is_mllm = True
             if isinstance(self.model, str):
                 self.model, self.processor, self.tokenizer, self.image_processor = mllm_load_model(
@@ -276,6 +293,14 @@ class ModelContext(BaseContext):
         # It is best to modify the model structure in the quantize function and check the format,
         # because it may cause the gguf format to not be exported normally.
         self._patch_custom_moe_modules()
+
+        # For vLLM models, replace FusedMoE with per-expert nn.Linear modules
+        # so auto-round can calibrate and quantize each expert independently.
+        if self.is_vllm:
+            from auto_round.compressors.vllm.linearized_fused_moe import linearize_vllm_moe
+
+            linearize_vllm_moe(self.model)
+
         self.model = update_module(
             self.model, formats=formats, trust_remote_code=self.trust_remote_code, cleanup_original=False
         )

--- a/auto_round/data_type/utils.py
+++ b/auto_round/data_type/utils.py
@@ -462,10 +462,20 @@ def update_fused_layer_global_scales(
             hasattr(module, "k_proj") or hasattr(module, "v_proj") or hasattr(module, "qkv_proj")
         )
 
-    def _is_mlp_module(module: Module):
-        return "mlp" in module.__class__.__name__.lower() and (
-            hasattr(module, "gate_proj") and hasattr(module, "up_proj")
-        )
+    def _get_mlp_input_projections(module: Module):
+        """Return input projection modules that should share one global scale.
+
+        For MoE-style MLPs this is typically gate/up (aka w1/w3).  We avoid
+        relying on class names so linearized expert wrappers (e.g.
+        ``_VLLMLinearizedExpert``) are also covered.
+        """
+        if hasattr(module, "gate_proj") and hasattr(module, "up_proj"):
+            return [module.gate_proj, module.up_proj]
+        if hasattr(module, "w1") and hasattr(module, "w3"):
+            return [module.w1, module.w3]
+        if hasattr(module, "w1_linear") and hasattr(module, "v1_linear"):
+            return [module.w1_linear, module.v1_linear]
+        return None
 
     def _update_global_scales(modules: List[Module]):
         """Update global scales for a list of modules."""
@@ -493,8 +503,9 @@ def update_fused_layer_global_scales(
         return
 
     # ---------------- MLP ----------------
-    if _is_mlp_module(submodule):
-        _update_global_scales([submodule.gate_proj, submodule.up_proj])
+    mlp_input_projs = _get_mlp_input_projections(submodule)
+    if mlp_input_projs is not None:
+        _update_global_scales(mlp_input_projs)
 
 
 def update_block_global_scale_if_needed(block, data_type, group_size):

--- a/auto_round/export/export_to_llmcompressor/export.py
+++ b/auto_round/export/export_to_llmcompressor/export.py
@@ -19,6 +19,13 @@ from typing import Callable, Union
 import torch
 
 from auto_round.export.utils import is_immediate_saving_mode, save_model, save_pretrained_artifact
+
+# Lazy import: vLLM LinearBase (None when vLLM is not installed).
+_VLLMLinearBase = None
+try:
+    from vllm.model_executor.layers.linear import LinearBase as _VLLMLinearBase
+except Exception:
+    pass
 from auto_round.logger import logger
 from auto_round.utils import (
     SUPPORTED_LAYER_TYPES,
@@ -101,6 +108,137 @@ def _get_quant_format(model):
     return None
 
 
+def _unfuse_integer_vllm_layer(name: str, model: torch.nn.Module, layer, output_sizes) -> bool:
+    """Split a compressed-tensors integer-packed fused vLLM layer
+    (qkv_proj / gate_up_proj) into separate nn.Linear sub-layers stored
+    under the corresponding HF-checkpoint key names.
+
+    For qkv_proj   → injects q_proj / k_proj / v_proj into the parent module.
+    For gate_up_proj → injects gate_proj / up_proj into the parent module.
+
+    Returns True if the layer was unfused, False otherwise.
+    """
+    layer_base = name.rsplit(".", 1)[-1]
+
+    if layer_base == "qkv_proj":
+        sub_names = ["q_proj", "k_proj", "v_proj"]
+    elif layer_base == "gate_up_proj":
+        sub_names = ["gate_proj", "up_proj"]
+    else:
+        return False
+
+    if len(output_sizes) != len(sub_names):
+        logger.warning(
+            "Cannot unfuse integer vLLM layer %s: output_sizes length mismatch "
+            "(expected %d, got %d). Saving as fused.",
+            name,
+            len(sub_names),
+            len(output_sizes),
+        )
+        return False
+
+    # Compute cumulative offsets
+    offsets = [0]
+    for s in output_sizes:
+        offsets.append(offsets[-1] + s)
+
+    # After _compress_and_set_format: weight becomes weight_packed (int4 → uint8)
+    # or remains as weight for non-pack-quantized formats.
+    if hasattr(layer, "weight_packed"):
+        fused_weight = layer.weight_packed
+        weight_attr = "weight_packed"
+    else:
+        fused_weight = layer.weight
+        weight_attr = "weight"
+
+    fused_scale = layer.weight_scale
+    # weight_zero_point may be deleted by compress_module for symmetric quantization
+    fused_zp = getattr(layer, "weight_zero_point", None)
+    fused_bias = getattr(layer, "bias", None)
+    q_scheme = layer.quantization_scheme
+
+    # Determine in_features for creating sub nn.Linear shells
+    if weight_attr == "weight_packed":
+        in_features = fused_weight.shape[1] * 2
+    else:
+        in_features = fused_weight.shape[1]
+
+    # Resolve parent module
+    parts = name.rsplit(".", 1)
+    parent_path = parts[0] if len(parts) == 2 else ""
+    parent = get_module(model, parent_path) if parent_path else model
+
+    for i, sub_name in enumerate(sub_names):
+        row_start, row_end = offsets[i], offsets[i + 1]
+        sub_out = row_end - row_start
+
+        # Slice all attributes along output dimension (dim=0)
+        sub_weight = fused_weight[row_start:row_end, :].contiguous()
+        sub_scale = fused_scale[row_start:row_end, :].contiguous()
+        sub_bias = fused_bias[row_start:row_end].contiguous() if fused_bias is not None else None
+
+        # Create a minimal nn.Linear shell with compressed-tensors attributes
+        sub_layer = torch.nn.Linear(in_features, sub_out, bias=sub_bias is not None)
+        # Remove default float weight (will be replaced by packed tensor)
+        del sub_layer.weight
+        setattr(sub_layer, weight_attr, torch.nn.Parameter(sub_weight, requires_grad=False))
+        sub_layer.weight_scale = torch.nn.Parameter(sub_scale, requires_grad=False)
+        if fused_zp is not None:
+            sub_zp = fused_zp[row_start:row_end, :].contiguous()
+            sub_layer.weight_zero_point = torch.nn.Parameter(sub_zp, requires_grad=False)
+        sub_layer.quantization_scheme = q_scheme
+        if sub_bias is not None:
+            sub_layer.bias = torch.nn.Parameter(sub_bias, requires_grad=False)
+
+        setattr(parent, sub_name, sub_layer)
+
+    delattr(parent, layer_base)
+    logger.info("Unfused integer vLLM layer %s → %s", name, sub_names)
+    return True
+
+
+def _vllm_to_linear(name: str, model: torch.nn.Module, vllm_layer) -> torch.nn.Linear:
+    """Replace a vLLM LinearBase layer in the model with an equivalent nn.Linear.
+
+    compress_module from compressed-tensors produces 'pack-quantized' format for
+    nn.Linear but falls back to 'dense' for unrecognised types (such as vLLM's
+    LinearBase subclasses).  Converting to nn.Linear first guarantees the correct
+    format and targets=["Linear"] in quantization_config.json.
+
+    The returned nn.Linear has the same weight/bias data and all quantization
+    attributes (bits, scale, zp, …) copied from the original vLLM layer.
+    """
+    in_features = getattr(vllm_layer, "input_size", vllm_layer.weight.shape[1])
+    out_features = getattr(vllm_layer, "output_size", vllm_layer.weight.shape[0])
+    has_bias = isinstance(getattr(vllm_layer, "bias", None), torch.Tensor)
+
+    linear = torch.nn.Linear(in_features, out_features, bias=has_bias)
+    # Replace the randomly-initialised weight with the actual (fake-quantised) weight
+    linear.weight = torch.nn.Parameter(vllm_layer.weight.data.clone())
+    if has_bias:
+        linear.bias = torch.nn.Parameter(vllm_layer.bias.data.clone())
+
+    # Copy all quantisation attributes expected by construct_ct_scheme / pack_layer
+    for attr in (
+        "bits",
+        "sym",
+        "group_size",
+        "data_type",
+        "act_bits",
+        "act_data_type",
+        "act_sym",
+        "act_dynamic",
+        "act_group_size",
+        "scale",
+        "zp",
+    ):
+        if hasattr(vllm_layer, attr):
+            setattr(linear, attr, getattr(vllm_layer, attr))
+
+    set_module(model, name, linear)
+    return linear
+
+
 def _compress_and_set_format(layer, scheme, device=None):
     """Compress a layer and set its quantization format.
 
@@ -130,19 +268,31 @@ def pack_layer(name, model, device=None):
     from compressed_tensors.quantization import QuantizationStatus  # pylint: disable=E0401
 
     layer = get_module(model, name)
-    if type(layer) not in SUPPORTED_LAYER_TYPES and not isinstance(layer, WrapperWALayer):  ##already packed
-        return
+    _is_vllm_linear = _VLLMLinearBase is not None and isinstance(layer, _VLLMLinearBase)
+    if type(layer) not in SUPPORTED_LAYER_TYPES and not isinstance(layer, WrapperWALayer) and not _is_vllm_linear:
+        return  ##already packed
 
     if hasattr(layer, "orig_layer"):  # revert WrapperWALayer for offline usage
         wp_layer = layer
         layer = wp_layer.orig_layer
         set_module(model, name, layer)
+        _is_vllm_linear = _VLLMLinearBase is not None and isinstance(layer, _VLLMLinearBase)
 
     if not check_to_quantized(layer):
         return
 
     if hasattr(layer, "quantization_status") and layer.quantization_status == QuantizationStatus.COMPRESSED:
         return
+
+    # Save vLLM fused-layer output_sizes and convert to nn.Linear before packing.
+    # compress_module produces 'pack-quantized' for nn.Linear but falls back to
+    # 'dense' for unrecognised types (vLLM LinearBase subclasses), so the
+    # conversion must happen before _compress_and_set_format is called.
+    vllm_output_sizes = None
+    if _is_vllm_linear:
+        if hasattr(layer, "output_sizes"):
+            vllm_output_sizes = list(layer.output_sizes)
+        layer = _vllm_to_linear(name, model, layer)
 
     # explicitly obtain the underlying device to prevent RuntimeError mismatched tensors
     weight_device = layer.weight.device
@@ -162,6 +312,10 @@ def pack_layer(name, model, device=None):
     delattr(layer, "scale")
 
     _compress_and_set_format(layer, scheme, device)
+
+    # Unfuse vLLM fused layers (qkv_proj → q_proj/k_proj/v_proj, gate_up_proj → gate_proj/up_proj)
+    if _is_vllm_linear and vllm_output_sizes is not None:
+        _unfuse_integer_vllm_layer(name, model, layer, vllm_output_sizes)
 
 
 @torch.no_grad()

--- a/auto_round/export/export_to_llmcompressor/export_to_fp.py
+++ b/auto_round/export/export_to_llmcompressor/export_to_fp.py
@@ -64,16 +64,129 @@ __all__ = [
     "save_quantized_as_fp",
 ]
 
+# Lazy import: vLLM LinearBase (None when vLLM is not installed).
+_VLLMLinearBase = None
+try:
+    from vllm.model_executor.layers.linear import LinearBase as _VLLMLinearBase
+except Exception:
+    pass
+
+
+def _unfuse_vllm_packed_layer(name: str, model: torch.nn.Module, qlayer) -> bool:
+    """Split a packed fused vLLM layer (qkv_proj / gate_up_proj) into separate
+    sub-layers stored under the corresponding HF-checkpoint key names.
+
+    For qkv_proj  → injects q_proj / k_proj / v_proj into the parent module.
+    For gate_up_proj → injects gate_proj / up_proj into the parent module.
+
+    Returns True if the layer was unfused, False otherwise.
+    """
+    layer_base = name.rsplit(".", 1)[-1]
+
+    # Determine the sub-layer names and output dimension split
+    if layer_base == "qkv_proj":
+        sub_names = ["q_proj", "k_proj", "v_proj"]
+    elif layer_base == "gate_up_proj":
+        sub_names = ["gate_proj", "up_proj"]
+    else:
+        return False
+
+    # Get the split sizes from the original vLLM LinearBase (stored as output_sizes)
+    # We stored output_sizes on qlayer before replacing the original layer.
+    output_sizes = getattr(qlayer, "_vllm_output_sizes", None)
+    if output_sizes is None or len(output_sizes) != len(sub_names):
+        logger.warning(
+            "Cannot unfuse vLLM layer %s: _vllm_output_sizes not set or length mismatch "
+            "(expected %d, got %s). Saving as fused.",
+            name,
+            len(sub_names),
+            output_sizes,
+        )
+        return False
+
+    # Compute cumulative offsets
+    offsets = [0]
+    for s in output_sizes:
+        offsets.append(offsets[-1] + s)
+
+    # bits=8 (MXFP8): weight attr is "weight"   [out, in]        dtype float8_e4m3fn
+    # bits=4 (MXFP4/NVFP4): weight attr is "weight_packed" [out, in//2] dtype uint8
+    if hasattr(qlayer, "weight_packed"):
+        fused_weight = qlayer.weight_packed
+        weight_attr = "weight_packed"
+    else:
+        fused_weight = qlayer.weight
+        weight_attr = "weight"
+    fused_scale = qlayer.weight_scale  # uint8 (mxfp8 exponents) or float16/fp8 (mxfp4/nvfp4)
+    fused_bias = getattr(qlayer, "bias", None)
+    global_scale = getattr(qlayer, "weight_global_scale", None)
+    input_global_scale = getattr(qlayer, "input_global_scale", None)
+
+    # Resolve parent module
+    parts = name.rsplit(".", 1)
+    parent_path = parts[0] if len(parts) == 2 else ""
+    parent = get_module(model, parent_path) if parent_path else model
+
+    # For bits=4 the weight is packed 2 fp4 per byte along in-dim,
+    # but output-dim slicing is unaffected.
+    in_features_packed = fused_weight.shape[1]
+
+    for i, sub_name in enumerate(sub_names):
+        row_start, row_end = offsets[i], offsets[i + 1]
+        sub_out = row_end - row_start
+
+        # Slice weight and scale along dim=0 (output dimension)
+        sub_weight = fused_weight[row_start:row_end, :].contiguous()
+        # weight_scale rows correspond 1:1 with weight rows
+        sub_scale = fused_scale[row_start:row_end, :].contiguous()
+        sub_bias = fused_bias[row_start:row_end].contiguous() if fused_bias is not None else None
+
+        # infeatures for the QuantLinear constructor: un-pack for bits=4
+        sub_infeatures = in_features_packed * 2 if qlayer.bits == 4 else in_features_packed
+
+        # Build a fresh QuantLinear shell and assign buffers directly (skip .pack())
+        sub_qlayer = QuantLinear(
+            qlayer.bits,
+            qlayer.group_size,
+            sub_infeatures,
+            sub_out,
+            sub_bias is not None,
+            weight_dtype=sub_weight.dtype,
+            sym=qlayer.sym,
+            data_type=qlayer.data_type,
+            act_bits=qlayer.act_bits,
+            act_data_type=qlayer.act_data_type,
+        )
+        sub_qlayer.device = qlayer.device
+        setattr(sub_qlayer, weight_attr, sub_weight)
+        sub_qlayer.weight_scale = sub_scale
+        if sub_bias is not None:
+            sub_qlayer.bias = sub_bias
+        if global_scale is not None:
+            sub_qlayer.weight_global_scale = global_scale
+        if input_global_scale is not None:
+            sub_qlayer.input_global_scale = input_global_scale
+
+        # Register under the parent module with the HF-style name
+        setattr(parent, sub_name, sub_qlayer)
+
+    # Remove the original fused layer from the parent
+    delattr(parent, layer_base)
+    logger.info("Unfused vLLM layer %s → %s", name, sub_names)
+    return True
+
 
 def pack_layer(name, model, device=None):
     layer = get_module(model, name)
-    if type(layer) not in SUPPORTED_LAYER_TYPES and not isinstance(layer, WrapperWALayer):  ##already packed
-        return
+    _is_vllm_linear = _VLLMLinearBase is not None and isinstance(layer, _VLLMLinearBase)
+    if type(layer) not in SUPPORTED_LAYER_TYPES and not isinstance(layer, WrapperWALayer) and not _is_vllm_linear:
+        return  ##already packed
 
     if isinstance(layer, WrapperWALayer):  # revert WrapperWALayer for offline usage
         wp_layer = layer
         layer = wp_layer.orig_layer
         set_module(model, name, layer)
+        _is_vllm_linear = _VLLMLinearBase is not None and isinstance(layer, _VLLMLinearBase)
 
     orig_device = layer.weight.device
     data_type = layer.data_type
@@ -106,6 +219,10 @@ def pack_layer(name, model, device=None):
     elif type(layer) == transformers.pytorch_utils.Conv1D:
         in_features = layer.weight.shape[0]
         out_features = layer.weight.shape[1]
+    elif _is_vllm_linear:
+        # vLLM LinearBase uses input_size / output_size instead of in_features / out_features
+        in_features = layer.input_size
+        out_features = layer.output_size
 
     bias = layer.bias is not None
     ##bias = True  ## if using the above, llama3 lambada RTN will be NAN , TODO why?
@@ -129,7 +246,21 @@ def pack_layer(name, model, device=None):
     # zero = layer.zp # no zeros to handle, as mxfp/nvfp do not support asym quantization
     qlayer.pack(layer, scale, global_scale=global_scale, input_global_scale=input_global_scale, device=device)
     qlayer.to(orig_device)
+
+    # For vLLM fused layers (qkv_proj, gate_up_proj), store the per-part output
+    # sizes so _unfuse_vllm_packed_layer can slice them into HF-style sub-layers.
+    if _is_vllm_linear and hasattr(layer, "output_sizes"):
+        qlayer._vllm_output_sizes = list(layer.output_sizes)
+        # QuantLinear stores act_data_type in **kwargs but doesn't set self.act_data_type;
+        # store it explicitly so _unfuse_vllm_packed_layer can read it.
+        qlayer.act_data_type = act_data_type
+
     set_module(model, name, qlayer)
+
+    # Attempt to unfuse vLLM fused layers into HF-style separate sub-layers.
+    if _is_vllm_linear:
+        _unfuse_vllm_packed_layer(name, model, qlayer)
+
     # Note: release weight and bias explicitly, in case they are referenced elsewhere
     release_layer_safely(layer)
 

--- a/auto_round/export/export_to_llmcompressor/export_to_fp.py
+++ b/auto_round/export/export_to_llmcompressor/export_to_fp.py
@@ -201,6 +201,13 @@ def pack_layer(name, model, device=None):
     if is_nv_fp(act_data_type) and act_bits <= 8:
         input_global_scale = getattr(layer, "input_global_scale", None)
         if input_global_scale is None:
+            if not hasattr(layer, "act_max"):
+                from auto_round.logger import logger as _logger
+                _logger.error(
+                    f"act_max missing for layer '{name}' "
+                    f"(type={type(layer).__name__}, act_bits={act_bits}, act_data_type={act_data_type}). "
+                    f"attrs: {[a for a in dir(layer) if not a.startswith('_')][:20]}"
+                )
             assert hasattr(layer, "act_max")
             from auto_round.data_type.nvfp import calculate_gparam
 

--- a/auto_round/export/export_to_llmcompressor/export_to_fp.py
+++ b/auto_round/export/export_to_llmcompressor/export_to_fp.py
@@ -203,6 +203,7 @@ def pack_layer(name, model, device=None):
         if input_global_scale is None:
             if not hasattr(layer, "act_max"):
                 from auto_round.logger import logger as _logger
+
                 _logger.error(
                     f"act_max missing for layer '{name}' "
                     f"(type={type(layer).__name__}, act_bits={act_bits}, act_data_type={act_data_type}). "

--- a/auto_round/export/utils.py
+++ b/auto_round/export/utils.py
@@ -264,8 +264,9 @@ def save_model(
     else:
         try:
             model.save_pretrained(save_dir, max_shard_size=max_shard_size, safe_serialization=safe_serialization)
-        except (KeyError, TypeError) as e:
+        except (KeyError, TypeError, AttributeError) as e:
             # Some third-party configs fail during config serialization in save_pretrained.
+            # AttributeError is raised when the model lacks save_pretrained (e.g. vLLM models).
             # Fall back to saving weights separately + config without diff.
             logger.warning("model.save_pretrained failed (%s), falling back to manual save.", e)
             from safetensors.torch import save_file

--- a/auto_round/utils/common.py
+++ b/auto_round/utils/common.py
@@ -640,6 +640,10 @@ deepspeed_exists = False
 if importlib.util.find_spec("deepspeed"):  # check if deepspeed is installed
     deepspeed_exists = True
 
+vllm_exists = False
+if importlib.util.find_spec("vllm"):  # check if vllm is installed
+    vllm_exists = True
+
 SUPPORTED_DTYPES = ("int", "mx_fp", "fp", "nv_fp", "mx_int")
 SUPPORTED_FORMATS = SupportedFormats()
 SUPPORTED_LAYER_TYPES = (torch.nn.Linear, transformers.pytorch_utils.Conv1D)

--- a/auto_round/utils/model.py
+++ b/auto_round/utils/model.py
@@ -994,9 +994,7 @@ def vllm_load_model(
     if not hasattr(model, "config"):
         _hf_model_name = llm.llm_engine.model_config.model
         try:
-            model.config = AutoConfig.from_pretrained(
-                _hf_model_name, trust_remote_code=True
-            )
+            model.config = AutoConfig.from_pretrained(_hf_model_name, trust_remote_code=True)
         except Exception as _e:
             logger.warning(
                 "Could not attach HF config to vLLM model from %r: %s. "

--- a/auto_round/utils/model.py
+++ b/auto_round/utils/model.py
@@ -20,7 +20,6 @@ from collections import UserDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
 
-import psutil
 import torch
 import transformers
 from packaging import version
@@ -190,6 +189,16 @@ def check_diffusers_installed():  # pragma: no cover
         return True
     except ImportError:
         logger.error("Please install diffusers via 'pip install diffusers'" " to run diffusion model")
+        exit(-1)
+
+
+def check_vllm_installed():  # pragma: no cover
+    try:
+        from vllm import LLM, SamplingParams  # noqa: F401
+
+        return True
+    except ImportError:
+        logger.error("Please install vllm via 'pip install vllm'" " to run vllm model")
         exit(-1)
 
 
@@ -925,6 +934,94 @@ def diffusion_load_model(
     return pipe, model.to(device)
 
 
+def vllm_load_model(
+    pretrained_model_name_or_path: str,
+    **kwargs,
+):
+    check_vllm_installed()
+    from transformers import AutoConfig, AutoTokenizer
+    from vllm import LLM
+
+    tp = kwargs.get("tensor_parallel_size", 1)
+    if tp != 1:
+        raise ValueError(
+            f"vllm_load_model only supports single-GPU quantization "
+            f"(tensor_parallel_size=1), but got tensor_parallel_size={tp}. "
+            "Multi-GPU TP is not supported: the wrapper forward, unfuse logic, "
+            "and act_max collection all assume TP=1."
+        )
+
+    if isinstance(pretrained_model_name_or_path, str):
+
+        os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+        logger.warning("VLLM_ENABLE_V1_MULTIPROCESSING is set to 0 for vllm model quantization")
+
+        # Keep max_model_len consistent with model config by default to avoid
+        # vLLM validation errors on short-context models.
+        user_max_model_len = kwargs.pop("max_model_len", None)
+        gpu_memory_utilization = kwargs.pop("gpu_memory_utilization", 0.8)
+
+        _CALIB_MAX_LEN = 4096
+        if user_max_model_len is not None:
+            max_model_len = max(user_max_model_len, _CALIB_MAX_LEN)
+        else:
+            max_model_len = _CALIB_MAX_LEN
+
+        llm = LLM(
+            pretrained_model_name_or_path,
+            enforce_eager=True,
+            gpu_memory_utilization=gpu_memory_utilization,
+            max_model_len=max_model_len,
+            # Reserve a fixed KV cache so vLLM's memory profiler does not
+            # try to allocate a large KV cache and OOM during calibration.
+            # 1 GB accommodates max_model_len up to ~7K (typical calibration
+            # needs are ≤ 4096 tokens).
+            kv_cache_memory_bytes=1024 * 1024 * 1024,
+            **kwargs,
+        )
+        model = llm.llm_engine.engine_core.engine_core.model_executor.driver_worker.worker.model_runner.model
+    elif isinstance(pretrained_model_name_or_path, LLM):
+        llm = pretrained_model_name_or_path
+        model = llm.llm_engine.engine_core.engine_core.model_executor.driver_worker.worker.model_runner.model
+    else:
+        raise ValueError(f"Only support str or LLM class for model, but get {type(model)}")
+
+    tokenizer = AutoTokenizer.from_pretrained(llm.llm_engine.model_config.model)
+
+    # Attach the HF config to the raw vLLM nn.Module so that export functions
+    # (save_quantized_as_llmcompressor etc.) can write config.json and embed
+    # quantization_config without AttributeError on model.config.
+    if not hasattr(model, "config"):
+        _hf_model_name = llm.llm_engine.model_config.model
+        try:
+            model.config = AutoConfig.from_pretrained(_hf_model_name, trust_remote_code=True)
+        except Exception as _e:
+            logger.warning(
+                "Could not attach HF config to vLLM model from %r: %s. "
+                "The export step may fail to write config.json.",
+                _hf_model_name,
+                _e,
+            )
+
+    if not hasattr(model.__class__, "dtype"):
+
+        @property
+        def dtype(self):
+            return self.lm_head.weight.dtype
+
+        setattr(model.__class__, "dtype", dtype)
+
+    if not hasattr(model.__class__, "device"):
+
+        @property
+        def device(self):
+            return self.lm_head.weight.device
+
+        setattr(model.__class__, "device", device)
+
+    return llm, model, tokenizer
+
+
 def is_pure_text_model(model):
     """verify on: phi-3.5, Mistral-Small-3.1, gemma-3, qwen2-vl,"""
     if hasattr(model, "config") and hasattr(model.config, "vision_config"):
@@ -1055,7 +1152,7 @@ def is_diffusion_model(model_or_path: Union[str, object], trust_remote_code: boo
                 index_file = hf_hub_download(model_or_path, "model_index.json")
                 check_diffusers_installed()
             except Exception as e:
-                print(e)
+                logger.debug(f"model_index.json not found for {model_or_path}: {e}")
                 index_file = None
 
         elif os.path.exists(os.path.join(model_or_path, "model_index.json")):
@@ -1070,16 +1167,39 @@ def is_diffusion_model(model_or_path: Union[str, object], trust_remote_code: boo
         return False
 
 
+def is_vllm_model(model_or_path: object) -> bool:
+    if "vllm" in str(type(model_or_path)):
+        check_vllm_installed()
+        if not isinstance(model_or_path, torch.nn.Module):
+            attr = get_nested_attr(
+                model_or_path,
+                "llm_engine.engine_core.engine_core.model_executor.driver_worker.worker.model_runner.model",
+            )
+            if attr is None:
+                raise ValueError(
+                    "Please add VLLM_ENABLE_V1_MULTIPROCESSING=0 and use enforce_eager=True to load vllm model"
+                )
+            return True
+        else:
+            return True
+    else:
+        return False
+
+
 def detect_model_type(model):
-    """Detect the type of model (LLM, MLLM, or Diffusion).
+    """Detect the type of model (LLM, MLLM, Diffusion, or vLLM based).
 
     Args:
         model: Model instance or model path string
 
     Returns:
-        str: "mllm", "diffusion", or "llm"
+        str: "mllm", "diffusion", "llm", or "vllm"
     """
-    # Check if it's a diffusion model first (more specific)
+    # Check if it's a vLLM based model first (based on class name)
+    if is_vllm_model(model):
+        return "vllm"
+
+    # Check if it's a diffusion model (more specific)
     if is_diffusion_model(model):
         return "diffusion"
 
@@ -1337,10 +1457,18 @@ def get_layer_names_in_block(
         list: A list of strings, where each string is the name of a layer
               within a block of the model.
     """
+    # Lazy import for vLLM LinearBase support (None when vLLM not installed).
+    _vllm_linear_base = None
+    try:
+        from vllm.model_executor.layers.linear import LinearBase as _vllm_linear_base
+    except Exception:
+        pass
+
     if class_names is None:
         class_names = []
     for n, m in model.named_modules():
-        if type(m) in supported_types or (class_names is not None and m.__class__.__name__ in class_names):
+        is_vllm = _vllm_linear_base is not None and isinstance(m, _vllm_linear_base)
+        if type(m) in supported_types or (class_names is not None and m.__class__.__name__ in class_names) or is_vllm:
             m.bk_global_name = n
     layers_in_block = []
     if bool(quant_block_list):
@@ -1961,7 +2089,6 @@ _EXTRA_MODEL_FILES = {
 
 def _copy_extra_model_files(src_dir: str, dst_dir: str):
     """Copy known extra model files from *src_dir* to *dst_dir* if they exist."""
-    import os
     import shutil
 
     for file in os.listdir(src_dir):
@@ -2200,13 +2327,31 @@ def wrap_block_forward_positional_to_kwargs(base_hook):
                 sig = inspect.signature(sig_target)
                 _param_names_cache[m_id] = [p for p in sig.parameters.keys() if p != "self"]
             _param_names = _param_names_cache[m_id]
-            for i, val in enumerate(positional_inputs):
-                param_idx = i + 1  # hidden_states is params[0]
-                if param_idx < len(_param_names):
-                    param_name = _param_names[param_idx]
-                    if param_name not in kwargs:
-                        kwargs[param_name] = val
-            positional_inputs = ()
+
+            # If the original forward's first parameter is NOT "hidden_states" (e.g.,
+            # vLLM's DecoderLayer uses ``(positions, hidden_states, residual)``), then
+            # what arrived in the ``hidden_states`` slot is actually the first positional
+            # arg.  Re-map all positional args according to the true signature.
+            if _param_names and _param_names[0] != "hidden_states":
+                all_args = (hidden_states,) + tuple(positional_inputs)
+                hidden_states = None
+                positional_inputs = ()
+                for i, val in enumerate(all_args):
+                    if i >= len(_param_names):
+                        break
+                    pname = _param_names[i]
+                    if pname == "hidden_states":
+                        hidden_states = val
+                    elif pname not in kwargs:
+                        kwargs[pname] = val
+            else:
+                for i, val in enumerate(positional_inputs):
+                    param_idx = i + 1  # hidden_states is params[0]
+                    if param_idx < len(_param_names):
+                        param_name = _param_names[param_idx]
+                        if param_name not in kwargs:
+                            kwargs[param_name] = val
+                positional_inputs = ()
         return base_hook(m, hidden_states, *positional_inputs, **kwargs)
 
     return forward
@@ -2230,8 +2375,6 @@ def config_save_pretrained(config, file_name, save_directory, model=None):
 def rename_weights_files(path: str, prefix="diffusion_pytorch_model"):
     """Rename weight files for diffusion models."""
     import glob
-    import json
-    import os
 
     # rename safetensors
     files = sorted(glob.glob(f"{path}/*.safetensors"))

--- a/auto_round/utils/model.py
+++ b/auto_round/utils/model.py
@@ -963,7 +963,7 @@ def vllm_load_model(
 
         _CALIB_MAX_LEN = 4096
         if user_max_model_len is not None:
-            max_model_len = max(user_max_model_len, _CALIB_MAX_LEN)
+            max_model_len = min(user_max_model_len, _CALIB_MAX_LEN)
         else:
             max_model_len = _CALIB_MAX_LEN
 
@@ -994,7 +994,9 @@ def vllm_load_model(
     if not hasattr(model, "config"):
         _hf_model_name = llm.llm_engine.model_config.model
         try:
-            model.config = AutoConfig.from_pretrained(_hf_model_name, trust_remote_code=True)
+            model.config = AutoConfig.from_pretrained(
+                _hf_model_name, trust_remote_code=True
+            )
         except Exception as _e:
             logger.warning(
                 "Could not attach HF config to vLLM model from %r: %s. "
@@ -1342,6 +1344,15 @@ def get_expert_linear_names(module: torch.nn.Module) -> list[str]:
         return ["linear_fc1", "linear_fc2"]
     elif module_match_name_list(module, ["DBRXMoeSparseMoeBlock"]):
         return ["w1_linear", "w2_linear", "v1_linear"]
+    elif module_match_name_list(module, ["LinearizedVLLMFusedMoE"]):
+        # Infer linear names from the first per-expert child (numbered "0", "1", …).
+        first_expert = next((m for n, m in module._modules.items() if n.isdigit()), None)
+        if first_expert is not None:
+            names = [n for n, m in first_expert.named_children() if isinstance(m, torch.nn.Linear)]
+            if names:
+                return names
+        # Fallback for standard MLP-style experts
+        return ["gate_proj", "down_proj", "up_proj"]
     else:
         # assuming w1, w2, w3 by default
         return ["w1", "w2", "w3"]
@@ -1385,6 +1396,14 @@ def get_expert_input_proj_names(module: torch.nn.Module) -> list[str]:
     elif module_match_name_list(module, ["DBRXMoeSparseMoeBlock"]):
         # w1_linear and v1_linear are input projections, w2_linear is output
         return ["w1_linear", "v1_linear"]
+    elif module_match_name_list(module, ["LinearizedVLLMFusedMoE"]):
+        # Infer input projection names: all linear children of the first expert except down_proj.
+        first_expert = next((m for n, m in module._modules.items() if n.isdigit()), None)
+        if first_expert is not None:
+            linear_names = [n for n, m in first_expert.named_children() if isinstance(m, torch.nn.Linear)]
+            # Exclude the output projection (commonly "down_proj" or "w2")
+            return [n for n in linear_names if n not in ("down_proj", "w2", "linear_fc2")]
+        return ["gate_proj", "up_proj"]
     else:
         logger.warning_once("Using default input projection names ['w1', 'w3'] for MoE expert alignment. ")
         # Default: w1 and w3 are input projections, w2 is output
@@ -1942,8 +1961,25 @@ def set_amax_for_all_moe_layers(model: torch.nn.Module, layer_name=None, attr_na
                 f"fused experts use parent module's act_max"
             )
             continue
+        elif "LinearizedVLLMFusedMoE" in type(sub_module.experts).__name__:
+            # LinearizedVLLMFusedMoE stores per-expert modules as numbered children.
+            # It is itself a named submodule and will appear as `sub_module` in a later
+            # iteration of this loop, at which point its `experts` property returns a
+            # plain list that passes the isinstance(…, Iterable) check below.  Skip here
+            # to avoid the "Unknown experts structure" warning on the outer MLP wrapper.
+            logger.debug(
+                f"Skipping '{name}' ({type(sub_module).__name__}): its experts "
+                f"(LinearizedVLLMFusedMoE) will be processed as a direct submodule."
+            )
+            continue
         elif isinstance(sub_module.experts, collections.abc.Iterable):
             # Iterable experts: list of expert modules (e.g., Mixtral)
+            logger.debug(
+                f"set_amax_for_all_moe_layers: processing '{name}' "
+                f"(type={type(sub_module).__name__}) with "
+                f"{len(list(sub_module.experts))} experts, "
+                f"linear_names={expert_linear_names}"
+            )
             for linear_name in expert_linear_names:
                 try:
                     # Determine if this is an input projection that needs scale unification
@@ -2000,8 +2036,16 @@ def _set_amax_for_moe_auxiliary_layers(moe_module: torch.nn.Module, attr_name: s
     # Collect all Linear layers that have act_bits set but missing act_max
     layers_needing_amax = []
 
-    # Check gate (router) layer - it's typically a Linear layer for token routing
-    if hasattr(moe_module, "gate") and isinstance(moe_module.gate, torch.nn.Linear):
+    # Lazy import for vLLM LinearBase (ReplicatedLinear, ColumnParallelLinear, etc.)
+    _LinearBase = None
+    try:
+        from vllm.model_executor.layers.linear import LinearBase as _LinearBase
+    except Exception:
+        pass
+    _linear_types = (torch.nn.Linear,) if _LinearBase is None else (torch.nn.Linear, _LinearBase)
+
+    # Check gate (router) layer - it may be nn.Linear or a vLLM LinearBase subclass
+    if hasattr(moe_module, "gate") and isinstance(moe_module.gate, _linear_types):
         gate = moe_module.gate
         if hasattr(gate, "act_bits") and gate.act_bits < 8:
             if get_nested_attr(gate, attr_name) is None:
@@ -2012,7 +2056,7 @@ def _set_amax_for_moe_auxiliary_layers(moe_module: torch.nn.Module, attr_name: s
         shared_experts = moe_module.shared_experts
         if shared_experts is not None:
             for child_name, child in shared_experts.named_modules():
-                if isinstance(child, torch.nn.Linear):
+                if isinstance(child, _linear_types):
                     if hasattr(child, "act_bits") and child.act_bits < 8:
                         if get_nested_attr(child, attr_name) is None:
                             layers_needing_amax.append(child)
@@ -2056,10 +2100,21 @@ def _get_reference_amax_from_experts(moe_module: torch.nn.Module, attr_name: str
 
     experts = moe_module.experts
 
+    # Handle LinearizedVLLMFusedMoE: .experts is a module with its own .experts property
+    # returning the list of per-expert modules.  Resolve the actual expert list and use
+    # the inner module (not the outer MLP) to look up correct linear names.
+    actual_experts = None
+    expert_linear_source = moe_module  # used for get_expert_linear_names()
+    if hasattr(experts, "experts") and isinstance(getattr(experts, "experts"), list):
+        actual_experts = experts.experts
+        expert_linear_source = experts  # LinearizedVLLMFusedMoE knows its own linear names
+    elif isinstance(experts, collections.abc.Iterable):
+        actual_experts = list(experts)
+
     # Handle iterable experts (list of modules)
-    if isinstance(experts, collections.abc.Iterable):
-        expert_linear_names = get_expert_linear_names(moe_module)
-        for expert in experts:
+    if actual_experts is not None:
+        expert_linear_names = get_expert_linear_names(expert_linear_source)
+        for expert in actual_experts:
             for linear_name in expert_linear_names:
                 layer = getattr(expert, linear_name, None)
                 if layer is not None:

--- a/auto_round/wrapper.py
+++ b/auto_round/wrapper.py
@@ -29,11 +29,19 @@ from auto_round.utils import (
     compile_func,
     deepspeed_exists,
     set_module,
+    vllm_exists,
 )
 
 if deepspeed_exists:
     from deepspeed import comm as dist
     from deepspeed.module_inject import LinearAllreduce, LinearLayer
+
+_VLLMLinearBase = None
+if vllm_exists:
+    try:
+        from vllm.model_executor.layers.linear import LinearBase as _VLLMLinearBase
+    except Exception:
+        pass
 
 
 def get_scale_shape(weight, group_size):
@@ -117,7 +125,9 @@ class WrapperLinear(torch.nn.Module):
         else:
             self.q_scale_thresh = 1e-5
         self._init_tuning_params_and_quant_func()
-        if deepspeed_exists:
+        if _VLLMLinearBase is not None and isinstance(self.orig_layer, _VLLMLinearBase):
+            self.orig_forward = self.vllm_linear_forward
+        elif deepspeed_exists:
             if type(self.orig_layer) in (torch.nn.Linear, LinearLayer):
                 self.orig_forward = self.linear_forward
             elif type(self.orig_layer) == LinearAllreduce:
@@ -475,6 +485,16 @@ class WrapperLinear(torch.nn.Module):
         """
         return F.linear(x, weight, bias)  # pylint: disable=E1102
 
+    def vllm_linear_forward(self, x, weight, bias):
+        """Forward for vLLM LinearBase subclasses (ColumnParallelLinear,
+        RowParallelLinear, etc.).
+
+        During quantization tuning TP=1, so F.linear is equivalent to the
+        original vLLM quant_method.apply.  The wrapper forward re-wraps the
+        result into a tuple when skip_bias_add=True.
+        """
+        return F.linear(x, weight, bias)  # pylint: disable=E1102
+
     def all_reduce_linear_forward(self, x, weight, bias):
         """Performs the forward pass for a linear layer.
 
@@ -556,6 +576,15 @@ class WrapperLinear(torch.nn.Module):
             hook_result = hook(self.orig_layer, (x,), output)
             if hook_result is not None:
                 output = hook_result
+
+        # vLLM parallel linear layers ALWAYS return (output, output_bias) 2-tuple.
+        # When skip_bias_add=True, bias is returned for caller to add; else None.
+        # Returning a bare tensor would cause callers like:
+        #   qkv, _ = self.qkv_proj(hidden_states)
+        # to unpack the tensor's first dimension → "too many values to unpack".
+        if _VLLMLinearBase is not None and isinstance(self.orig_layer, _VLLMLinearBase):
+            output_bias = self.orig_layer.bias if getattr(self.orig_layer, "skip_bias_add", False) else None
+            return output, output_bias
 
         return output
 
@@ -790,7 +819,7 @@ def wrapper_block(
     quantized_layers = []
     unquantized_layers = []
     for n, m in block.named_modules():
-        if type(m) in SUPPORTED_LAYER_TYPES:
+        if type(m) in SUPPORTED_LAYER_TYPES or (_VLLMLinearBase is not None and isinstance(m, _VLLMLinearBase)):
             if not check_to_quantized(m):
                 unquantized_layers.append(n)
                 continue


### PR DESCRIPTION
## Description

### Summary

Adds `--enable_vllm_loading` to load a model through the vLLM engine before quantization, enabling quantization of models that rely on vLLM's kernel infrastructure (e.g., `FusedMoE`, `ColumnParallelLinear`) and exporting them in `llm_compressor` format for direct vLLM inference.

**Supported schemes:** `W4A16`, `W8A16`, `MXFP8`, `MXFP4`, `NVFP4`  
**Constraint:** Single-GPU only (`tensor_parallel_size=1`); enforced at both CLI and API level.

---

### Key Changes

| Component | Change |
|---|---|
| `cli/parser.py`, `cli/main.py` | Add `--enable_vllm_loading` and `--vllm_model_kwargs` (JSON) CLI flags; TP=1 guard |
| `compressors/vllm_mixin.py` *(new)* | `VLLMMixin`: registers vLLM `LinearBase` layers into `layer_config` |
| `compressors/vllm/vllm_calibrator.py` *(new)* | Drives `llm.generate()` for block-hook calibration; registers act_max hooks for static activation quantization (NVFP4) |
| `compressors/vllm/linearized_fused_moe.py` *(new)* | Decomposes vLLM `FusedMoE` (3-D weight tensors) into per-expert `nn.Linear` before quantization |
| `context/model.py` | Add vLLM load path; call `linearize_vllm_moe()` in `prepare_model()` |
| `wrapper.py` | `vllm_linear_forward`: replaces vLLM `quant_method.apply` with `F.linear` (valid at TP=1) |
| `export/export_to_llmcompressor/export.py` | Integer formats: convert `LinearBase`→`nn.Linear` before packing; unfuse `qkv_proj`→`q/k/v_proj` and `gate_up_proj`→`gate/up_proj` after packing |
| `export/export_to_llmcompressor/export_to_fp.py` | FP formats: same unfuse logic for MXFP8/MXFP4/NVFP4 |
| `algorithms/quantization/rtn/quantizer.py` | `list(block.named_modules())` snapshot to prevent `RuntimeError` when unfuse mutates `_modules` during iteration |
| `calibration/hooks.py` | Pass `hidden_states` as keyword arg; recognize `LinearBase` as leaf layer (not block) |
| `compressors/data_driven.py` | Preserve `int64` tensors (`positions`) in `input_others`; skip `collect_reference` when vLLM `ForwardContext` is unavailable (safe for `iters=0`) |

---

### Validated Tests

**Environment:** vLLM v0.22.1, A100-80G, single GPU

#### Quantization

```bash
# W4A16 — Qwen3-30B-A3B, Qwen3-4B (dense/MoE, RTN zero-shot)
auto-round \
  --model /dataset/Qwen3-30B-A3B \
  --format llm_compressor \
  --scheme W4A16 \
  --output_dir /tmp/qwen3_30b_w4a16 \
  --enable_vllm_loading \
  --iters 0 \
  --disable_opt_rtn

# W4A16 — Qwen3-30B-A3B, Qwen3-4B (dense/MoE, Opt-RTN)
auto-round \
  --model /dataset/Qwen3-30B-A3B \
  --format llm_compressor \
  --scheme W4A16 \
  --output_dir /tmp/qwen3_30b_w4a16 \
  --enable_vllm_loading \
  --iters 0 \
  --nsamples 128

# NVFP4 — Qwen3-30B-A3B, Qwen3-4B (dense/MOE, RTN zero-shot, static activation quantization)
auto-round \
  --model /dataset/Qwen3-30B-A3B \
  --format llm_compressor \
  --scheme NVFP4 \
  --output_dir /tmp/qwen3_4b_nvfp4 \
  --enable_vllm_loading \
  --disable_opt_rtn \
  --iters 0 \
  --nsamples 128

# MXFP4 — Qwen3-30B-A3B, Qwen3-4B (dense/MOE, RTN zero-shot)
auto-round \
  --model /dataset/Qwen3-4B \
  --format llm_compressor \
  --scheme MXFP4 \
  --output_dir /tmp/qwen3_4b_mxfp4 \
  --enable_vllm_loading \
  --disable_opt_rtn \
  --iters 0 

# MXFP8 — Qwen3-30B-A3B, Qwen3-4B (dense/MOE, RTN zero-shot)
auto-round \
  --model /dataset/Qwen3-30B-A3B \
  --format llm_compressor \
  --scheme MXFP8 \
  --output_dir /tmp/qwen3_30b_mxfp8 \
  --enable_vllm_loading \
  --disable_opt_rtn \
  --iters 0 \
```

Inference (vLLM)
from vllm import LLM, SamplingParams
```
llm = LLM(
    model="/tmp/qwen3_30b_w4a16/w4g128",  # or any output dir above
    max_model_len=512,
)
outputs = llm.generate(
    ["What is the capital of France?"],
    SamplingParams(temperature=0.0, max_tokens=32),
)
print(outputs[0].outputs[0].text)
```
quantization=compressed-tensors is loaded automatically from `quantization_config` in  `config.json`. All four quantized models loaded and generated correct outputs.

#### Known Limitations

- tensor_parallel_size > 1 is explicitly rejected with `ValueError`— wrapper forward and unfuse logic assume TP=1.
- Multimodal and diffusion models conflict with `--enable_vllm_loading` and raise an early error.
- `iters > 0` (gradient-based tuning) with vLLM loading is not tested; collect_reference skips are safe only for `iters=0`

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

 New feature

## Related Issues

<!-- Link to related issues using #issue_number -->


Fixes or relates to https://github.com/intel/auto-round/issues/1119

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
