### PR TITLE
fix DiffusionCompressionOrchestrator missing nsamples

### DIFF
--- a/auto_round/compressors/diffusion_mixin.py
+++ b/auto_round/compressors/diffusion_mixin.py
@@ -217,7 +217,7 @@ class DiffusionMixin:
                 dataset=dataset,
                 bs=self.batch_size,
                 seed=self.seed,
-                nsamples=self.nsamples,
+                nsamples=self.calibration_context.nsamples,
             )
         else:
             self.dataloader = self.dataset
@@ -414,7 +414,7 @@ class DiffusionMixin:
         logger.info("start to cache block inputs for primary transformer")
         all_inputs = self.try_cache_inter_data_gpucpu(
             to_cache_block_names,
-            self.nsamples,
+            self.calibration_context.nsamples,
             layer_names=[],
         )
         self.inputs = all_inputs
@@ -463,7 +463,7 @@ class DiffusionMixin:
             logger.info(f"start to cache block inputs for {comp_name}")
             all_inputs = self.try_cache_inter_data_gpucpu(
                 to_cache_block_names,
-                self.nsamples,
+                self.calibration_context.nsamples,
                 layer_names=[],
             )
             self.inputs = all_inputs


### PR DESCRIPTION
## Description

issue #2177 
```
(.nvfp4) root@5090D:/mnt/disk3/changwa1# CUDA_VISIBLE_DEVICES=0 auto-round --model Wan2.2-I2V-A14B-Diffusers --scheme nvfp4 --
disable_opt_rtn --iters 0 --nsamples 1 --format fake --output_dir Wan2.2-I2V-A14B-Diffusers-nvfp4 --model_dtype bf16 --low_gpu
_mem_usage
2026-08-18 03:56:01 INFO main.py L295: start to quantize Wan2.2-I2V-A14B-Diffusers
2026-08-18 03:56:01 WARNING model.py L1265: Failed to load config for Wan2.2-I2V-A14B-Diffusers, trying to check model_index.j
son for diffusion pipeline.
2026-08-18 03:56:01 WARNING diffusion_mixin.py L109: reset batch_size(8) to 1 and gradient_accumulate_steps to 8 because batch
_size=8 cannot be used for calibrating non-text modules.
2026-08-18 03:56:01 WARNING logging.py L340: unrecognized keys ['gradient_accumulate_steps'] were passed. Please check them. I
f you use old api, just ignore this warning.
2026-08-18 03:56:01 WARNING model.py L1265: Failed to load config for Wan2.2-I2V-A14B-Diffusers, trying to check model_index.j
son for diffusion pipeline.
[transformers] `CLIPImageProcessor` requires torchvision (not installed); falling back to `CLIPImageProcessorPil` for backward
 compatibility. Install torchvision to use the default backend, or import `CLIPImageProcessorPil` directly to silence this war
ning.
Loading pipeline components...:   0%|                                                                  | 0/6 [00:00<?, ?it/s]P
assed `torch_dtype` torch.float32 is not a `torch.dtype`. Defaulting to `torch.float32`.
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████| 12/12 [00:00<00:00, 161.47it/s]
Loading pipeline components...:  17%|█████████▋                                                | 1/6 [00:15<01:15, 15.12s/it]P
assed `torch_dtype` torch.float32 is not a `torch.dtype`. Defaulting to `torch.float32`.
Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████| 12/12 [00:00<00:00, 160.95it/s]
Loading weights: 100%|███████████████████████████████████████████████████████████████████| 242/242 [00:00<00:00, 7607.37it/s]
Loading pipeline components...:  67%|██████████████████████████████████████▋                   | 4/6 [00:28<00:09,  4.98s/it]P
assed `torch_dtype` torch.float32 is not a `torch.dtype`. Defaulting to `torch.float32`.
Loading pipeline components...: 100%|██████████████████████████████████████████████████████████| 6/6 [00:28<00:00,  4.81s/it]
There are modules in WanTransformer3DModel that should be kept in float32: ['time_embedder', 'scale_shift_table', 'norm1', 'no
rm2', 'norm3']. Casting directly with `to()` can lead to inconsistent results; set `torch_dtype` in `from_pretrained()` instea
d to keep these modules in float32.
There are modules in AutoencoderKLWan that should be kept in float32: []. Casting directly with `to()` can lead to inconsisten
t results; set `torch_dtype` in `from_pretrained()` instead to keep these modules in float32.
2026-08-18 03:56:41 WARNING logging.py L340: reset enable_torch_compile to `False` as activation is static
2026-08-18 03:56:41 INFO diffusion_mixin.py L386: Detected multi-transformer diffusion pipeline, quantizing all transformers
2026-08-18 03:56:41 INFO diffusion_mixin.py L414: start to cache block inputs for primary transformer
Traceback (most recent call last):
  File "/mnt/disk3/changwa1/.nvfp4/bin/auto-round", line 10, in <module>
    sys.exit(run())
             ~~~^^
  File "/mnt/disk3/changwa1/auto-round/auto_round/cli/main.py", line 507, in run
    start(argv=command_argv)
    ~~~~~^^^^^^^^^^^^^^^^^^^
  File "/mnt/disk3/changwa1/auto-round/auto_round/cli/main.py", line 240, in start
    tune(args)
    ~~~~^^^^^^
  File "/mnt/disk3/changwa1/auto-round/auto_round/cli/main.py", line 404, in tune
    model, folders = autoround.quantize_and_save(args.output_dir, format=args.format)  # pylint: disable=no-member
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/disk3/changwa1/auto-round/auto_round/compressors/base.py", line 1873, in quantize_and_save
    self.quantize()
    ~~~~~~~~~~~~~^^
  File "/mnt/disk3/changwa1/auto-round/auto_round/compressors/diffusion_mixin.py", line 417, in quantize
    self.nsamples,
    ^^^^^^^^^^^^^
  File "/mnt/disk3/changwa1/auto-round/auto_round/compressors/base.py", line 1499, in __getattr__
    raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
AttributeError: 'DiffusionCompressionOrchestrator' object has no attribute 'nsamples'
```
## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
