### PR TITLE
enhance logging and data loading for AutoScheme and model-free compatibility

### DIFF
--- a/auto_round/auto_scheme/utils.py
+++ b/auto_round/auto_scheme/utils.py
@@ -536,20 +536,35 @@ def _log_score_summary_by_block_and_nonblock(
 
     tag = f"[{scheme_tag}] " if scheme_tag else ""
     stage_str = f" ({summary_stage})" if summary_stage else ""
-    logger.debug("AutoScheme %sblock loss summary%s:", tag, stage_str)
-    logger.debug("AutoScheme | block | avg_loss |")
-
+    rows_in_order: list[tuple[str, float]] = []
     for block_name in block_names:
         total_loss, cnt = block_stats.get(block_name, [0.0, 0.0])
         avg_loss = 0.0 if cnt <= 0 else total_loss / cnt
-        logger.debug("AutoScheme | %s | %.6f |", _short_summary_name(block_name), avg_loss)
+        if math.isfinite(avg_loss):
+            rows_in_order.append((_short_summary_name(block_name), avg_loss))
 
-    if head_name is not None:
-        head_loss = None
-        if head_name in scores_dict:
-            head_loss = float(scores_dict[head_name][1])
-        head_avg = "N/A" if head_loss is None or not math.isfinite(head_loss) else f"{head_loss:.6f}"
-        logger.debug("AutoScheme | %s | %s |", head_name, head_avg)
+    # lm_head participates in ranking and ratio when present.
+    if head_name is not None and head_name in scores_dict:
+        head_loss = float(scores_dict[head_name][1])
+        if math.isfinite(head_loss):
+            rows_in_order.append((head_name, head_loss))
+
+    sorted_for_rank = sorted(rows_in_order, key=lambda item: item[1], reverse=True)
+    rank_map: dict[str, int] = {}
+    for idx, (name, _avg_loss) in enumerate(sorted_for_rank, start=1):
+        rank_map[name] = idx
+
+    total_avg_loss = sum(avg_loss for _, avg_loss in rows_in_order)
+
+    logger.debug("AutoScheme %sblock loss summary%s:", tag, stage_str)
+    logger.debug("AutoScheme | rank | block | avg_loss | ratio(%%total) |")
+    for name, avg_loss in rows_in_order:
+        rank = rank_map.get(name, -1)
+        ratio_pct = 0.0 if abs(total_avg_loss) < _ZERO_EPS else (avg_loss / total_avg_loss) * 100.0
+        logger.debug("AutoScheme | %d | %s | %.6f | %.2f%% |", rank, name, avg_loss, ratio_pct)
+
+    if head_name is not None and head_name not in scores_dict:
+        logger.debug("AutoScheme | - | %s | N/A | N/A |", head_name)
 
     if non_block_items:
         non_block_items.sort(key=lambda x: x[0])

--- a/auto_round/compressors/mllm/dataset.py
+++ b/auto_round/compressors/mllm/dataset.py
@@ -268,7 +268,12 @@ def get_mllm_dataloader(
         )
 
         set_seed(seed)
-        dataloader_params = {"batch_size": bs, "shuffle": True, "collate_fn": dataset.template.processor.data_collator}
+        # Calibration should be deterministic: keep a fixed sample order.
+        dataloader_params = {
+            "batch_size": bs,
+            "shuffle": False,
+            "collate_fn": dataset.template.processor.data_collator,
+        }
 
         return DataLoader(dataset, **dataloader_params), bs, seqlen, gradient_accumulate_steps
     else:

--- a/auto_round/compressors/model_free.py
+++ b/auto_round/compressors/model_free.py
@@ -2455,6 +2455,31 @@ class ModelFreeCompressor(_ModelFreeCompressorCore):
             len(fp16_layers),
         )
 
+    def _precheck_auto_scheme_fallback(self, format: str) -> bool:
+        """Early fallback check for model-free + AutoScheme.
+
+        This avoids spending time on delta-loss AutoScheme selection when the
+        requested export format is known to be incompatible with the resolved
+        AutoScheme option family.
+        """
+        if not _looks_like_auto_scheme(self.scheme_input):
+            return False
+
+        family = _validate_auto_scheme_options(self.scheme_input)
+        accepted_formats = {"auto_round", "auto_round:auto_gptq"}
+        if family == "mx_fp":
+            accepted_formats = {"llm_compressor"}
+
+        if format not in accepted_formats:
+            logger.warning(
+                "Format '%s' is incompatible with model-free + AutoScheme (family=%s); "
+                "fallback before running AutoScheme scoring.",
+                format,
+                family,
+            )
+            return True
+        return False
+
     # ------------------------------------------------------------------
     # AutoRound compressor interface
     # ------------------------------------------------------------------
@@ -2467,6 +2492,11 @@ class ModelFreeCompressor(_ModelFreeCompressorCore):
         **kwargs,
     ) -> Any:
         """Quantize and save — AutoRound compressor entry point."""
+        # Early fallback gate for model-free + AutoScheme: avoid running
+        # costly delta-loss selection when format is known incompatible.
+        if self._precheck_auto_scheme_fallback(format):
+            return self._fallback_to_quantize_and_save(output_dir=output_dir, format=format, inplace=inplace, **kwargs)
+
         # AutoScheme: run delta-loss selection first so the effective scheme /
         # data-type family (which drives the accepted export formats) is known.
         if _looks_like_auto_scheme(self.scheme_input):


### PR DESCRIPTION
## Description

Model free will fallback after autoscheme, which causes double autoscheme process.


## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix: add check to avoid this.

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
