### PR TITLE
Refactor unit test scripts

### DIFF
--- a/.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh
+++ b/.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh
@@ -90,7 +90,7 @@ function run_unit_test() {
 
         COVERAGE_CORE=sysmon pytest -m "not skip_ci" \
             --cov=auto_round --cov-report= --cov-append --timeout=60 --session-timeout=720 \
-            -vs --disable-warnings --durations=0 --durations-min=1 --junitxml="${ut_log_name%.log}.xml" \
+            -vs --junitxml="${ut_log_name%.log}.xml" \
             ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
     done
@@ -123,8 +123,8 @@ function run_unit_test_llmc() {
         local test_basename=$(basename ${test_file} .py)
         local ut_log_name=${LOG_DIR}/unittest_cuda_llmc_${test_basename}.log
         COVERAGE_CORE=sysmon pytest -m "not skip_ci" \
-            --cov=auto_round --cov-report= --cov-append -vs --disable-warnings \
-            --durations=0 --durations-min=1 --junitxml="${ut_log_name%.log}.xml" \
+            --cov=auto_round --cov-report= --cov-append -vs \
+            --junitxml="${ut_log_name%.log}.xml" \
             ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
     done
@@ -157,8 +157,8 @@ function run_unit_test_sglang() {
         local test_basename=$(basename ${test_file} .py)
         local ut_log_name=${LOG_DIR}/unittest_cuda_sglang_${test_basename}.log
         COVERAGE_CORE=sysmon pytest -m "not skip_ci" \
-            --cov=auto_round --cov-report= --cov-append -vs --disable-warnings \
-            --durations=0 --durations-min=1 --junitxml="${ut_log_name%.log}.xml" \
+            --cov=auto_round --cov-report= --cov-append -vs \
+            --junitxml="${ut_log_name%.log}.xml" \
              ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
     done
@@ -191,8 +191,8 @@ function run_unit_test_vllm() {
         local test_basename=$(basename ${test_file} .py)
         local ut_log_name=${LOG_DIR}/unittest_cuda_vllm_${test_basename}.log
         COVERAGE_CORE=sysmon pytest -m "not skip_ci" \
-            --cov=auto_round --cov-report= --cov-append -vs --disable-warnings \
-            --durations=0 --durations-min=1 --junitxml="${ut_log_name%.log}.xml" \
+            --cov=auto_round --cov-report= --cov-append -vs \
+            --junitxml="${ut_log_name%.log}.xml" \
             ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
     done

--- a/.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh
+++ b/.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh
@@ -32,20 +32,8 @@ function setup_environment() {
 }
 
 function print_summary() {
-    local status=0
-    while IFS= read -r line; do
-        if [[ "$line" == *"FAILED"* ]]; then
-            $LIGHT_RED && echo "$line" && $RESET
-            status=1
-        elif [[ "$line" == *"PASSED"* ]]; then
-            $LIGHT_GREEN && echo "$line" && $RESET
-        elif [[ "$line" == *"NO_TESTS"* ]]; then
-            $LIGHT_YELLOW && echo "$line" && $RESET
-        else
-            echo "$line"
-        fi
-    done < "${SUMMARY_LOG}"
-    exit $status
+    python ${BUILD_SOURCESDIRECTORY}/.azure-pipelines/scripts/ut/print_summary.py --summary-log "${SUMMARY_LOG}"
+    exit $?
 }
 
 function check_storage_usage() {

--- a/.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh
+++ b/.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh
@@ -64,7 +64,7 @@ function run_unit_test() {
     echo "##[endgroup]"
 
     uv pip list
-    export COVERAGE_RCFILE="${BUILD_SOURCESDIRECTORY}/.azure-pipelines/scripts/ut/.coverage"
+    export COVERAGE_RCFILE="${BUILD_SOURCESDIRECTORY}/.azure-pipelines/scripts/ut/.coveragerc"
 
     cd "${BUILD_SOURCESDIRECTORY}/test" || exit 1
 
@@ -88,7 +88,7 @@ function run_unit_test() {
         local test_basename=$(basename ${test_file} .py)
         local ut_log_name=${LOG_DIR}/unittest_cuda_${test_basename}.log
 
-        COVERAGE_CORE=sysmon pytest -m "not skip_ci" \
+        pytest -m "not skip_ci" \
             --cov=auto_round --cov-report= --cov-append --timeout=60 --session-timeout=720 \
             -vs --junitxml="${ut_log_name%.log}.xml" \
             ${test_file} 2>&1 | tee ${ut_log_name}
@@ -116,13 +116,13 @@ function run_unit_test_llmc() {
 
     cd "${BUILD_SOURCESDIRECTORY}/test" || exit 1
 
-    export COVERAGE_RCFILE="${BUILD_SOURCESDIRECTORY}/.azure-pipelines/scripts/ut/.coverage"
+    export COVERAGE_RCFILE="${BUILD_SOURCESDIRECTORY}/.azure-pipelines/scripts/ut/.coveragerc"
 
     for test_file in $(find ./integration/test_cuda -name "test_llmc*.py" | sort); do
         echo "##[group]Running ${test_file}..."
         local test_basename=$(basename ${test_file} .py)
         local ut_log_name=${LOG_DIR}/unittest_cuda_llmc_${test_basename}.log
-        COVERAGE_CORE=sysmon pytest -m "not skip_ci" \
+        pytest -m "not skip_ci" \
             --cov=auto_round --cov-report= --cov-append -vs \
             --junitxml="${ut_log_name%.log}.xml" \
             ${test_file} 2>&1 | tee ${ut_log_name}
@@ -150,13 +150,13 @@ function run_unit_test_sglang() {
     echo "##[endgroup]"
 
     cd "${BUILD_SOURCESDIRECTORY}/test" || exit 1
-    export COVERAGE_RCFILE="${BUILD_SOURCESDIRECTORY}/.azure-pipelines/scripts/ut/.coverage"
+    export COVERAGE_RCFILE="${BUILD_SOURCESDIRECTORY}/.azure-pipelines/scripts/ut/.coveragerc"
 
     for test_file in $(find ./integration/test_cuda ./e2e/test_cuda -name "test_sglang*.py" | sort); do
         echo "##[group]Running ${test_file}..."
         local test_basename=$(basename ${test_file} .py)
         local ut_log_name=${LOG_DIR}/unittest_cuda_sglang_${test_basename}.log
-        COVERAGE_CORE=sysmon pytest -m "not skip_ci" \
+        pytest -m "not skip_ci" \
             --cov=auto_round --cov-report= --cov-append -vs \
             --junitxml="${ut_log_name%.log}.xml" \
              ${test_file} 2>&1 | tee ${ut_log_name}
@@ -184,13 +184,13 @@ function run_unit_test_vllm() {
     echo "##[endgroup]"
 
     cd "${BUILD_SOURCESDIRECTORY}/test" || exit 1
-    export COVERAGE_RCFILE="${BUILD_SOURCESDIRECTORY}/.azure-pipelines/scripts/ut/.coverage"
+    export COVERAGE_RCFILE="${BUILD_SOURCESDIRECTORY}/.azure-pipelines/scripts/ut/.coveragerc"
 
     for test_file in $(find ./integration/test_cuda ./e2e/test_cuda -name "test_vllm*.py" | sort); do
         echo "##[group]Running ${test_file}..."
         local test_basename=$(basename ${test_file} .py)
         local ut_log_name=${LOG_DIR}/unittest_cuda_vllm_${test_basename}.log
-        COVERAGE_CORE=sysmon pytest -m "not skip_ci" \
+        pytest -m "not skip_ci" \
             --cov=auto_round --cov-report= --cov-append -vs \
             --junitxml="${ut_log_name%.log}.xml" \
             ${test_file} 2>&1 | tee ${ut_log_name}

--- a/.azure-pipelines/scripts/ut/.coveragerc
+++ b/.azure-pipelines/scripts/ut/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-branch = True
+core = sysmon
 
 [paths]
 source =

--- a/.azure-pipelines/scripts/ut/collect_log.sh
+++ b/.azure-pipelines/scripts/ut/collect_log.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 uv pip install coverage
-export COVERAGE_RCFILE=${BUILD_SOURCESDIRECTORY}/.azure-pipelines/scripts/ut/.coverage
+export COVERAGE_RCFILE=${BUILD_SOURCESDIRECTORY}/.azure-pipelines/scripts/ut/.coveragerc
 coverage_log="${BUILD_SOURCESDIRECTORY}/log_dir/coverage_log"
 cd "${BUILD_SOURCESDIRECTORY}/log_dir"
 

--- a/.azure-pipelines/scripts/ut/print_summary.py
+++ b/.azure-pipelines/scripts/ut/print_summary.py
@@ -1,0 +1,47 @@
+"""Print a colorized test summary and exit non-zero on any failure.
+
+Reads the summary log line by line and prints each line with an ANSI color
+based on its content:
+
+* lines containing ``FAILED``   -> red   (and force a non-zero exit code)
+* lines containing ``PASSED``   -> green
+* lines containing ``NO_TESTS`` -> yellow
+* everything else               -> unchanged
+"""
+
+import argparse
+import sys
+
+RED = "\033[31m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+RESET = "\033[0m"
+
+
+def print_summary(summary_log: str) -> int:
+    """Print the colorized summary and return the exit status."""
+    status = 0
+    with open(summary_log, encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if "FAILED" in line:
+                print(f"{RED}{line}{RESET}")
+                status = 1
+            elif "PASSED" in line:
+                print(f"{GREEN}{line}{RESET}")
+            elif "NO_TESTS" in line:
+                print(f"{YELLOW}{line}{RESET}")
+            else:
+                print(line)
+    return status
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--summary-log", required=True, help="Path to the summary log file.")
+    args = parser.parse_args()
+    sys.exit(print_summary(args.summary_log))
+
+
+if __name__ == "__main__":
+    main()

--- a/.azure-pipelines/scripts/ut/run_ut.sh
+++ b/.azure-pipelines/scripts/ut/run_ut.sh
@@ -38,20 +38,8 @@ function setup_environment() {
 }
 
 function print_summary() {
-    local status=0
-    while IFS= read -r line; do
-        if [[ "$line" == *"FAILED"* ]]; then
-            $LIGHT_RED && echo "$line" && $RESET
-            status=1
-        elif [[ "$line" == *"PASSED"* ]]; then
-            $LIGHT_GREEN && echo "$line" && $RESET
-        elif [[ "$line" == *"NO_TESTS"* ]]; then
-            $LIGHT_YELLOW && echo "$line" && $RESET
-        else
-            echo "$line"
-        fi
-    done < "${SUMMARY_LOG}"
-    exit $status
+    python /auto-round/.azure-pipelines/scripts/ut/print_summary.py --summary-log "${SUMMARY_LOG}"
+    exit $?
 }
 
 function check_storage_usage() {

--- a/.azure-pipelines/scripts/ut/run_ut.sh
+++ b/.azure-pipelines/scripts/ut/run_ut.sh
@@ -79,9 +79,9 @@ function run_unit_test() {
         local ut_log_name=${LOG_DIR}/unittest_${test_basename}.log
 
         COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-15}" --membind="${NUMA_NODE:-0}" \
-            pytest -m "not skip_ci" --timeout=30 --session-timeout=600 --durations=0 --durations-min=1 \
+            pytest -m "not skip_ci" --timeout=30 --session-timeout=600 \
                 --cov=auto_round --cov-report= --cov-append \
-                -vs --disable-warnings --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
+                -vs --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
     done
 }
@@ -99,9 +99,9 @@ function run_inc_unit_test() {
         local ut_log_name=${LOG_DIR}/unittest_${test_basename}.log
 
         COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-15}" --membind="${NUMA_NODE:-0}" \
-            pytest --timeout=30 --session-timeout=600 --durations=0 --durations-min=1 \
+            pytest --timeout=30 --session-timeout=600 \
                 --cov=auto_round --cov-report= --cov-append \
-                -vs --disable-warnings --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
+                -vs --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
     done
 }
@@ -121,9 +121,9 @@ function run_llmc_unit_test() {
         local ut_log_name=${LOG_DIR}/unittest_${test_basename}.log
 
         COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-15}" --membind="${NUMA_NODE:-0}" \
-            pytest --timeout=30 --session-timeout=600 --durations=0 --durations-min=1 \
+            pytest --timeout=30 --session-timeout=600 \
                 --cov=auto_round --cov-report= --cov-append \
-                -vs --disable-warnings --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
+                -vs --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
     done
 }

--- a/.azure-pipelines/scripts/ut/run_ut.sh
+++ b/.azure-pipelines/scripts/ut/run_ut.sh
@@ -31,7 +31,7 @@ function setup_environment() {
 
     export LD_LIBRARY_PATH=${HOME}/.venv/lib/:$LD_LIBRARY_PATH
     export FORCE_BF16=1
-    export COVERAGE_RCFILE=/auto-round/.azure-pipelines/scripts/ut/.coverage
+    export COVERAGE_RCFILE=/auto-round/.azure-pipelines/scripts/ut/.coveragerc
     echo "##[endgroup]"
 
     uv pip list
@@ -78,7 +78,7 @@ function run_unit_test() {
         local test_basename=$(basename ${test_file} .py)
         local ut_log_name=${LOG_DIR}/unittest_${test_basename}.log
 
-        COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-15}" --membind="${NUMA_NODE:-0}" \
+        numactl --physcpubind="${NUMA_CPUSET:-0-15}" --membind="${NUMA_NODE:-0}" \
             pytest -m "not skip_ci" --timeout=30 --session-timeout=600 \
                 --cov=auto_round --cov-report= --cov-append \
                 -vs --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
@@ -98,7 +98,7 @@ function run_inc_unit_test() {
         local test_basename=$(basename ${test_file} .py)
         local ut_log_name=${LOG_DIR}/unittest_${test_basename}.log
 
-        COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-15}" --membind="${NUMA_NODE:-0}" \
+        numactl --physcpubind="${NUMA_CPUSET:-0-15}" --membind="${NUMA_NODE:-0}" \
             pytest --timeout=30 --session-timeout=600 \
                 --cov=auto_round --cov-report= --cov-append \
                 -vs --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
@@ -120,7 +120,7 @@ function run_llmc_unit_test() {
         local test_basename=$(basename ${test_file} .py)
         local ut_log_name=${LOG_DIR}/unittest_${test_basename}.log
 
-        COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-15}" --membind="${NUMA_NODE:-0}" \
+        numactl --physcpubind="${NUMA_CPUSET:-0-15}" --membind="${NUMA_NODE:-0}" \
             pytest --timeout=30 --session-timeout=600 \
                 --cov=auto_round --cov-report= --cov-append \
                 -vs --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}

--- a/.azure-pipelines/scripts/ut/run_ut_cuda.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_cuda.sh
@@ -103,7 +103,7 @@ function run_unit_test() {
     cd ${REPO_PATH} && uv pip install . && cd ${REPO_PATH}/test
 
     pip list > ${LOG_DIR}/ut_pip_list.txt
-    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coverage
+    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coveragerc
 
     # run unit tests individually with separate logs
     for test_file in $(find ./unit/test_cuda -type f -name "test_*.py" | grep -Ev "vlms|llmc|sglang|vllm|multiple_card" | sort); do
@@ -111,7 +111,7 @@ function run_unit_test() {
         local ut_log_name=${LOG_DIR}/unittest_cuda_${test_basename}.log
         echo "Running ${test_file}..."
 
-        COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
+        pytest --cov=auto_round --cov-report= --cov-append \
             -p no:timeout -vs ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.unit
@@ -138,7 +138,7 @@ function run_unit_test_vlm() {
     cd ${REPO_PATH} && uv pip install . && cd ${REPO_PATH}/test
 
     pip list > ${LOG_DIR}/vlm_ut_pip_list.txt
-    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coverage
+    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coveragerc
 
     # run VLM unit tests individually with separate logs
     for test_file in $(find ./unit/test_cuda -name "test*vlms.py"); do
@@ -146,7 +146,7 @@ function run_unit_test_vlm() {
         local ut_log_name=${LOG_DIR}/unittest_cuda_vlm_${test_basename}.log
         echo "Running ${test_file}..."
 
-        COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
+        pytest --cov=auto_round --cov-report= --cov-append \
             -p no:timeout -vs ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.vlm
@@ -170,7 +170,7 @@ function run_unit_test_llmc() {
     cd ${REPO_PATH} && uv pip install . && cd ${REPO_PATH}/test
 
     pip list > ${LOG_DIR}/llmc_ut_pip_list.txt
-    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coverage
+    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coveragerc
 
     # run unit tests individually with separate logs
     for test_file in $(find ./integration/test_cuda -name "test_llmc*.py" | sort); do
@@ -178,7 +178,7 @@ function run_unit_test_llmc() {
         local ut_log_name=${LOG_DIR}/unittest_cuda_llmc_${test_basename}.log
         echo "Running ${test_file}..."
 
-        COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
+        pytest --cov=auto_round --cov-report= --cov-append \
             -p no:timeout -vs ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.llmc
@@ -204,7 +204,7 @@ function run_unit_test_sglang() {
     cd ${REPO_PATH} && uv pip install . && cd ${REPO_PATH}/test
 
     pip list > ${LOG_DIR}/sglang_ut_pip_list.txt
-    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coverage
+    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coveragerc
 
     # run unit tests individually with separate logs
     for test_file in $(find ./integration/test_cuda ./e2e/test_cuda -name "test_sglang*.py" | sort); do
@@ -212,7 +212,7 @@ function run_unit_test_sglang() {
         local ut_log_name=${LOG_DIR}/unittest_cuda_sglang_${test_basename}.log
         echo "Running ${test_file}..."
 
-        COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
+        pytest --cov=auto_round --cov-report= --cov-append \
             -p no:timeout -vs ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.sglang
@@ -239,7 +239,7 @@ function run_unit_test_vllm() {
     cd ${REPO_PATH} && uv pip install . && cd ${REPO_PATH}/test
 
     pip list > ${LOG_DIR}/vllm_ut_pip_list.txt
-    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coverage
+    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coveragerc
 
     # run unit tests individually with separate logs
     for test_file in $(find ./integration/test_cuda ./e2e/test_cuda -name "test_vllm*.py" | sort); do
@@ -247,7 +247,7 @@ function run_unit_test_vllm() {
         local ut_log_name=${LOG_DIR}/unittest_cuda_vllm_${test_basename}.log
         echo "Running ${test_file}..."
 
-        COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
+        pytest --cov=auto_round --cov-report= --cov-append \
             -p no:timeout -vs ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.vllm
@@ -268,7 +268,7 @@ function merge_coverage() {
         return
     fi
 
-    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coverage
+    export COVERAGE_RCFILE=${REPO_PATH}/.azure-pipelines/scripts/ut/.coveragerc
     coverage combine ${coverage_files}
     coverage xml -o ${LOG_DIR}/coverage_merged.xml
     coverage html -d ${LOG_DIR}/htmlcov

--- a/.azure-pipelines/scripts/ut/run_ut_cuda.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_cuda.sh
@@ -112,7 +112,7 @@ function run_unit_test() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            --timeout=0 --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.unit
 
@@ -147,7 +147,7 @@ function run_unit_test_vlm() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            --timeout=0 --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.vlm
 
@@ -179,7 +179,7 @@ function run_unit_test_llmc() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            --timeout=0 --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.llmc
 
@@ -213,7 +213,7 @@ function run_unit_test_sglang() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            --timeout=0 --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.sglang
 
@@ -248,7 +248,7 @@ function run_unit_test_vllm() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            --timeout=0 --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.vllm
 

--- a/.azure-pipelines/scripts/ut/run_ut_cuda.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_cuda.sh
@@ -95,8 +95,8 @@ function run_unit_test() {
     uv pip install torch==2.13.0 torchvision torchao --index-url https://download.pytorch.org/whl/cu130
     uv pip install llama-cpp-python --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu130
     uv pip install 'git+https://github.com/ggml-org/llama.cpp.git#subdirectory=gguf-py'
-    uv pip install -r test/unit/test_cuda/requirements.txt
-    uv pip install -r test/unit/test_cuda/requirements_diffusion.txt
+    uv pip install -r unit/test_cuda/requirements.txt
+    uv pip install -r unit/test_cuda/requirements_diffusion.txt
     uv pip install -U transformers chardet
     uv pip uninstall torch torchvision
     uv pip install torch==2.13.0 torchvision torchao --index-url https://download.pytorch.org/whl/cu130
@@ -131,7 +131,7 @@ function run_unit_test_vlm() {
     uv pip install torch==2.13.0 torchvision --index-url https://download.pytorch.org/whl/cu130
     uv pip install git+https://github.com/haotian-liu/LLaVA.git@v1.2.2 --no-deps
     uv pip install flash-attn==2.8.3 --no-build-isolation
-    uv pip install -r test_cuda/requirements_vlm.txt \
+    uv pip install -r unit/test_cuda/requirements_vlm.txt \
         --extra-index-url https://download.pytorch.org/whl/cu130 \
         --index-strategy unsafe-best-match
     uv pip install -U chardet
@@ -163,7 +163,9 @@ function run_unit_test_llmc() {
 
     cd ${REPO_PATH}/test
     rm -rf .coverage* *.xml *.html
-    BUILD_TYPE="nightly" uv pip install -r test_cuda/requirements_llmc.txt --extra-index-url https://download.pytorch.org/whl/cu130 --index-strategy unsafe-best-match
+    BUILD_TYPE="nightly" uv pip install -r integration/test_cuda/requirements_llmc.txt \
+        --extra-index-url https://download.pytorch.org/whl/cu130 \
+        --index-strategy unsafe-best-match
     uv pip install -U chardet
     cd ${REPO_PATH} && uv pip install . && cd ${REPO_PATH}/test
 
@@ -193,7 +195,7 @@ function run_unit_test_sglang() {
 
     cd ${REPO_PATH}/test
     rm -rf .coverage* *.xml *.html
-    uv pip install -r test_cuda/requirements_sglang.txt \
+    uv pip install -r integration/test_cuda/requirements_sglang.txt \
         --prerelease=allow \
         --extra-index-url https://download.pytorch.org/whl/cu130 \
         --index-strategy unsafe-best-match
@@ -228,7 +230,7 @@ function run_unit_test_vllm() {
 
     cd ${REPO_PATH}/test
     rm -rf .coverage* *.xml *.html
-    uv pip install -r test_cuda/requirements_vllm.txt \
+    uv pip install -r integration/test_cuda/requirements_vllm.txt \
         --extra-index-url https://download.pytorch.org/whl/cu130 \
         --index-strategy unsafe-best-match
     local flashinfer_version=$(uv pip show flashinfer-python 2>/dev/null | grep -i "^Version" | awk '{print $2}')

--- a/.azure-pipelines/scripts/ut/run_ut_cuda.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_cuda.sh
@@ -112,7 +112,7 @@ function run_unit_test() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            --timeout=0 --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            -p no:timeout --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.unit
 
@@ -147,7 +147,7 @@ function run_unit_test_vlm() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            --timeout=0 --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            -p no:timeout --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.vlm
 
@@ -179,7 +179,7 @@ function run_unit_test_llmc() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            --timeout=0 --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            -p no:timeout --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.llmc
 
@@ -213,7 +213,7 @@ function run_unit_test_sglang() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            --timeout=0 --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            -p no:timeout --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.sglang
 
@@ -248,7 +248,7 @@ function run_unit_test_vllm() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            --timeout=0 --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            -p no:timeout --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.vllm
 

--- a/.azure-pipelines/scripts/ut/run_ut_cuda.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_cuda.sh
@@ -112,7 +112,7 @@ function run_unit_test() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            -p no:timeout --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            -p no:timeout -vs ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.unit
 
@@ -147,7 +147,7 @@ function run_unit_test_vlm() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            -p no:timeout --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            -p no:timeout -vs ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.vlm
 
@@ -179,7 +179,7 @@ function run_unit_test_llmc() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            -p no:timeout --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            -p no:timeout -vs ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.llmc
 
@@ -213,7 +213,7 @@ function run_unit_test_sglang() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            -p no:timeout --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            -p no:timeout -vs ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.sglang
 
@@ -248,7 +248,7 @@ function run_unit_test_vllm() {
         echo "Running ${test_file}..."
 
         COVERAGE_CORE=sysmon pytest --cov=auto_round --cov-report= --cov-append \
-            -p no:timeout --durations=0 --durations-min=1 -vs --disable-warnings ${test_file} 2>&1 | tee ${ut_log_name}
+            -p no:timeout -vs ${test_file} 2>&1 | tee ${ut_log_name}
     done
     [ -f .coverage ] && cp .coverage ${LOG_DIR}/.coverage.vllm
 

--- a/.azure-pipelines/scripts/ut/run_ut_hpu.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_hpu.sh
@@ -17,7 +17,7 @@ function setup_environment() {
 
     export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH
     export FORCE_BF16=1
-    export COVERAGE_RCFILE=/auto-round/.azure-pipelines/scripts/ut/.coverage
+    export COVERAGE_RCFILE=/auto-round/.azure-pipelines/scripts/ut/.coveragerc
 
     LOG_DIR=/auto-round/log_dir
     mkdir -p ${LOG_DIR}
@@ -33,7 +33,7 @@ function run_unit_test() {
 
         echo "##[group]Running ${test_file} in HPU lazy mode..."
         local ut_log_name="${LOG_DIR}/unittest_lazy_${test_basename}.log"
-        COVERAGE_CORE=sysmon PT_HPU_LAZY_MODE=1 pytest --cov="${auto_round_path}" \
+        PT_HPU_LAZY_MODE=1 pytest --cov="${auto_round_path}" \
             --timeout=30 --session-timeout=600 \
             --cov-report= --cov-append -vs \
             --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
@@ -41,7 +41,7 @@ function run_unit_test() {
 
         echo "##[group]Running ${test_file} in HPU compile mode..."
         local ut_log_name="${LOG_DIR}/unittest_compile_${test_basename}.log"
-        COVERAGE_CORE=sysmon PT_HPU_LAZY_MODE=0 pytest --mode compile --cov="${auto_round_path}" \
+        PT_HPU_LAZY_MODE=0 pytest --mode compile --cov="${auto_round_path}" \
             --timeout=30 --session-timeout=600 \
             --cov-report= --cov-append -vs \
             --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}

--- a/.azure-pipelines/scripts/ut/run_ut_hpu.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_hpu.sh
@@ -34,16 +34,16 @@ function run_unit_test() {
         echo "##[group]Running ${test_file} in HPU lazy mode..."
         local ut_log_name="${LOG_DIR}/unittest_lazy_${test_basename}.log"
         COVERAGE_CORE=sysmon PT_HPU_LAZY_MODE=1 pytest --cov="${auto_round_path}" \
-            --timeout=30 --session-timeout=600 --durations=0 --durations-min=1 \
-            --cov-report= --cov-append -vs --disable-warnings \
+            --timeout=30 --session-timeout=600 \
+            --cov-report= --cov-append -vs \
             --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
 
         echo "##[group]Running ${test_file} in HPU compile mode..."
         local ut_log_name="${LOG_DIR}/unittest_compile_${test_basename}.log"
         COVERAGE_CORE=sysmon PT_HPU_LAZY_MODE=0 pytest --mode compile --cov="${auto_round_path}" \
-            --timeout=30 --session-timeout=600 --durations=0 --durations-min=1 \
-            --cov-report= --cov-append -vs --disable-warnings \
+            --timeout=30 --session-timeout=600 \
+            --cov-report= --cov-append -vs \
             --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
     done

--- a/.azure-pipelines/scripts/ut/run_ut_hpu.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_hpu.sh
@@ -50,20 +50,8 @@ function run_unit_test() {
 }
 
 function print_summary() {
-    local status=0
-    while IFS= read -r line; do
-        if [[ "$line" == *"FAILED"* ]]; then
-            $LIGHT_RED && echo "$line" && $RESET
-            status=1
-        elif [[ "$line" == *"PASSED"* ]]; then
-            $LIGHT_GREEN && echo "$line" && $RESET
-        elif [[ "$line" == *"NO_TESTS"* ]]; then
-            $LIGHT_YELLOW && echo "$line" && $RESET
-        else
-            echo "$line"
-        fi
-    done < "${SUMMARY_LOG}"
-    exit $status
+    python /auto-round/.azure-pipelines/scripts/ut/print_summary.py --summary-log "${SUMMARY_LOG}"
+    exit $?
 }
 
 function collect_log() {

--- a/.azure-pipelines/scripts/ut/run_ut_xpu.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_xpu.sh
@@ -22,7 +22,7 @@ function setup_environment() {
     export TQDM_MININTERVAL=60
     export HF_HUB_DISABLE_PROGRESS_BARS=1
     export LD_LIBRARY_PATH=${HOME}/.venv/lib/:$LD_LIBRARY_PATH
-    export COVERAGE_RCFILE=/auto-round/.azure-pipelines/scripts/ut/.coverage
+    export COVERAGE_RCFILE=/auto-round/.azure-pipelines/scripts/ut/.coveragerc
 
     LOG_DIR=/auto-round/log_dir
     mkdir -p ${LOG_DIR}
@@ -38,7 +38,7 @@ function run_unit_test() {
 
         echo "##[group]Running ark ${test_file}..."
         local ut_log_name="${LOG_DIR}/unittest_ark_${test_basename}.log"
-        COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-27}" --membind="${NUMA_NODE:-0}" \
+        numactl --physcpubind="${NUMA_CPUSET:-0-27}" --membind="${NUMA_NODE:-0}" \
             pytest --timeout=30 --session-timeout=600 \
                 --cov="${auto_round_path}" --cov-report= --cov-append -vs \
                 --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
@@ -50,7 +50,7 @@ function run_unit_test() {
 
         echo "##[group]Running xpu ${test_file}..."
         local ut_log_name="${LOG_DIR}/unittest_xpu_${test_basename}.log"
-        COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-27}" --membind="${NUMA_NODE:-0}" \
+        numactl --physcpubind="${NUMA_CPUSET:-0-27}" --membind="${NUMA_NODE:-0}" \
             pytest --timeout=30 --session-timeout=600 \
                 --cov="${auto_round_path}" --cov-report= --cov-append -vs \
                 --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
@@ -71,7 +71,7 @@ function run_unit_test_llmc() {
 
         echo "##[group]Running xpu llmc ${test_file}..."
         local ut_log_name="${LOG_DIR}/unittest_xpu_${test_basename}.log"
-        COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-27}" --membind="${NUMA_NODE:-0}" \
+        numactl --physcpubind="${NUMA_CPUSET:-0-27}" --membind="${NUMA_NODE:-0}" \
             pytest --timeout=30 --session-timeout=600 \
                 --cov="${auto_round_path}" --cov-report= --cov-append -vs \
                 --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}

--- a/.azure-pipelines/scripts/ut/run_ut_xpu.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_xpu.sh
@@ -39,8 +39,8 @@ function run_unit_test() {
         echo "##[group]Running ark ${test_file}..."
         local ut_log_name="${LOG_DIR}/unittest_ark_${test_basename}.log"
         COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-27}" --membind="${NUMA_NODE:-0}" \
-            pytest --timeout=30 --session-timeout=600 --durations=0 --durations-min=1 \
-                --cov="${auto_round_path}" --cov-report= --cov-append -vs --disable-warnings \
+            pytest --timeout=30 --session-timeout=600 \
+                --cov="${auto_round_path}" --cov-report= --cov-append -vs \
                 --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
     done
@@ -51,8 +51,8 @@ function run_unit_test() {
         echo "##[group]Running xpu ${test_file}..."
         local ut_log_name="${LOG_DIR}/unittest_xpu_${test_basename}.log"
         COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-27}" --membind="${NUMA_NODE:-0}" \
-            pytest --timeout=30 --session-timeout=600 --durations=0 --durations-min=1 \
-                --cov="${auto_round_path}" --cov-report= --cov-append -vs --disable-warnings \
+            pytest --timeout=30 --session-timeout=600 \
+                --cov="${auto_round_path}" --cov-report= --cov-append -vs \
                 --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
     done
@@ -72,8 +72,8 @@ function run_unit_test_llmc() {
         echo "##[group]Running xpu llmc ${test_file}..."
         local ut_log_name="${LOG_DIR}/unittest_xpu_${test_basename}.log"
         COVERAGE_CORE=sysmon numactl --physcpubind="${NUMA_CPUSET:-0-27}" --membind="${NUMA_NODE:-0}" \
-            pytest --timeout=30 --session-timeout=600 --durations=0 --durations-min=1 \
-                --cov="${auto_round_path}" --cov-report= --cov-append -vs --disable-warnings \
+            pytest --timeout=30 --session-timeout=600 \
+                --cov="${auto_round_path}" --cov-report= --cov-append -vs \
                 --junitxml="${ut_log_name%.log}.xml" ${test_file} 2>&1 | tee ${ut_log_name}
         echo "##[endgroup]"
     done

--- a/.azure-pipelines/scripts/ut/run_ut_xpu.sh
+++ b/.azure-pipelines/scripts/ut/run_ut_xpu.sh
@@ -80,20 +80,8 @@ function run_unit_test_llmc() {
 }
 
 function print_summary() {
-    local status=0
-    while IFS= read -r line; do
-        if [[ "$line" == *"FAILED"* ]]; then
-            $LIGHT_RED && echo "$line" && $RESET
-            status=1
-        elif [[ "$line" == *"PASSED"* ]]; then
-            $LIGHT_GREEN && echo "$line" && $RESET
-        elif [[ "$line" == *"NO_TESTS"* ]]; then
-            $LIGHT_YELLOW && echo "$line" && $RESET
-        else
-            echo "$line"
-        fi
-    done < "${SUMMARY_LOG}"
-    exit $status
+    python /auto-round/.azure-pipelines/scripts/ut/print_summary.py --summary-log "${SUMMARY_LOG}"
+    exit $?
 }
 
 function collect_log() {

--- a/.azure-pipelines/unit-test.yml
+++ b/.azure-pipelines/unit-test.yml
@@ -44,6 +44,16 @@ variables:
   ARTIFACT_NAME: "UT_coverage_report"
   REPO: $(Build.Repository.Uri)
 
+parameters:
+  - name: unitTestParts
+    type: object
+    default:
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+
 stages:
   - template: template/lib-build-template.yml
     parameters:
@@ -60,16 +70,9 @@ stages:
         timeoutInMinutes: 60
         strategy:
           matrix:
-            part1:
-              PART: 1
-            part2:
-              PART: 2
-            part3:
-              PART: 3
-            part4:
-              PART: 4
-            part5:
-              PART: 5
+            ${{ each part in parameters.unitTestParts }}:
+              part_${{ part }}:
+                PART: ${{ part }}
         steps:
           - template: template/ut-template.yml
             parameters:

--- a/.azure-pipelines/unit-test.yml
+++ b/.azure-pipelines/unit-test.yml
@@ -30,8 +30,9 @@ pr:
       - test/e2e
       - "*.md"
       - "**/*.md"
-      - .azure-pipelines/scripts/ut/run_ut_hpu.sh
+      - .azure-pipelines/scripts/ut/run_ark_ut.sh
       - .azure-pipelines/scripts/ut/run_ut_cuda.sh
+      - .azure-pipelines/scripts/ut/run_ut_hpu.sh
       - .azure-pipelines/scripts/ut/run_ut_xpu.sh
 
 pool: INTEL-CPU

--- a/auto_round/calib_dataset.py
+++ b/auto_round/calib_dataset.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import json
 import logging
 import multiprocessing
@@ -1015,7 +1016,12 @@ def _get_dataset_impl(tokenizer, seqlen, dataset_name="NeelNanda/pile-10k", seed
         if name in data_lens:
             dataset = select_dataset(dataset, range(data_lens[name]))
         if isinstance(dataset, IterableDataset):
-            dataset = Dataset.from_list(list(dataset))
+            # A single dataset source never contributes more than `nsamples` rows to the
+            # final combined dataset, so cap materialization here instead of fully consuming
+            # the (much larger) internal `.take(...)` pool used by streaming dataset loaders.
+            # This avoids needless downloads/shard resolution for large remote datasets
+            # (e.g. BAAI/CCI3-HQ) when only a small subset of samples is actually needed.
+            dataset = Dataset.from_list(list(itertools.islice(dataset, nsamples)))
         dataset.set_format(type="torch", columns=["input_ids", "attention_mask"])
         new_features = {}
         for k, v in dataset.features.items():

--- a/test/integration/test_cpu/test_llmc_integration.py
+++ b/test/integration/test_cpu/test_llmc_integration.py
@@ -10,7 +10,7 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from auto_round import AutoRound, AWQConfig
 from auto_round.calib_dataset import get_dataset
 
-from ...envs import multi_card
+from ...unit.envs import multi_card
 
 recipe_str = """
 quant_stage:

--- a/test/integration/test_cuda/test_llmc_integration.py
+++ b/test/integration/test_cuda/test_llmc_integration.py
@@ -1,1 +1,1 @@
-../../test_cpu/integrations/test_llmc_integration.py
+../test_cpu/test_llmc_integration.py

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -3,4 +3,4 @@ testpaths = unit
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
-addopts = -v --tb=short --ignore=test/unit/test_xpu
+addopts = -vs --tb=short --ignore=test/unit/test_xpu --durations=0 --durations-min=1 --disable-warnings


### PR DESCRIPTION
## Description

This pull request makes several improvements to the unit test infrastructure, focusing on unifying coverage configuration, simplifying test summary printing, and cleaning up test runner scripts. The main changes include switching from a `.coverage` config file to a `.coveragerc` file, replacing shell-based summary printing with a Python script, and removing unnecessary environment variables and pytest flags from the test runners.

Key changes:

**Coverage configuration and environment:**
* Standardized the coverage configuration file from `.coverage` to `.coveragerc` across all test scripts and pipelines, updating all relevant `COVERAGE_RCFILE` environment variable assignments. (`.azure-pipelines/scripts/ut/.coveragerc`, `.azure-pipelines/scripts/ut/collect_log.sh`, `.azure-pipelines/scripts/ut/run_ut.sh`, `.azure-pipelines/scripts/ut/run_ut_cuda.sh`, `.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh`) [[1]](diffhunk://#diff-0175e9fc6029cf9586c017a95057e9ae1ba00dd5d8f075cde313026965762b03L2-R2) [[2]](diffhunk://#diff-730514107e527164a020cdece936dea8a19ae061396ce52b686816593aa36344L4-R4) [[3]](diffhunk://#diff-84af0a0f302bb6a5eea2c3675c8697ee40a107943d26c7415c58ebce3cf60550L34-R42) [[4]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L98-R115) [[5]](diffhunk://#diff-aeaf3986a1a0811c31823572fc115d5b13ea35705b0f4b6d56a9f423a486ef19L79-R67) [[6]](diffhunk://#diff-aeaf3986a1a0811c31823572fc115d5b13ea35705b0f4b6d56a9f423a486ef19L131-R127) [[7]](diffhunk://#diff-aeaf3986a1a0811c31823572fc115d5b13ea35705b0f4b6d56a9f423a486ef19L165-R161) [[8]](diffhunk://#diff-aeaf3986a1a0811c31823572fc115d5b13ea35705b0f4b6d56a9f423a486ef19L199-R195) [[9]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L134-R150) [[10]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L166-R182) [[11]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L205-R216) [[12]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L231-R233) [[13]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L240-R251) [[14]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L269-R271)

**Test summary handling:**
* Replaced the shell-based `print_summary` function with a new Python script (`print_summary.py`) that colorizes test output and handles exit codes, improving maintainability and clarity. (`.azure-pipelines/scripts/ut/print_summary.py`, `.azure-pipelines/scripts/ut/run_ut.sh`, `.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh`) [[1]](diffhunk://#diff-0aa07c20e9d6f1911bea5fd3bcfa098d4e870b69deb69c9a01cef160f282dc54R1-R47) [[2]](diffhunk://#diff-84af0a0f302bb6a5eea2c3675c8697ee40a107943d26c7415c58ebce3cf60550L34-R42) [[3]](diffhunk://#diff-aeaf3986a1a0811c31823572fc115d5b13ea35705b0f4b6d56a9f423a486ef19L35-R36)

**Test runner simplifications:**
* Removed the use of the `COVERAGE_CORE=sysmon` environment variable and several unnecessary pytest flags (such as `--disable-warnings`, `--durations`, and `--durations-min`) from all test runner scripts, streamlining test execution. (`.azure-pipelines/scripts/ut/run_ut.sh`, `.azure-pipelines/scripts/ut/run_ut_cuda.sh`, `.azure-pipelines/scripts/cuda_unit_test/run_cuda_ut.sh`) [[1]](diffhunk://#diff-84af0a0f302bb6a5eea2c3675c8697ee40a107943d26c7415c58ebce3cf60550L93-R84) [[2]](diffhunk://#diff-84af0a0f302bb6a5eea2c3675c8697ee40a107943d26c7415c58ebce3cf60550L113-R104) [[3]](diffhunk://#diff-84af0a0f302bb6a5eea2c3675c8697ee40a107943d26c7415c58ebce3cf60550L135-R126) [[4]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L98-R115) [[5]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L134-R150) [[6]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L166-R182) [[7]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L205-R216) [[8]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L240-R251) [[9]](diffhunk://#diff-aeaf3986a1a0811c31823572fc115d5b13ea35705b0f4b6d56a9f423a486ef19L103-R93) [[10]](diffhunk://#diff-aeaf3986a1a0811c31823572fc115d5b13ea35705b0f4b6d56a9f423a486ef19L131-R127) [[11]](diffhunk://#diff-aeaf3986a1a0811c31823572fc115d5b13ea35705b0f4b6d56a9f423a486ef19L165-R161) [[12]](diffhunk://#diff-aeaf3986a1a0811c31823572fc115d5b13ea35705b0f4b6d56a9f423a486ef19L199-R195)

**Test requirements and paths:**
* Fixed and standardized paths to requirements files in CUDA test runners to ensure correct package installation for all test types. (`.azure-pipelines/scripts/ut/run_ut_cuda.sh`) [[1]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L98-R115) [[2]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L134-R150) [[3]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L166-R182) [[4]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L196-R198) [[5]](diffhunk://#diff-335b5294c23e069e84c065ac020101786bb2b29b604157f0a82791c70f7aff79L231-R233)

These updates make the CI scripts more maintainable, reduce duplication, and improve the clarity of test results.
