### PR TITLE
Add timeout decorators to improve test case stability

### DIFF
--- a/test/unit/test_cpu/core/test_autoround.py
+++ b/test/unit/test_cpu/core/test_autoround.py
@@ -680,6 +680,7 @@ class TestAutoRound:
         assert ar.optimizer == torch.optim.AdamW
         assert ar.mllm
 
+    @pytest.mark.timeout(60)
     def test_attention_mask_in_dataset(self):
         from transformers import AutoTokenizer
 

--- a/test/unit/test_cpu/core/test_autoround.py
+++ b/test/unit/test_cpu/core/test_autoround.py
@@ -698,6 +698,7 @@ class TestAutoRound:
         ar = AutoRound(model_name, iters=1, dataset=data, seqlen=8)
         ar.quantize()
 
+    @pytest.mark.timeout(60)
     def test_attention_mask_via_tokenize_in_dataset(self):
         from transformers import AutoTokenizer
 

--- a/test/unit/test_cpu/quantization/test_static_attn.py
+++ b/test/unit/test_cpu/quantization/test_static_attn.py
@@ -37,7 +37,7 @@ def setup_deepseekv3():
     return model, tokenizer, output_dir, config
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(180)
 def test_deepseek_v2(setup_deepseekv2):
     model, tokenizer, output_dir, config = setup_deepseekv2
     autoround = AutoRound(

--- a/test/unit/test_cpu/schemes/test_auto_scheme.py
+++ b/test/unit/test_cpu/schemes/test_auto_scheme.py
@@ -280,6 +280,7 @@ class TestAutoScheme:
     def teardown_class(self):
         shutil.rmtree("runs", ignore_errors=True)
 
+    @pytest.mark.timeout(60)
     def test_auto_scheme_export(self, tiny_opt_model_path):
         model_name = tiny_opt_model_path
         int_save_dir = os.path.join(self.save_dir, "int")

--- a/test/unit/test_cpu/utils/test_cli_usage.py
+++ b/test/unit/test_cpu/utils/test_cli_usage.py
@@ -138,6 +138,7 @@ class TestAutoRoundCmd:
             ],
         )
 
+    @pytest.mark.timeout(60)
     def test_auto_round_cmd8(self, monkeypatch, tiny_opt_model_path, tiny_qwen_vl_model_path):
         _assert_cli_ok(
             monkeypatch,


### PR DESCRIPTION
This pull request increases the robustness of several unit tests by adding or adjusting timeout markers to prevent tests from hanging indefinitely. The main changes are the addition of `pytest.mark.timeout` decorators to specific test methods and the adjustment of an existing timeout value.

**Test timeout improvements:**

* Added a 60-second timeout to `test_attention_mask_in_dataset` in `test_autoround.py` to ensure the test fails if it runs too long.
* Increased the timeout for `test_deepseek_v2` in `test_static_attn.py` from 120 to 180 seconds to accommodate longer test runs.
* Added a 60-second timeout to `test_auto_scheme_export` in `test_auto_scheme.py` for better test reliability.
* Added a 60-second timeout to `test_auto_round_cmd8` in `test_cli_usage.py` to prevent indefinite execution.