### PR TITLE
Remove transformers version limit for release package

### DIFF
--- a/auto_round/version.py
+++ b/auto_round/version.py
@@ -14,4 +14,4 @@
 """Intel® auto-round: An open-source Python library
 supporting popular model weight only compression based on signround."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/auto_round_extension/ark/auto_round_kernel/version.py
+++ b/auto_round_extension/ark/auto_round_kernel/version.py
@@ -14,4 +14,4 @@
 """Intel® auto-round: An open-source Python library
 supporting popular model weight only compression based on signround."""
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ numpy
 py-cpuinfo
 torch
 tqdm
-transformers<=5.12.1
+transformers>=4.38
 pydantic

--- a/test/test_cpu/requirements.txt
+++ b/test/test_cpu/requirements.txt
@@ -6,8 +6,8 @@ torchvision
 pillow
 numba
 pytest
-lm_eval >= 0.4.10  # for transformers >= 5.0.0
+lm_eval>=0.4.10  # for transformers >= 5.0.0
 diffusers
 protobuf
-compressed-tensors >= 0.15.0
-transformers >= 5.5.0
+compressed-tensors>=0.15.0
+transformers>=5.5.0,<=5.12.1

--- a/test/test_cpu/requirements_inc.txt
+++ b/test/test_cpu/requirements_inc.txt
@@ -1,2 +1,2 @@
-neural_compressor_pt @ git+https://github.com/intel/neural-compressor.git@v3.8.1rc
+neural_compressor_pt
 compressed-tensors

--- a/test/test_cuda/requirements.txt
+++ b/test/test_cuda/requirements.txt
@@ -1,10 +1,11 @@
 einops
 gptqmodel
 # pip install gguf
-lm_eval >= 0.4.10  # for transformers >= 5.0.0
+lm_eval>=0.4.10  # for transformers >= 5.0.0
 optimum
 pandas
 pillow
 torchvision
 numba
 sentencepiece
+transformers>=5.5.0,<=5.12.1


### PR DESCRIPTION
## Description

1. Remove transformers version limit for release package.
2. Add version limit in CI test, and should be removed after https://github.com/intel/auto-round/issues/1996 and https://github.com/intel/auto-round/issues/1997 fixed. 
3. Remove INC version limit. 
4. Bump version. 

## Type of Change

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
