### PR TITLE
Fix dataset and batch_size not taking effect in CLI

### DIFF
--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -244,8 +244,10 @@ class AutoRound:
                 seed=seed,
                 low_cpu_mem_usage=low_cpu_mem_usage,
                 layer_config=layer_config,
+                dataset=dataset,
                 nsamples=nsamples,
                 seqlen=seqlen,
+                batch_size=batch_size,
                 **entry_kwargs,
             )
 


### PR DESCRIPTION
## Description

Forward `dataset` and `batch_size` when the compatibility `AutoRound` entry delegates to the new pipeline through `alg_configs`.

  These explicit parameters were previously omitted from the delegation, causing the new pipeline to use default calibration settings.
 

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
