### PR TITLE
fix: add triton to requirements for LLMC CPU tests

### DIFF
--- a/test/test_cpu/requirements_llmc.txt
+++ b/test/test_cpu/requirements_llmc.txt
@@ -1,2 +1,3 @@
 llmcompressor @ git+https://github.com/vllm-project/llm-compressor.git@main
 compressed-tensors @ git+https://github.com/vllm-project/compressed-tensors.git@main
+triton

--- a/test/test_cuda/requirements_llmc.txt
+++ b/test/test_cuda/requirements_llmc.txt
@@ -1,4 +1,3 @@
 llmcompressor @ git+https://github.com/vllm-project/llm-compressor.git@main
 compressed-tensors @ git+https://github.com/vllm-project/compressed-tensors.git@main
 parameterized
-triton

--- a/test/test_cuda/requirements_llmc.txt
+++ b/test/test_cuda/requirements_llmc.txt
@@ -1,3 +1,4 @@
 llmcompressor @ git+https://github.com/vllm-project/llm-compressor.git@main
 compressed-tensors @ git+https://github.com/vllm-project/compressed-tensors.git@main
 parameterized
+triton


### PR DESCRIPTION
This pull request makes a small update to the `test/test_cpu/requirements_llmc.txt` file by adding a new dependency.

* Added the `triton` package to the requirements file to ensure all necessary dependencies are installed for CPU tests.