### PR TITLE
fix MXFP model free auto-round format bug

### DIFF
--- a/auto_round/compressors/model_free.py
+++ b/auto_round/compressors/model_free.py
@@ -576,9 +576,8 @@ def _quantize_single_tensor(
     layer_name = tensor_name.rsplit(".", 1)[0]
 
     if not _is_eligible_weight(tensor_name, tensor):
-        if tensor_name.endswith(".weight"):
-            return layer_name, {tensor_name: tensor}, None, layer_name
-        return layer_name, {tensor_name: tensor}, None, None
+        ignored_layer = layer_name if tensor_name.endswith(".weight") and tensor.dim() > 1 else None
+        return layer_name, {tensor_name: tensor}, None, ignored_layer
 
     if matcher.should_ignore(tensor_name):
         logger.debug(f"Ignoring (user-specified): {layer_name}")
@@ -960,10 +959,15 @@ def _process_shard(
 
     raw_tensors = split_fused_expert_tensors(raw_tensors)
 
-    # Snapshot eligible weight layer names *before* any preprocessing so that
-    # the ignored-layer list can be derived by dict comparison at the end.
+    # Snapshot candidate weight layer names *before* any preprocessing. 1D
+    # weights (for example LayerNorm) are not quantization targets, while 3D
+    # weights remain tracked so unsupported layouts are visible as ignored.
     input_weight_layers: list[str] = list(
-        dict.fromkeys(k.rsplit(".", 1)[0] for k in raw_tensors if k.endswith(".weight"))
+        dict.fromkeys(
+            name.rsplit(".", 1)[0]
+            for name, tensor in raw_tensors.items()
+            if name.endswith(".weight") and tensor.dim() > 1
+        )
     )
 
     # Preserve original tensors for ignored/skipped layers so that already-
@@ -1140,6 +1144,7 @@ def _build_mxfp_autoround_quantization_config(
     quantized_layers: list[str],
     ignored_layers: list[str],
     layer_config: dict | None = None,
+    block_name_to_quantize: Optional[str] = None,
 ) -> dict:
     """Build an auto-round style quantization_config for MXFP4 / MXFP8.
 
@@ -1198,6 +1203,8 @@ def _build_mxfp_autoround_quantization_config(
         "autoround_version": __version__,
         "enable_quanted_input": False,
     }
+    if block_name_to_quantize:
+        qconfig["block_name_to_quantize"] = block_name_to_quantize
 
     # Carry activation quantization fields from the scheme (e.g. MXFP4 has
     # act_bits=4, act_data_type="mx_fp", act_dynamic=True, act_group_size=32,
@@ -1214,19 +1221,15 @@ def _build_mxfp_autoround_quantization_config(
     non_linear_re = re.compile("|".join(re.escape(op) for op in non_linear_ops))
 
     if layer_config:
+        from auto_round.export.export_to_autoround.utils import check_neq_config
+
+        expected_scheme = {key: qconfig.get(key) for key in scheme_keys}
         for layer_name, cfg in layer_config.items():
             if not isinstance(cfg, dict):
                 continue
-            cfg_bits = cfg.get("bits", bits)
-            if cfg_bits >= 16:
-                extra_config[layer_name] = {k: cfg[k] for k in scheme_keys if cfg.get(k) is not None}
-                continue
-            differs = any(
-                cfg.get(key) is not None and cfg[key] != default_scheme.get(key)
-                for key in ("bits", "group_size", "sym", "data_type")
-            )
-            if differs:
-                extra_config[layer_name] = {k: cfg[k] for k in scheme_keys if cfg.get(k) is not None}
+            neq_keys = check_neq_config(cfg, **expected_scheme)
+            if neq_keys:
+                extra_config[layer_name] = {key: cfg[key] for key in neq_keys if cfg.get(key) is not None}
 
     quantized_set = set(quantized_layers)
     unique_ignored = list(dict.fromkeys(ignored_layers))
@@ -1235,7 +1238,12 @@ def _build_mxfp_autoround_quantization_config(
             continue
         if non_linear_re.search(layer_name):
             continue
-        extra_config[layer_name] = {"bits": 16, "data_type": "float"}
+        extra_config[layer_name] = {
+            "bits": 16,
+            "data_type": "float",
+            "act_bits": 16,
+            "act_data_type": "float",
+        }
 
     # lm_head: when explicitly quantized, record its full scheme in extra_config
     # (mirrors the regular AutoRound MXFP export behavior).
@@ -1352,7 +1360,7 @@ def _build_quantization_config(
     ignore_patterns: list[str],
     quantized_layers: list[str],
     ignored_layers: list[str],
-    block_name_to_quantize: Optional[list[str]] = None,
+    block_name_to_quantize: Optional[str] = None,
     format: str = "auto_round",
 ) -> dict:
     """Build a quantization_config dict compatible with auto-round format."""
@@ -1373,6 +1381,7 @@ def _build_quantization_config(
                 quantized_layers=quantized_layers,
                 ignored_layers=ignored_layers,
                 layer_config=layer_config,
+                block_name_to_quantize=block_name_to_quantize,
             )
         return _build_mxfp_quantization_config(
             default_scheme=default_scheme,
@@ -1822,13 +1831,15 @@ def _validate_auto_scheme_options(auto_scheme: Any) -> str:
 
 def _convert_auto_scheme_layer_config(
     generated: dict[str, dict],
+    preferred_base_scheme: Union[str, QuantizationScheme, None] = None,
 ) -> tuple[QuantizationScheme, dict[str, dict], list[str]]:
     """Convert an AutoScheme-generated ``layer_config`` into model-free inputs.
 
     Returns ``(base_scheme, per_layer_overrides, fp16_layers)`` where:
 
-    * ``base_scheme`` is the most common quantized scheme across layers, used
-      as the model-free default (top-level config.json ``bits``/``group_size``).
+        * ``base_scheme`` is ``preferred_base_scheme`` when provided, matching the
+            primary scheme selected by the regular AutoRound path. Otherwise the
+            most common quantized scheme is used as a fallback.
     * ``per_layer_overrides`` maps every quantized layer name to its resolved
       :class:`QuantizationScheme` fields.
     * ``fp16_layers`` lists layers AutoScheme kept at >= 16 bits (added to the
@@ -1882,13 +1893,16 @@ def _convert_auto_scheme_layer_config(
     if not counter:
         raise ValueError("AutoScheme did not assign any quantizable layers for model-free mode.")
 
-    (base_bits, base_group_size, base_sym, base_dtype), _ = counter.most_common(1)[0]
-    base_scheme = QuantizationScheme(
-        bits=base_bits,
-        group_size=base_group_size,
-        sym=base_sym,
-        data_type=base_dtype,
-    )
+    if preferred_base_scheme is not None:
+        base_scheme = copy.deepcopy(_normalize_scheme(preferred_base_scheme))
+    else:
+        (base_bits, base_group_size, base_sym, base_dtype), _ = counter.most_common(1)[0]
+        base_scheme = QuantizationScheme(
+            bits=base_bits,
+            group_size=base_group_size,
+            sym=base_sym,
+            data_type=base_dtype,
+        )
     return base_scheme, per_layer, fp16_layers
 
 
@@ -2308,12 +2322,22 @@ class _ModelFreeCompressorCore:
         _write_index_file(self._quant_output_dir, self.output_weight_map)
 
     def _write_config_files(self) -> None:
+        block_prefixes = []
+        for layer_name in self.all_quantized_layers:
+            parts = layer_name.split(".")
+            for index, part in enumerate(parts):
+                if part.isdigit() and index > 0:
+                    block_prefixes.append(".".join(parts[:index]))
+                    break
+        block_name_to_quantize = ",".join(dict.fromkeys(block_prefixes)) or None
+
         quantization_config = _build_quantization_config(
             default_scheme=self.default_scheme,
             layer_config=self.layer_config,
             ignore_patterns=self.ignore_patterns,
             quantized_layers=self.all_quantized_layers,
             ignored_layers=self.all_ignored_layers,
+            block_name_to_quantize=block_name_to_quantize,
             format=self.format,
         )
 
@@ -2717,7 +2741,17 @@ class ModelFreeCompressor(_ModelFreeCompressorCore):
         )
 
         generated = self._run_auto_scheme_selection(auto_scheme)
-        base_scheme, per_layer, fp16_layers = _convert_auto_scheme_layer_config(generated)
+        preferred_base_scheme = None
+        for option in auto_scheme.options:
+            option_scheme = _normalize_scheme(option)
+            act_bits = option_scheme.act_bits if option_scheme.act_bits is not None else 16
+            if (option_scheme.bits or 0) < 16 or act_bits < 16:
+                preferred_base_scheme = option_scheme
+                break
+        base_scheme, per_layer, fp16_layers = _convert_auto_scheme_layer_config(
+            generated,
+            preferred_base_scheme=preferred_base_scheme,
+        )
 
         # Merge the generated per-layer overrides; any user-provided
         # layer_config entries take priority.

--- a/test/test_cpu/quantization/test_model_free.py
+++ b/test/test_cpu/quantization/test_model_free.py
@@ -1601,11 +1601,59 @@ class TestMXFPAutoRoundFormat:
             ignored_layers=ignored,
         )
         extra = cfg.get("extra_config", {})
-        assert extra.get("lm_head") == {"bits": 16, "data_type": "float"}
-        assert extra.get("model.layers.0.mlp.gate") == {"bits": 16, "data_type": "float"}
+        full_precision = {"bits": 16, "data_type": "float", "act_bits": 16, "act_data_type": "float"}
+        assert extra.get("lm_head") == full_precision
+        assert extra.get("model.layers.0.mlp.gate") == full_precision
         # embed / conv are non-Linear — filtered out
         assert "model.embed_tokens" not in extra
         assert "model.conv1" not in extra
+
+    @require_compressed_tensors
+    def test_ignored_lm_head_loads_as_full_precision(self):
+        """An ignored lm_head must not inherit MXFP activation quantization."""
+        from types import SimpleNamespace
+
+        from transformers import OPTConfig, OPTForCausalLM
+
+        from auto_round.inference.convert_model import get_layer_config
+        from auto_round.utils import check_to_quantized
+
+        default = {
+            "bits": 4,
+            "group_size": 32,
+            "sym": True,
+            "data_type": "mx_fp",
+            "act_bits": 4,
+            "act_data_type": "mx_fp",
+            "act_dynamic": True,
+            "act_group_size": 32,
+            "act_sym": True,
+        }
+        quantization_config = _build_mxfp_autoround_quantization_config(
+            default,
+            quantized_layers=["model.decoder.layers.0.fc1"],
+            ignored_layers=["lm_head"],
+            block_name_to_quantize="model.decoder.layers",
+        )
+        model = OPTForCausalLM(
+            OPTConfig(
+                hidden_size=32,
+                ffn_dim=64,
+                num_hidden_layers=1,
+                num_attention_heads=4,
+                vocab_size=64,
+                word_embed_proj_dim=32,
+            )
+        )
+
+        layer_configs = get_layer_config(model, SimpleNamespace(**quantization_config))
+        lm_head_config = layer_configs["lm_head"]
+
+        assert lm_head_config.bits == 16
+        assert lm_head_config.act_bits == 16
+        assert lm_head_config.data_type == "float"
+        assert lm_head_config.act_data_type == "float"
+        assert not check_to_quantized(lm_head_config)
 
     @require_compressed_tensors
     def test_quantized_lm_head_in_extra_config(self):
@@ -1697,7 +1745,12 @@ class TestMXFPAutoRoundFormat:
         assert qc["model_free"] is True
         # lm_head kept full-precision → extra_config entry
         extra = qc.get("extra_config", {})
-        assert extra.get("lm_head") == {"bits": 16, "data_type": "float"}
+        assert extra.get("lm_head") == {
+            "bits": 16,
+            "data_type": "float",
+            "act_bits": 16,
+            "act_data_type": "float",
+        }
 
     @require_compressed_tensors
     def test_e2e_mxfp4_weight_tensors(self, tmp_path):

--- a/test/test_cpu/quantization/test_model_free_parity.py
+++ b/test/test_cpu/quantization/test_model_free_parity.py
@@ -15,8 +15,9 @@
 """Parity tests between ``AutoRound(model_free=True)`` and the regular
 ``AutoRound(iters=0, disable_opt_rtn=True, disable_model_free=True)`` flow.
 
-Both code paths perform RTN integer weight-only quantization in the
-``auto_round`` packing format.  These tests assert that:
+The integer tests compare RTN weight-only quantization in the ``auto_round``
+packing format. The MXFP test compares the AutoRound-format quantization
+metadata produced for a mixed MXFP4/MXFP8 AutoScheme. These tests assert that:
 
 1. The ``quantization_config`` keys ``bits``, ``group_size``, ``sym``,
    ``data_type`` (family), ``quant_method``, ``packing_format`` agree.
@@ -248,3 +249,69 @@ def test_disable_model_free_opt_out(tiny_opt_model_path):
     )
     assert getattr(ar, "model_free", False) is False
     assert ar.model is not None
+
+
+def test_mxfp_auto_scheme_quantization_config_parity(tmp_path, tiny_opt_model_path):
+    """Mixed MXFP AutoScheme must serialize the same scheme metadata in both paths."""
+    pytest.importorskip("compressed_tensors")
+
+    from auto_round import AutoRound, AutoScheme
+
+    out_model_free = str(tmp_path / "mxfp_model_free")
+    out_regular = str(tmp_path / "mxfp_regular")
+    scheme_kwargs = {
+        "avg_bits": 6.0,
+        "options": ("MXFP4", "MXFP8"),
+        "nsamples": 1,
+        "ignore_scale_zp_bits": True,
+    }
+
+    torch.manual_seed(42)
+    model_free = AutoRound(
+        tiny_opt_model_path,
+        scheme=AutoScheme(**scheme_kwargs),
+        iters=0,
+        disable_opt_rtn=True,
+        model_free=True,
+        nsamples=1,
+        device_map=_device_str(),
+    )
+    _, out_model_free = model_free.quantize_and_save(format="auto_round", output_dir=out_model_free)
+
+    torch.manual_seed(42)
+    regular = AutoRound(
+        tiny_opt_model_path,
+        scheme=AutoScheme(**scheme_kwargs),
+        iters=0,
+        disable_opt_rtn=True,
+        disable_model_free=True,
+        nsamples=1,
+        device_map=_device_str(),
+    )
+    _, out_regular = regular.quantize_and_save(format="auto_round", output_dir=out_regular)
+
+    model_free_config = _read_qconfig(out_model_free)
+    regular_config = _read_qconfig(out_regular)
+
+    scheme_keys = (
+        "bits",
+        "group_size",
+        "sym",
+        "data_type",
+        "act_bits",
+        "act_group_size",
+        "act_sym",
+        "act_data_type",
+        "act_dynamic",
+    )
+    for key in scheme_keys:
+        assert model_free_config.get(key) == regular_config.get(key), (
+            f"qconfig[{key}] differs: model_free={model_free_config.get(key)} " f"regular={regular_config.get(key)}"
+        )
+
+    assert model_free_config["bits"] == 4
+    assert model_free_config["act_bits"] == 4
+    assert model_free_config["packing_format"] == regular_config["packing_format"]
+    assert model_free_config.get("block_name_to_quantize") == regular_config.get("block_name_to_quantize")
+    assert model_free_config.get("extra_config", {}) == regular_config.get("extra_config", {})
+    assert any(cfg.get("bits") == 8 for cfg in model_free_config.get("extra_config", {}).values())


### PR DESCRIPTION
## Description

ValueError: No compatible backend found for layer model.layers.9.self_attn.v_proj with config QuantizationScheme(bits=8, group_size=32, sym=True, data_type='mx_fp', act_bits=None, act_group_size=False, act_sym=None, act_data_type=None, act_dynamic=False, super_bits=None, super_group_size=None, rotation_config=None) 

ValueError: No compatible backend found for layer lm_head with config QuantizationScheme(bits=16, group_size=32, sym=True, data_type='float', act_bits=4, act_group_size=32, act_sym=True, act_data_type='mx_fp', act_dynamic=True, super_bits=None, super_group_size=None, rotation_config=None) 

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [x] My code has been tested locally.
- [x] Documentation has been updated as needed.
- [x] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
