### PR TITLE
Implement AutoScheme support for model-free packing with validation a…

### DIFF
--- a/auto_round/compressors/model_free.py
+++ b/auto_round/compressors/model_free.py
@@ -1514,9 +1514,16 @@ def _validate_auto_scheme_options(auto_scheme: Any) -> str:
     families: set[str] = set()
     unsupported: list[Any] = []
     for opt in options:
-        try:
-            scheme_obj = _normalize_scheme(opt) if isinstance(opt, (str, QuantizationScheme)) else None
-        except (ValueError, TypeError):
+        # Preserve original string validation semantics so preset-name
+        # restrictions (e.g. MXFP4/MXFP8 only) are enforced.
+        if isinstance(opt, str):
+            try:
+                scheme_obj = _normalize_scheme(opt)
+            except (ValueError, TypeError):
+                scheme_obj = None
+        elif isinstance(opt, QuantizationScheme):
+            scheme_obj = opt
+        else:
             scheme_obj = None
 
         # GGUF k-quants carry super_bits and are not packable by the model-free
@@ -1524,7 +1531,7 @@ def _validate_auto_scheme_options(auto_scheme: Any) -> str:
         if scheme_obj is None or getattr(scheme_obj, "super_bits", None) is not None:
             unsupported.append(opt)
             continue
-        if not is_model_free_supported_scheme(scheme_obj):
+        if not is_model_free_supported_scheme(opt):
             unsupported.append(opt)
             continue
 

--- a/auto_round/compressors/model_free.py
+++ b/auto_round/compressors/model_free.py
@@ -2089,7 +2089,7 @@ class _ModelFreeCompressorCore:
         # ---- AutoScheme: resolve per-layer schemes before anything else ----
         if _looks_like_auto_scheme(self.scheme_input):
             resolver = getattr(self, "_resolve_auto_scheme", None)
-            if resolver is None:
+            if not callable(resolver):
                 raise ValueError(
                     "AutoScheme schemes are only supported through the "
                     "AutoRound(model_free=True) API, not the low-level "
@@ -2362,13 +2362,18 @@ class ModelFreeCompressor(_ModelFreeCompressorCore):
         try:
             # post_init() (outside inference_mode) runs the delta-loss scheme
             # selection and populates ``compressor.layer_config``.
-            compressor.post_init()
+            post_init = getattr(compressor, "post_init", None)
+            if not callable(post_init):
+                raise RuntimeError("AutoScheme fallback compressor has no callable post_init().")
+            post_init()
             layer_config = copy.deepcopy(getattr(compressor, "layer_config", {}) or {})
         finally:
             # Release the model that was loaded only for scoring so the
             # packing phase keeps model-free's low memory footprint.
             try:
-                compressor.model_context.model = None
+                model_context = getattr(compressor, "model_context", None)
+                if model_context is not None and hasattr(model_context, "model"):
+                    model_context.model = None
             except Exception:  # pragma: no cover - best-effort cleanup
                 pass
             del compressor

--- a/auto_round/compressors/model_free.py
+++ b/auto_round/compressors/model_free.py
@@ -2102,7 +2102,7 @@ class _ModelFreeCompressorCore:
                     "AutoRound(model_free=True) API, not the low-level "
                     "_ModelFreeCompressorCore driver."
                 )
-            resolver()
+            resolver()  # pylint: disable=E1102
 
         # ---- preflight ----
         self._validate_format()
@@ -2372,7 +2372,7 @@ class ModelFreeCompressor(_ModelFreeCompressorCore):
             post_init = getattr(compressor, "post_init", None)
             if not callable(post_init):
                 raise RuntimeError("AutoScheme fallback compressor has no callable post_init().")
-            post_init()
+            post_init()  # pylint: disable=E1102
             layer_config = copy.deepcopy(getattr(compressor, "layer_config", {}) or {})
         finally:
             # Release the model that was loaded only for scoring so the

--- a/auto_round/compressors/model_free.py
+++ b/auto_round/compressors/model_free.py
@@ -1486,6 +1486,117 @@ def is_model_free_supported_scheme(
 
 
 # ---------------------------------------------------------------------------
+# AutoScheme support (two-phase: delta-loss selection + model-free packing)
+# ---------------------------------------------------------------------------
+
+
+def _looks_like_auto_scheme(scheme: Any) -> bool:
+    """Duck-typed check for an :class:`~auto_round.auto_scheme.AutoScheme`.
+
+    Avoids importing ``AutoScheme`` at module scope (it pulls in exporter /
+    compressor modules that would create an import cycle with this file).
+    """
+    return hasattr(scheme, "options") and hasattr(scheme, "avg_bits")
+
+
+def _validate_auto_scheme_options(auto_scheme: Any) -> str:
+    """Validate that every AutoScheme option is model-free-packable.
+
+    Returns the single data-type family shared by all options
+    (``"int"`` or ``"mx_fp"``).  Raises ``ValueError`` when any option is
+    unsupported or when INT and MXFP options are mixed (they use different
+    packing formats and cannot be produced in one model-free run).
+    """
+    options = list(getattr(auto_scheme, "options", []) or [])
+    if not options:
+        raise ValueError("AutoScheme.options must be non-empty for model-free mode.")
+
+    families: set[str] = set()
+    unsupported: list[Any] = []
+    for opt in options:
+        try:
+            scheme_obj = _normalize_scheme(opt) if isinstance(opt, (str, QuantizationScheme)) else None
+        except (ValueError, TypeError):
+            scheme_obj = None
+
+        # GGUF k-quants carry super_bits and are not packable by the model-free
+        # RTN kernel even though their data_type is nominally "int".
+        if scheme_obj is None or getattr(scheme_obj, "super_bits", None) is not None:
+            unsupported.append(opt)
+            continue
+        if not is_model_free_supported_scheme(scheme_obj):
+            unsupported.append(opt)
+            continue
+
+        data_type = (scheme_obj.data_type or "int").lower()
+        families.add("mx_fp" if is_mx_fp(data_type) else "int")
+
+    if unsupported:
+        raise ValueError(
+            f"Model-free + AutoScheme received unsupported option(s): {unsupported}. "
+            f"Model-free supports INT WOQ (bits in {_SUPPORTED_INT_BITS}) and MXFP "
+            f"(bits in {_SUPPORTED_MXFP_BITS}); GGUF / NVFP4 / FP8 options are not "
+            f"packable in model-free mode. Remove the unsupported options or pass "
+            f"disable_model_free=True to use the regular flow."
+        )
+    if len(families) > 1:
+        raise ValueError(
+            "Model-free + AutoScheme cannot mix INT and MXFP options in a single run "
+            f"(got families {sorted(families)}); INT and MXFP use different packing "
+            "formats. Use a single data-type family, or pass disable_model_free=True."
+        )
+    return families.pop()
+
+
+def _convert_auto_scheme_layer_config(
+    generated: dict[str, dict],
+) -> tuple[QuantizationScheme, dict[str, dict], list[str]]:
+    """Convert an AutoScheme-generated ``layer_config`` into model-free inputs.
+
+    Returns ``(base_scheme, per_layer_overrides, fp16_layers)`` where:
+
+    * ``base_scheme`` is the most common quantized scheme across layers, used
+      as the model-free default (top-level config.json ``bits``/``group_size``).
+    * ``per_layer_overrides`` maps every quantized layer name to its resolved
+      :class:`QuantizationScheme` fields.
+    * ``fp16_layers`` lists layers AutoScheme kept at >= 16 bits (added to the
+      model-free ignore list so they stay in full precision).
+    """
+    from collections import Counter
+
+    scheme_keys = {f.name for f in fields(QuantizationScheme)}
+    per_layer: dict[str, dict] = {}
+    fp16_layers: list[str] = []
+    counter: "Counter[tuple]" = Counter()
+
+    for name, cfg in generated.items():
+        if not isinstance(cfg, dict):
+            continue
+        bits = cfg.get("bits")
+        if bits is None:
+            continue
+        clean = {k: cfg[k] for k in scheme_keys if cfg.get(k) is not None}
+        if bits >= 16:
+            fp16_layers.append(name)
+            continue
+        data_type = (clean.get("data_type") or "int").lower()
+        per_layer[name] = clean
+        counter[(clean.get("bits"), clean.get("group_size"), bool(clean.get("sym", True)), data_type)] += 1
+
+    if not counter:
+        raise ValueError("AutoScheme did not assign any quantizable layers for model-free mode.")
+
+    (base_bits, base_group_size, base_sym, base_dtype), _ = counter.most_common(1)[0]
+    base_scheme = QuantizationScheme(
+        bits=base_bits,
+        group_size=base_group_size,
+        sym=base_sym,
+        data_type=base_dtype,
+    )
+    return base_scheme, per_layer, fp16_layers
+
+
+# ---------------------------------------------------------------------------
 # Main class
 # ---------------------------------------------------------------------------
 
@@ -1975,6 +2086,17 @@ class _ModelFreeCompressorCore:
         Returns:
             Absolute path to the output directory.
         """
+        # ---- AutoScheme: resolve per-layer schemes before anything else ----
+        if _looks_like_auto_scheme(self.scheme_input):
+            resolver = getattr(self, "_resolve_auto_scheme", None)
+            if resolver is None:
+                raise ValueError(
+                    "AutoScheme schemes are only supported through the "
+                    "AutoRound(model_free=True) API, not the low-level "
+                    "_ModelFreeCompressorCore driver."
+                )
+            resolver()
+
         # ---- preflight ----
         self._validate_format()
         self._parse_scheme()
@@ -2151,6 +2273,10 @@ class ModelFreeCompressor(_ModelFreeCompressorCore):
             self._fallback_init_kwargs["quant_nontext_module"] = quant_nontext_module
         # remaining kwargs intentionally consumed/ignored
 
+        # AutoScheme (two-phase delta-loss selection) state.
+        self._auto_scheme_resolved = False
+        self._auto_scheme_family: Optional[str] = None
+
     def _fallback_to_base_compressor(self):
         from auto_round.autoround import AutoRound
 
@@ -2217,6 +2343,87 @@ class ModelFreeCompressor(_ModelFreeCompressorCore):
         return super().__getattribute__(name)
 
     # ------------------------------------------------------------------
+    # AutoScheme (two-phase: delta-loss selection + model-free packing)
+    # ------------------------------------------------------------------
+
+    def _run_auto_scheme_selection(self, auto_scheme: Any) -> dict[str, dict]:
+        """Run AutoScheme delta-loss selection to obtain a per-layer config.
+
+        The model is loaded temporarily (via the regular AutoRound flow) so
+        that delta-loss scoring can run its forward/backward passes, then it is
+        released before the model-free shard-by-shard packing begins.
+        """
+        from auto_round.autoround import AutoRound
+
+        init_kwargs = dict(self._fallback_init_kwargs)
+        init_kwargs["scheme"] = auto_scheme
+
+        compressor = AutoRound(**init_kwargs, disable_model_free=True)
+        try:
+            # post_init() (outside inference_mode) runs the delta-loss scheme
+            # selection and populates ``compressor.layer_config``.
+            compressor.post_init()
+            layer_config = copy.deepcopy(getattr(compressor, "layer_config", {}) or {})
+        finally:
+            # Release the model that was loaded only for scoring so the
+            # packing phase keeps model-free's low memory footprint.
+            try:
+                compressor.model_context.model = None
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+            del compressor
+            clear_memory()
+
+        if not layer_config:
+            raise RuntimeError("AutoScheme did not produce a layer_config for model-free mode.")
+        return layer_config
+
+    def _resolve_auto_scheme(self) -> None:
+        """Resolve an ``AutoScheme`` scheme into concrete model-free inputs.
+
+        Idempotent.  Validates the options, runs delta-loss selection, then
+        rewrites ``scheme_input`` / ``layer_config_input`` / ``ignore_layers_input``
+        so the standard model-free pipeline can proceed unchanged.
+        """
+        if self._auto_scheme_resolved:
+            return
+
+        auto_scheme = self.scheme_input
+        family = _validate_auto_scheme_options(auto_scheme)
+        logger.info(
+            "Model-free + AutoScheme: generating a per-layer scheme via delta-loss. "
+            "The model is loaded temporarily for scoring, then released before "
+            "shard-by-shard packing."
+        )
+
+        generated = self._run_auto_scheme_selection(auto_scheme)
+        base_scheme, per_layer, fp16_layers = _convert_auto_scheme_layer_config(generated)
+
+        # Merge the generated per-layer overrides; any user-provided
+        # layer_config entries take priority.
+        merged_lc: dict = dict(per_layer)
+        if self.layer_config_input:
+            merged_lc.update(copy.deepcopy(self.layer_config_input))
+        self.layer_config_input = merged_lc
+
+        # Keep AutoScheme's 16-bit layers in full precision.
+        if fp16_layers:
+            extra = ",".join(fp16_layers)
+            self.ignore_layers_input = f"{self.ignore_layers_input},{extra}" if self.ignore_layers_input else extra
+
+        self.scheme_input = base_scheme
+        self._auto_scheme_family = family
+        self._auto_scheme_resolved = True
+
+        logger.info(
+            "Model-free + AutoScheme resolved: base scheme %s, %d per-layer override(s), "
+            "%d layer(s) kept at 16-bit.",
+            base_scheme,
+            len(per_layer),
+            len(fp16_layers),
+        )
+
+    # ------------------------------------------------------------------
     # AutoRound compressor interface
     # ------------------------------------------------------------------
 
@@ -2228,13 +2435,19 @@ class ModelFreeCompressor(_ModelFreeCompressorCore):
         **kwargs,
     ) -> Any:
         """Quantize and save — AutoRound compressor entry point."""
+        # AutoScheme: run delta-loss selection first so the effective scheme /
+        # data-type family (which drives the accepted export formats) is known.
+        if _looks_like_auto_scheme(self.scheme_input):
+            self._resolve_auto_scheme()
+
         # Accept the standard auto_round formats.
         _accepted_formats = {
             "auto_round",
             "auto_round:auto_gptq",
         }
-        # MXFP only supports the llm_compressor format.
-        if self.scheme_input in ["MXFP4", "MXFP8"]:
+        # MXFP only supports the llm_compressor format (INT string preset,
+        # or an AutoScheme run whose options resolved to the MXFP family).
+        if self.scheme_input in ["MXFP4", "MXFP8"] or self._auto_scheme_family == "mx_fp":
             _accepted_formats = ["llm_compressor"]
         if format not in _accepted_formats:
             logger.warning(

--- a/auto_round/utils/model.py
+++ b/auto_round/utils/model.py
@@ -2302,7 +2302,11 @@ def is_model_free_route(
 
     Note: this function only *reads* kwargs; it does **not** pop any keys.
     """
-    from auto_round.compressors.model_free import is_model_free_supported_scheme
+    from auto_round.compressors.model_free import (
+        _looks_like_auto_scheme,
+        _validate_auto_scheme_options,
+        is_model_free_supported_scheme,
+    )
 
     explicit = bool(kwargs.get("model_free", False))
     disabled = bool(kwargs.get("disable_model_free", False))
@@ -2313,15 +2317,23 @@ def is_model_free_route(
     if fmt is None:
         fmt = "auto_round"
     fmt_first = str(fmt).lower().replace(" ", "").split(",")[0]
+    common_conditions = not disabled and isinstance(model, str) and iters == 0 and disable_opt_rtn is True
+
+    if _looks_like_auto_scheme(scheme):
+        try:
+            family = _validate_auto_scheme_options(scheme)
+        except ValueError:
+            return False
+
+        if fmt_first == "auto_round":
+            return common_conditions and family == "int"
+        if fmt_first == "llm_compressor":
+            return common_conditions and family == "mx_fp"
+        return False
+
     if fmt_first != "auto_round":
         return False
-    return (
-        not disabled
-        and isinstance(model, str)
-        and iters == 0
-        and disable_opt_rtn is True
-        and is_model_free_supported_scheme(scheme, kwargs)
-    )
+    return common_conditions and is_model_free_supported_scheme(scheme, kwargs)
 
 
 def find_layers_from_config(model_dir: str, class_names: list[str] | None = None) -> dict[str, str]:

--- a/docs/step_by_step.md
+++ b/docs/step_by_step.md
@@ -486,6 +486,8 @@ We will try to optimize the RAM usage in the future. The RAM usage is about 1.1-
 #### Limitations
 Embedding layer is not supported in AutoScheme, it will use the best scheme in options.
 
+When using AutoScheme with `model_free=True`, only INT (`W2A16`/`W4A16`/`W8A16`) and MXFP (`MXFP4`/`MXFP8`) option families are supported. Options like `W3A16`, `GGUF:*`, and `NVFP4` will raise a `ValueError`. INT and MXFP families cannot be mixed in the same `AutoScheme`.
+
 ### AWQ Quantization Algorithm
 
 AWQ (`algorithm="awq"`) is a pre-processing quantization algorithm that analyzes activation patterns and applies channel-wise scaling to protect salient weights. It runs BEFORE the actual quantization (RTN by default, or auto_round/SignRound).
@@ -569,6 +571,7 @@ Model-free mode performs RTN WOQ quantization **without loading the full model i
 - **Per-layer configuration** – supports `--layer_config` for per-layer bit-width overrides and `--ignore_layers` to keep specific layers in full precision
 - **Predefined ignore layers** – automatically skips model-specific layers (e.g., MoE gates, MTP layers) based on config detection
 - **Bit-exact parity** with the standard `--iters 0 --disable_opt_rtn` flow for all supported schemes
+- **AutoScheme integration** – pass an `AutoScheme` object as `scheme` to get automatic mixed-bit selection followed by shard-by-shard packing (two-phase: score with model briefly loaded, then free and pack)
 
 <details>
   <summary>Model-free Parallelism Benchmarks (Rounded Minutes)</summary>
@@ -697,6 +700,41 @@ AutoRound(
 ```
 
 > **Note:** Model-free mode uses RTN (no calibration data, no iterative tuning).  INT schemes output in `auto_round:auto_gptq` format; MXFP schemes output in compressed-tensors format (`mxfp4-pack-quantized` / `mxfp8-quantized`).  For higher-quality quantization or schemes outside the supported list, use the standard AutoRound flow.
+
+#### AutoScheme + Model-Free (Mixed-Bit)
+
+You can combine `AutoScheme` with `model_free=True` for automatic mixed-bit selection with minimal memory overhead. AutoRound uses a **two-phase** approach:
+
+1. **Selection phase** — briefly loads the model, runs delta-loss scoring to determine per-layer bit allocations, then immediately frees the model from memory.
+2. **Packing phase** — performs the normal shard-by-shard model-free packing using the selected per-layer configuration.
+
+**Constraints:**
+- Only INT options (`W2A16`, `W4A16`, `W8A16`, and custom `QuantizationScheme` with `bits ∈ {2, 4, 8}`) and MXFP options (`MXFP4`, `MXFP8`) are supported.
+- INT and MXFP options cannot be mixed in the same `AutoScheme`.
+- Unsupported options (`W3A16`, `GGUF:*`, `NVFP4`, etc.) raise `ValueError` immediately.
+- MXFP selection automatically uses `llm_compressor` export format.
+
+```python
+from auto_round import AutoRound, AutoScheme
+
+# INT mixed-bit: layers get W2A16, W4A16, or W8A16 based on delta-loss scoring
+scheme = AutoScheme(avg_bits=3.0, options=("W2A16", "W4A16", "W8A16"), nsamples=128)
+AutoRound(
+    model="meta-llama/Llama-3.2-1B-Instruct",
+    scheme=scheme,
+    iters=0,
+    model_free=True,
+).quantize_and_save("./int-mixed-llama", format="auto_round")
+
+# MXFP mixed-bit (requires llm_compressor)
+scheme = AutoScheme(avg_bits=6.0, options=("MXFP4", "MXFP8"), nsamples=128)
+AutoRound(
+    model="meta-llama/Llama-3.2-1B-Instruct",
+    scheme=scheme,
+    iters=0,
+    model_free=True,
+).quantize_and_save("./mxfp-mixed-llama", format="llm_compressor")
+```
 
 </details>
 

--- a/docs/step_by_step.md
+++ b/docs/step_by_step.md
@@ -701,41 +701,6 @@ AutoRound(
 
 > **Note:** Model-free mode uses RTN (no calibration data, no iterative tuning).  INT schemes output in `auto_round:auto_gptq` format; MXFP schemes output in compressed-tensors format (`mxfp4-pack-quantized` / `mxfp8-quantized`).  For higher-quality quantization or schemes outside the supported list, use the standard AutoRound flow.
 
-#### AutoScheme + Model-Free (Mixed-Bit)
-
-You can combine `AutoScheme` with `model_free=True` for automatic mixed-bit selection with minimal memory overhead. AutoRound uses a **two-phase** approach:
-
-1. **Selection phase** — briefly loads the model, runs delta-loss scoring to determine per-layer bit allocations, then immediately frees the model from memory.
-2. **Packing phase** — performs the normal shard-by-shard model-free packing using the selected per-layer configuration.
-
-**Constraints:**
-- Only INT options (`W2A16`, `W4A16`, `W8A16`, and custom `QuantizationScheme` with `bits ∈ {2, 4, 8}`) and MXFP options (`MXFP4`, `MXFP8`) are supported.
-- INT and MXFP options cannot be mixed in the same `AutoScheme`.
-- Unsupported options (`W3A16`, `GGUF:*`, `NVFP4`, etc.) raise `ValueError` immediately.
-- MXFP selection automatically uses `llm_compressor` export format.
-
-```python
-from auto_round import AutoRound, AutoScheme
-
-# INT mixed-bit: layers get W2A16, W4A16, or W8A16 based on delta-loss scoring
-scheme = AutoScheme(avg_bits=3.0, options=("W2A16", "W4A16", "W8A16"), nsamples=128)
-AutoRound(
-    model="meta-llama/Llama-3.2-1B-Instruct",
-    scheme=scheme,
-    iters=0,
-    model_free=True,
-).quantize_and_save("./int-mixed-llama", format="auto_round")
-
-# MXFP mixed-bit (requires llm_compressor)
-scheme = AutoScheme(avg_bits=6.0, options=("MXFP4", "MXFP8"), nsamples=128)
-AutoRound(
-    model="meta-llama/Llama-3.2-1B-Instruct",
-    scheme=scheme,
-    iters=0,
-    model_free=True,
-).quantize_and_save("./mxfp-mixed-llama", format="llm_compressor")
-```
-
 </details>
 
 ### GGUF format

--- a/docs/step_by_step_CN.md
+++ b/docs/step_by_step_CN.md
@@ -484,6 +484,8 @@ ar.quantize_and_save()
 #### 局限性
 AutoScheme 目前还**不支持对嵌入层（Embedding layer）进行自动量化**。该层将直接采用候选方案中精度最高的配置。
 
+当 AutoScheme 与 `model_free=True` 联合使用时，仅支持 INT（`W2A16`/`W4A16`/`W8A16`）和 MXFP（`MXFP4`/`MXFP8`）两种选项族。`W3A16`、`GGUF:*`、`NVFP4` 等不支持的选项会直接抛出 `ValueError`；同一 `AutoScheme` 中也不允许混用 INT 和 MXFP 选项族。
+
 ### AWQ 量化算法
 
 AWQ（`algorithm="awq"`）是一种预处理量化算法，通过分析激活分布并应用通道缩放（channel-wise scaling）来保护重要的权重。它在实际量化（默认为 RTN，或使用 auto_round/SignRound）之前运行。
@@ -567,6 +569,7 @@ ar.quantize_and_save(output_dir, format="auto_round")
 - **逐层配置** — 支持 `--layer_config` 设置逐层位宽，以及 `--ignore_layers` 保持特定层全精度
 - **预定义忽略层** — 根据模型配置自动跳过特定层（如 MoE 门控层、MTP 层等）
 - 与标准 `--iters 0 --disable_opt_rtn` 流程对所有受支持的 scheme **位级等价**
+- **AutoScheme 集成** — 将 `AutoScheme` 对象传入 `scheme` 参数，即可在免模型模式下完成自动混合精度选择与逐分片打包（两阶段：短暂加载模型评分 → 释放模型 → 逐分片打包）
 
 <details>
   <summary>Model-free 并行量化基准（分钟向上取整）</summary>

--- a/test/test_cpu/quantization/test_model_free.py
+++ b/test/test_cpu/quantization/test_model_free.py
@@ -26,15 +26,18 @@ from auto_round import AutoRound
 from auto_round.compressors.model_free import (
     _build_mxfp_quantization_config,
     _build_quantization_config,
+    _convert_auto_scheme_layer_config,
     _dequant_fp8_tensors,
     _dequant_mxfp_tensors,
     _expand_e8m0_block_scale,
     _handle_mxfp_source_tensors,
+    _looks_like_auto_scheme,
     _ModelFreeCompressorCore,
     _PatternMatcher,
     _preprocess_model_type_source_tensors,
     _process_shard,
     _quantize_weight_mxfp,
+    _validate_auto_scheme_options,
     get_predefined_ignore_layers_from_config,
     is_model_free_supported_scheme,
 )
@@ -1304,3 +1307,85 @@ class TestResolveShardParallelism:
             index = json.load(f)
         unique_shards = set(index["weight_map"].values())
         assert len(unique_shards) == 7, f"Expected 7 output shards, got {len(unique_shards)}: {unique_shards}"
+
+
+# ===========================================================================
+#  Model-free + AutoScheme (two-phase delta-loss selection + packing)
+# ===========================================================================
+
+
+class TestModelFreeAutoScheme:
+    """Model-free support for ``AutoScheme`` mixed-bit selection."""
+
+    def test_looks_like_auto_scheme(self):
+        from auto_round import AutoScheme
+
+        assert _looks_like_auto_scheme(AutoScheme(avg_bits=3, options=("W2A16", "W4A16")))
+        assert not _looks_like_auto_scheme("W4A16")
+        assert not _looks_like_auto_scheme(QuantizationScheme(bits=4))
+
+    def test_validate_options_int_family(self):
+        from auto_round import AutoScheme
+
+        assert _validate_auto_scheme_options(AutoScheme(avg_bits=3, options=("W2A16", "W4A16", "W8A16"))) == "int"
+
+    def test_validate_options_mxfp_family(self):
+        from auto_round import AutoScheme
+
+        assert _validate_auto_scheme_options(AutoScheme(avg_bits=6, options=("MXFP4", "MXFP8"))) == "mx_fp"
+
+    def test_validate_options_mixed_family_raises(self):
+        from auto_round import AutoScheme
+
+        with pytest.raises(ValueError, match="mix INT and MXFP"):
+            _validate_auto_scheme_options(AutoScheme(avg_bits=4, options=("W4A16", "MXFP4")))
+
+    @pytest.mark.parametrize("options", [("W3A16", "W4A16"), ("GGUF:Q4_K_M", "W8A16"), ("NVFP4", "W4A16")])
+    def test_validate_options_unsupported_raises(self, options):
+        from auto_round import AutoScheme
+
+        with pytest.raises(ValueError, match="unsupported option"):
+            _validate_auto_scheme_options(AutoScheme(avg_bits=4, options=options))
+
+    def test_convert_layer_config(self):
+        generated = {
+            "model.layers.0.q_proj": {"bits": 4, "group_size": 128, "sym": True, "data_type": "int"},
+            "model.layers.0.k_proj": {"bits": 2, "group_size": 128, "sym": True, "data_type": "int"},
+            "model.layers.0.v_proj": {"bits": 4, "group_size": 128, "sym": True, "data_type": "int"},
+            "model.embed_tokens": {"bits": 16, "group_size": 128, "sym": True, "data_type": "int"},
+        }
+        base_scheme, per_layer, fp16_layers = _convert_auto_scheme_layer_config(generated)
+        # Most common quantized scheme (4-bit) becomes the base.
+        assert base_scheme.bits == 4 and base_scheme.group_size == 128
+        assert per_layer["model.layers.0.k_proj"]["bits"] == 2
+        assert "model.embed_tokens" not in per_layer
+        assert fp16_layers == ["model.embed_tokens"]
+
+    def test_e2e_int_auto_scheme(self, tmp_path, tiny_opt_model_path):
+        from auto_round import AutoScheme
+
+        output_dir = str(tmp_path / "output")
+        scheme = AutoScheme(avg_bits=3.0, options=("W2A16", "W4A16", "W8A16"), nsamples=1)
+        ar = AutoRound(model=tiny_opt_model_path, scheme=scheme, iters=0, model_free=True, nsamples=1)
+        ar.quantize_and_save(output_dir, format="auto_round")
+
+        qc = _read_qconfig(output_dir)
+        assert qc["quant_method"] == "auto-round"
+        assert qc["model_free"] is True
+        # A genuine mix of bit-widths must have been selected across layers.
+        extra = qc.get("extra_config", {})
+        selected_bits = {qc["bits"]} | {v["bits"] for v in extra.values() if v.get("bits", 16) < 16}
+        assert len(selected_bits) >= 2, f"expected mixed bit-widths, got {selected_bits}"
+
+    @require_compressed_tensors
+    def test_e2e_mxfp_auto_scheme(self, tmp_path, tiny_opt_model_path):
+        from auto_round import AutoScheme
+
+        output_dir = str(tmp_path / "output")
+        scheme = AutoScheme(avg_bits=6.0, options=("MXFP4", "MXFP8"), nsamples=1)
+        ar = AutoRound(model=tiny_opt_model_path, scheme=scheme, iters=0, model_free=True, nsamples=1)
+        ar.quantize_and_save(output_dir, format="llm_compressor")
+
+        qc = _read_qconfig(output_dir)
+        assert qc["quant_method"] == "compressed-tensors"
+        assert qc["provider"] == "auto-round"

--- a/test/test_cpu/quantization/test_model_free.py
+++ b/test/test_cpu/quantization/test_model_free.py
@@ -943,19 +943,36 @@ _UNSUPPORTED = [
 class TestSchemeValidation:
     @pytest.mark.parametrize("name", _SUPPORTED)
     def test_supported(self, tmp_path, name):
+        """Each supported preset must resolve and quantize without error.
+
+        This exercises the same scheme-resolution code (``_parse_scheme`` /
+        ``_parse_layer_config`` / ``_build_ignore_patterns``) used by the real
+        pipeline, then quantizes a shard directly via ``_process_shard`` —
+        skipping the multiprocessing shard pipeline (already covered by the
+        full end-to-end tests in ``TestModelFreeQuantize`` / ``TestModelFreeMXFP``)
+        to keep this parametrized check fast.
+        """
         if name.startswith("MXFP"):
             pytest.importorskip("compressed_tensors", reason="test requires compressed-tensors")
-            format = "llm_compressor"
-        else:
-            format = "auto_round"
-        model_dir = _make_model_dir(tmp_path, _LLAMA_CFG, {"model.layers.0.mlp.fc1.weight": torch.randn(64, 128)})
-        out = str(tmp_path / f"out_{name}")
-        AutoRound(model=model_dir, scheme=name, model_free=True).quantize_and_save(out, format=format)
-        keys = _read_output_keys(out)
+
+        core = _ModelFreeCompressorCore(model_name_or_path="unused", output_dir=str(tmp_path), scheme=name)
+        core._parse_scheme()
+        core._parse_layer_config()
+        core._build_ignore_patterns()
+
+        shard_path = str(tmp_path / f"shard_{name}.safetensors")
+        save_file({"model.layers.0.mlp.fc1.weight": torch.randn(64, 128)}, shard_path)
+        output, quantized, _ignored = _process_shard(
+            shard_path,
+            default_scheme=core.default_scheme,
+            layer_config=core.layer_config,
+            ignore_patterns=core.ignore_patterns,
+        )
+        assert "model.layers.0.mlp.fc1" in quantized
         if name.startswith("MXFP"):
-            assert "model.layers.0.mlp.fc1.weight_scale" in keys
+            assert "model.layers.0.mlp.fc1.weight_scale" in output
         else:
-            assert "model.layers.0.mlp.fc1.qweight" in keys
+            assert "model.layers.0.mlp.fc1.qweight" in output
 
     @pytest.mark.parametrize("name", _UNSUPPORTED)
     def test_unsupported_raises(self, tmp_path, name):

--- a/test/test_cpu/quantization/test_model_free.py
+++ b/test/test_cpu/quantization/test_model_free.py
@@ -1340,7 +1340,15 @@ class TestModelFreeAutoScheme:
         with pytest.raises(ValueError, match="mix INT and MXFP"):
             _validate_auto_scheme_options(AutoScheme(avg_bits=4, options=("W4A16", "MXFP4")))
 
-    @pytest.mark.parametrize("options", [("W3A16", "W4A16"), ("GGUF:Q4_K_M", "W8A16"), ("NVFP4", "W4A16")])
+    @pytest.mark.parametrize(
+        "options",
+        [
+            ("W3A16", "W4A16"),
+            ("GGUF:Q4_K_M", "W8A16"),
+            ("NVFP4", "W4A16"),
+            ("MXFP4_RCEIL", "MXFP4"),
+        ],
+    )
     def test_validate_options_unsupported_raises(self, options):
         from auto_round import AutoScheme
 


### PR DESCRIPTION
## Description

This pull request introduces comprehensive support for using `AutoScheme` (automatic mixed-bit quantization selection) in model-free mode, enabling a two-phase workflow: first, a brief model load for delta-loss scoring to select per-layer bit-widths, followed by efficient shard-by-shard packing without keeping the model in memory. The changes include both implementation and documentation updates, as well as new tests to ensure correct behavior and constraints.

**Key changes:**

### Model-Free + AutoScheme Integration

* Added functions (`_looks_like_auto_scheme`, `_validate_auto_scheme_options`, `_convert_auto_scheme_layer_config`) to detect, validate, and process `AutoScheme` objects for model-free quantization, ensuring only supported option families (INT or MXFP) are allowed and not mixed. (`auto_round/compressors/model_free.py` [auto_round/compressors/model_free.pyR1488-R1598](diffhunk://#diff-4752b06d555af6f5fb006b7d2bc9582aa47012819c79da1427ec06ff90279170R1488-R1598))
* Implemented a two-phase workflow: the model is loaded only briefly for delta-loss scoring (selection), then released before model-free packing begins. The resolved per-layer scheme and ignore-lists are injected into the standard pipeline. (`auto_round/compressors/model_free.py` [[1]](diffhunk://#diff-4752b06d555af6f5fb006b7d2bc9582aa47012819c79da1427ec06ff90279170R2345-R2425) [[2]](diffhunk://#diff-4752b06d555af6f5fb006b7d2bc9582aa47012819c79da1427ec06ff90279170R2276-R2279) [[3]](diffhunk://#diff-4752b06d555af6f5fb006b7d2bc9582aa47012819c79da1427ec06ff90279170R2089-R2099) [[4]](diffhunk://#diff-4752b06d555af6f5fb006b7d2bc9582aa47012819c79da1427ec06ff90279170R2438-R2450)

### Utilities and Routing

* Updated `is_model_free_route` to recognize and correctly route `AutoScheme` objects, including family validation and format restrictions. (`auto_round/utils/model.py` [[1]](diffhunk://#diff-55172aae42fb0c3affdae72c96126eb408381f7556adc94ee67e949a90b9a7cdL2305-R2309) [[2]](diffhunk://#diff-55172aae42fb0c3affdae72c96126eb408381f7556adc94ee67e949a90b9a7cdR2320-R2336)

### Documentation

* Added detailed documentation and usage examples for combining `AutoScheme` with model-free mode, including constraints and supported option families, in both English and Chinese guides. (`docs/step_by_step.md` [[1]](diffhunk://#diff-8e4d91ebd603d059b7f3dae2b5093c15a4861a508ea6ac1872baea2ad2c02a4fR489-R490) [[2]](diffhunk://#diff-8e4d91ebd603d059b7f3dae2b5093c15a4861a508ea6ac1872baea2ad2c02a4fR574) [[3]](diffhunk://#diff-8e4d91ebd603d059b7f3dae2b5093c15a4861a508ea6ac1872baea2ad2c02a4fR704-R738); `docs/step_by_step_CN.md` [[4]](diffhunk://#diff-24f689b8fbbd3284b39d2d0fe44c4c94bbcab555441688b648b93f4efacd7641R487-R488) [[5]](diffhunk://#diff-24f689b8fbbd3284b39d2d0fe44c4c94bbcab555441688b648b93f4efacd7641R572)

### Testing

* Added a comprehensive test suite for model-free + AutoScheme, covering detection, validation (including error cases), layer config conversion, and end-to-end runs for both INT and MXFP families. (`test/test_cpu/quantization/test_model_free.py` [test/test_cpu/quantization/test_model_free.pyR1310-R1391](diffhunk://#diff-b6598aed8df3eb0f5a794fc63c768878c8fa14b6f93549ca52169e9dbceaa9efR1310-R1391))

These changes ensure that users can now perform automatic mixed-bit quantization in model-free mode with robust validation, clear documentation, and strong test coverage.

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Enhancement

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #910 

## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
