### PR TITLE
fix: save the config of diffusers models on export

### DIFF
--- a/auto_round/export/export_to_llmcompressor/export.py
+++ b/auto_round/export/export_to_llmcompressor/export.py
@@ -18,7 +18,12 @@ from typing import Callable, Union
 
 import torch
 
-from auto_round.export.utils import is_immediate_saving_mode, save_model, save_pretrained_artifact
+from auto_round.export.utils import (
+    is_immediate_saving_mode,
+    save_config_artifact,
+    save_model,
+    save_pretrained_artifact,
+)
 from auto_round.logger import logger
 from auto_round.utils import (
     SUPPORTED_LAYER_TYPES,
@@ -227,7 +232,7 @@ def save_quantized_as_llmcompressor(
         return model
 
     # save model.config, model.state_dict()
-    model.config.save_pretrained(output_dir)
+    save_config_artifact(model, output_dir)
 
     save_model(model, output_dir, safe_serialization=safe_serialization, immediate_saving=immediate_saving)
 

--- a/auto_round/export/utils.py
+++ b/auto_round/export/utils.py
@@ -42,18 +42,42 @@ def save_pretrained_artifact(artifact, output_dir: str, artifact_name: str = "ar
     return True
 
 
-def _save_model_configs(model: nn.Module, save_dir: str) -> None:
-    if hasattr(model, "config") and model.config is not None:
-        try:
-            model.config.save_pretrained(save_dir)
-        except (KeyError, TypeError):
-            # Some third-party configs (e.g. qwen-tts) fail with use_diff=True
-            # due to missing keys in recursive_diff_dict. Fall back to full config.
-            import json
+def save_config_artifact(model: nn.Module, save_dir: str) -> None:
+    """Write ``model.config`` to ``save_dir``, for transformers and diffusers models alike.
 
+    A diffusers ``ModelMixin`` keeps its config in a ``FrozenDict``, which has no
+    ``save_pretrained``; ``ModelMixin.save_config`` is the equivalent writer.
+    """
+    config = getattr(model, "config", None)
+    if config is None:
+        return
+
+    if not hasattr(config, "save_pretrained") and hasattr(model, "save_config"):
+        model.save_config(save_dir)
+        # save_config serializes the config's own dict, so the quantization_config the
+        # exporter set on the config object afterwards has to be merged back in.
+        quantization_config = getattr(config, "quantization_config", None)
+        if quantization_config is not None:
             config_path = os.path.join(save_dir, "config.json")
+            with open(config_path, encoding="utf-8") as f:
+                config_dict = json.load(f)
+            config_dict["quantization_config"] = quantization_config
             with open(config_path, "w", encoding="utf-8") as f:
-                f.write(model.config.to_json_string(use_diff=False))
+                json.dump(config_dict, f, indent=2, sort_keys=True)
+        return
+
+    try:
+        config.save_pretrained(save_dir)
+    except (KeyError, TypeError):
+        # Some third-party configs (e.g. qwen-tts) fail with use_diff=True
+        # due to missing keys in recursive_diff_dict. Fall back to full config.
+        config_path = os.path.join(save_dir, "config.json")
+        with open(config_path, "w", encoding="utf-8") as f:
+            f.write(config.to_json_string(use_diff=False))
+
+
+def _save_model_configs(model: nn.Module, save_dir: str) -> None:
+    save_config_artifact(model, save_dir)
 
     if hasattr(model, "generation_config") and model.generation_config is not None:
         model.generation_config.save_pretrained(save_dir)

--- a/auto_round/formats.py
+++ b/auto_round/formats.py
@@ -358,8 +358,10 @@ class FakeFormat(OutputFormat):
         if not unsupported_meta_device(model):
             model = model.to("cpu")
             model.save_pretrained(output_dir)
-        elif hasattr(model, "config") and model.config is not None:
-            model.config.save_pretrained(output_dir)
+        else:
+            from auto_round.export.utils import save_config_artifact
+
+            save_config_artifact(model, output_dir)
 
         if tokenizer is not None and hasattr(tokenizer, "save_pretrained"):
             tokenizer.save_pretrained(output_dir)

--- a/test/test_cpu/export/test_export.py
+++ b/test/test_cpu/export/test_export.py
@@ -659,3 +659,33 @@ def test_immediate_saving_mode(tiny_opt_model_path, tmp_path, low_cpu_mem_usage,
     with safe_open(os.path.join(quantized_model_path, safetensor_files[0]), framework="pt") as f:
         keys = f.keys()
         assert len(keys) > 0, "Safetensors file has no tensors"
+
+
+def test_save_model_writes_diffusers_config(tmp_path):
+    """A diffusers config is a FrozenDict with no save_pretrained; the export must still write it."""
+    diffusers = pytest.importorskip("diffusers")
+
+    from auto_round.export.utils import save_model
+
+    model = diffusers.SD3Transformer2DModel(
+        sample_size=8,
+        patch_size=2,
+        in_channels=4,
+        num_layers=1,
+        attention_head_dim=32,
+        num_attention_heads=2,
+        joint_attention_dim=64,
+        caption_projection_dim=64,
+        pooled_projection_dim=64,
+        out_channels=4,
+    )
+    assert not hasattr(model.config, "save_pretrained")
+    model.config.quantization_config = {"quant_method": "auto-round", "bits": 4}
+
+    # immediate_saving: weights are already on disk, only the configs are written
+    save_model(model, str(tmp_path), immediate_saving=True)
+
+    with open(os.path.join(tmp_path, "config.json")) as f:
+        config = json.load(f)
+    assert config["_class_name"] == "SD3Transformer2DModel"
+    assert config["quantization_config"] == {"quant_method": "auto-round", "bits": 4}


### PR DESCRIPTION
## Description

`quantize_and_save` on a diffusers `ModelMixin` writes every safetensors shard and then dies before writing any config, leaving a checkpoint nothing can load.

```
AttributeError: 'FrozenDict' object has no attribute 'save_pretrained'
  File "auto_round/export/utils.py", line 48, in _save_model_configs
    model.config.save_pretrained(save_dir)
```

A diffusers model's `.config` is a `diffusers.configuration_utils.FrozenDict`, which has no `save_pretrained`; `ModelMixin.save_config` is the equivalent writer. The diffusion path never hits this because `diffusion_load_model` patches a `save_pretrained` onto the pipeline and component configs (`auto_round/utils/model.py`, around the `config_save_pretrained` partials). So the crash is reserved for callers who load a transformer themselves and pass it to `AutoRound`, and what they get is shards on disk with no `config.json` and no `quantization_config`.

One detail that made the obvious fix wrong: calling `model.save_config(save_dir)` alone writes a `config.json` **without** `quantization_config`, because the exporter sets that on the config object (`export_to_autoround/export.py`: `model.config.quantization_config = quantization_config`) and `save_config` only serializes the config's own dict. I verified that directly — `save_config` after setting the attribute produces a `config.json` whose keys do not include `quantization_config`. So the helper writes the config with diffusers' own writer and then merges `quantization_config` back in.

The same `model.config.save_pretrained(...)` call exists at two more sites, so all three now go through one helper: `formats.py` (fake format, meta-device branch) and `export_to_llmcompressor/export.py`. I only exercised the `auto_round` format path with a diffusers model; the other two are the same substitution, unverified against a diffusers model. `export_to_mlx` has the same call and is left alone — a diffusers transformer is not an MLX target.

### Reproduction

Against `main` at 417d87de, with torch 2.11.0+cu128 / diffusers 0.40.0.dev0 / transformers 5.14.1:

```python
import torch
from diffusers import SD3Transformer2DModel
from auto_round import AutoRound

SD3Transformer2DModel(
    sample_size=8, patch_size=2, in_channels=4, num_layers=1,
    attention_head_dim=32, num_attention_heads=2, joint_attention_dim=64,
    caption_projection_dim=64, pooled_projection_dim=64, out_channels=4,
).save_pretrained("/tmp/tiny_sd3")
model = SD3Transformer2DModel.from_pretrained("/tmp/tiny_sd3", torch_dtype=torch.bfloat16)

class _StubTokenizer:  # see note below
    pass

AutoRound(
    model=model, tokenizer=_StubTokenizer(), scheme="W4A16", group_size=32, sym=True,
    iters=0, disable_opt_rtn=True, to_quant_block_names="transformer_blocks", batch_size=1,
).quantize_and_save("/tmp/out", format="auto_round", inplace=True)
```

Before: `AttributeError` as above, and the only thing on disk is `w4g32/model.safetensors`.

After: no error, and

```
w4g32/config.json
w4g32/model.safetensors
w4g32/quantization_config.json
```

with `config.json` carrying `_class_name: SD3Transformer2DModel`, `_diffusers_version`, and a `quantization_config` (`quant_method: auto-round`, `bits: 4`, `group_size: 32`, `packing_format: auto_round:auto_gptq`).

Two honest notes about that snippet:

* The `_StubTokenizer` is not part of this bug. On current `main`, `ModelContext` raises `ValueError("A tokenizer must be set for non-str model input")` for any model object, including data-free RTN, because `BaseOrchestrator.__init__` passes `need_calib=self.need_calib` (still the class default `True`) before `self.need_calib = self._check_need_calib()` runs later in the same `__init__`. That looks like a separate ordering bug; happy to file it separately.
* The shards are still named `model-*.safetensors`, while diffusers looks for `diffusion_pytorch_model*`. This PR does not touch naming — `rename_weights_files` already exists for that and is used by the diffusion path.

### Test

`test/test_cpu/export/test_export.py::test_save_model_writes_diffusers_config` builds a tiny SD3 transformer in-process (no download) and calls `save_model(..., immediate_saving=True)`, the path that crashed.

```
# with the fix
1 passed, 26 deselected in 0.43s

# with auto_round/ reverted, test kept
auto_round/export/utils.py:48: AttributeError
1 failed, 26 deselected in 0.33s
```

### Where this came from

Quantizing MiniMax-H3's 33B video/audio DiT (`MiniMaxH3Transformer3DModel`) to W4A16. The transformer is loaded directly rather than through a pipeline, so the export died after writing all 14 shards; the config had to be reconstructed by hand from the tensors on disk. Result and write-up: https://huggingface.co/Ar4ikov/MiniMax-H3-transformer-W4A16-RTN

## Type of Change

Bug fix

## Related Issues

No issue filed — the failure is deterministic and the fix is small. Happy to open one if you prefer it tracked.

## Checklist Before Submitting

- [x] My code has been tested locally. black / isort / ruff / codespell clean on the touched files. On the export subset (`autogptq_format`, `autoround_format`, `awq_format`, `immediate_saving`) the patched tree gives the same result as unpatched `main` in the same environment: `5 failed, 1 passed` either way, plus the new test passing. All five failures are `check_compressed_tensors_supported` (`ImportError: Please install compressed-tensors ...` / `SystemExit: -1`) — a missing optional dependency here, which also means the `llm_compressor` export path is not covered by my local run.
- [ ] Documentation has been updated as needed. No docs describe this path.
- [x] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. I cannot trigger `/azp run Unit-Test-CUDA-AutoRound` on this repo; please kick it off.

@WeiweiZhang1, you last touched this config-saving code in #1810, and @mengniwang95 as the author of diffusion model saving (#1519), where the `save_pretrained`-on-the-config patch that hides this bug comes from.
