### PR TITLE
Fix: temporarily skip tests due to known issues with xfail annotations

### DIFF
--- a/test/test_cpu/export/test_llmc_format.py
+++ b/test/test_cpu/export/test_llmc_format.py
@@ -267,8 +267,6 @@ def test_llmcompressor_static_fp8_kv_config(tiny_opt_model_path, dataloader, tmp
     assert kv_cache_scheme["symmetric"] is True
 
 
-# TODO: remove xfail once the issue is resolved.
-@pytest.mark.xfail(reason="https://github.com/vllm-project/compressed-tensors/issues/795")
 def test_llmcompressor_static_fp8_attention_config(dataloader, tmp_path):
     model_name = get_model_path("stas/tiny-random-llama-2")
     autoround = AutoRound(

--- a/test/test_xpu/test_llmc_integration.py
+++ b/test/test_xpu/test_llmc_integration.py
@@ -73,6 +73,7 @@ w8a8_static_recipe_modifier = AutoRoundModifier(
     },
 )
 
+
 # TODO: remove xfail once the issue is resolved.
 @pytest.mark.xfail(reason="skip this case temporarily due to issue https://github.com/intel/auto-round/issues/2112")
 @pytest.mark.skipif(torch.xpu.device_count() < 1, reason="test requires at least 1 XPU")

--- a/test/test_xpu/test_llmc_integration.py
+++ b/test/test_xpu/test_llmc_integration.py
@@ -73,7 +73,8 @@ w8a8_static_recipe_modifier = AutoRoundModifier(
     },
 )
 
-
+# TODO: remove xfail once the issue is resolved.
+@pytest.mark.xfail(reason="skip this case temporarily due to issue https://github.com/intel/auto-round/issues/2112")
 @pytest.mark.skipif(torch.xpu.device_count() < 1, reason="test requires at least 1 XPU")
 @pytest.mark.parametrize(
     "recipe",


### PR DESCRIPTION
This pull request updates test annotations to better handle known issues in the test suite. Specifically, it removes an `xfail` marker from one test where the related issue has been resolved, and adds an `xfail` marker to another test to temporarily skip it due to a newly identified issue.

Test annotation updates:

* Removed the `@pytest.mark.xfail` annotation from `test_llmcompressor_static_fp8_attention_config` in `test/test_cpu/export/test_llmc_format.py`, as the referenced issue has been resolved.
* Added a `@pytest.mark.xfail` annotation to a test in `test/test_xpu/test_llmc_integration.py` to temporarily skip the test due to issue https://github.com/intel/auto-round/issues/2112.