### PR TITLE
fix: preserve mixed LLM-Compressor quantization targets

### DIFF
--- a/HANDOFF_MINIMAX_RANDOM_INIT.md
+++ b/HANDOFF_MINIMAX_RANDOM_INIT.md
@@ -1,0 +1,308 @@
+# AutoRound Random-Init Diffusion Handoff
+
+## Scope
+
+This handoff covers the work done to enable an API path for quantizing a local diffusion-style repository with random-initialized transformer weights, intended for MiniMax-style layouts where the full checkpoints are not yet available.
+
+Target behavior:
+
+- local path input
+- diffusion model path
+- `init_mode="random"`
+- `scheme="W4A16"`
+- `iters=0`
+- `disable_opt_rtn=True`
+- `model_free=False`
+
+Current status:
+
+- implemented
+- syntax-checked
+- directly validated with a dummy local MiniMax-style repo
+- not yet validated against real MiniMax checkpoints
+
+## Repo And Environment
+
+Machine:
+
+- `a100` (`yi4l@mlp-dgx-01.sh.intel.com`)
+
+Repo:
+
+- `~/workspace/auto-round`
+
+Branch / commit at handoff time:
+
+- branch: `main`
+- base commit: `a2f6b3161ab3fadb723e82513bf13bd4e1e9e2f0`
+
+Important environment notes:
+
+- `diffusers` is not installed in `~/workspace/auto-round/.venv`
+- `pytest` is not installed in `~/workspace/auto-round/.venv`
+- validation was done with direct Python scripts and monkeypatched fake `diffusers` classes
+
+## Files Changed
+
+Code:
+
+- `auto_round/autoround.py`
+- `auto_round/compressors/base.py`
+- `auto_round/context/model.py`
+- `auto_round/utils/model.py`
+
+Tests:
+
+- `test/test_cpu/core/test_entry_contract.py`
+- `test/test_cpu/models/test_diffusion.py`
+- `test/test_cpu/quantization/test_model_free.py`
+
+Artifacts created for validation:
+
+- `artifacts/minimax_dummy_random_init/source`
+- `artifacts/minimax_dummy_random_init/quantized_w4a16`
+
+## What Was Implemented
+
+### 1. New Entry Option
+
+`init_mode` is now threaded through the AutoRound entry path and model loading path.
+
+Supported values:
+
+- `pretrained` (default)
+- `random`
+
+### 2. Validation Rules For `init_mode="random"`
+
+The new mode is intentionally narrow. It currently accepts only:
+
+- local directory path
+- diffusion repository layout
+- fixed non-auto scheme
+- pure zero-shot RTN flow
+
+It rejects:
+
+- `model_free=True`
+- non-local model paths
+- non-diffusion repos
+- `AutoScheme`
+- activation-calibration-required schemes
+- anything other than pure RTN zero-shot behavior
+
+Practical meaning:
+
+- use `iters=0`
+- use `disable_opt_rtn=True`
+- use a weight-only zero-shot scheme such as `W4A16`
+
+### 3. Random-Init Diffusion Loader
+
+For `init_mode="random"`, the diffusion loader does not call `DiffusionPipeline.from_pretrained(...)`.
+
+Instead it:
+
+- reads `model_index.json`
+- instantiates only transformer-like components from their local `config.json`
+- keeps non-transformer components as metadata-copy proxies
+- preserves root metadata when saving
+
+Current assumption:
+
+- a primary `transformer/` component must exist
+
+### 4. Model-Free Routing
+
+`is_model_free_route(...)` now returns `False` for `init_mode="random"`.
+
+This forces the flow through the new non-model-free path.
+
+## Dummy Quantized Artifact
+
+A full end-to-end dummy quantization was run successfully on `a100`.
+
+Source repo:
+
+- `/home/yi4l/workspace/auto-round/artifacts/minimax_dummy_random_init/source`
+
+Quantized output:
+
+- `/home/yi4l/workspace/auto-round/artifacts/minimax_dummy_random_init/quantized_w4a16`
+
+Saved files:
+
+- `README.md`
+- `model_index.json`
+- `processor/processor_config.json`
+- `tokenizer/tokenizer_config.json`
+- `transformer/config.json`
+- `transformer/model.safetensors`
+- `transformer/quantization_config.json`
+
+Output size:
+
+- about `140K`
+
+Why it is small:
+
+- this is a tiny dummy transformer, not the real MiniMax model
+- the dummy config used `hidden_size=128` and `num_hidden_layers=2`
+
+Quantization config summary:
+
+- `bits=4`
+- `group_size=128`
+- `data_type=int`
+- `sym=true`
+- `quant_method=auto-round`
+- `packing_format=auto_round:auto_gptq`
+
+## Verification Completed
+
+Completed:
+
+- `python -m py_compile` on edited modules and tests
+- direct validation script for:
+  - entry kwarg routing
+  - model-free route rejection
+  - random-init diffusion loading
+  - metadata preservation on save
+  - missing-transformer failure case
+- full dummy end-to-end quantize-and-save run
+
+Not completed:
+
+- real `pytest` run, because `pytest` is not installed in `.venv`
+- real diffusers-backed load, because `diffusers` is not installed in `.venv`
+- quantization with actual MiniMax checkpoints
+
+## Known Limitations
+
+### 1. Real MiniMax Weights Are Still Missing
+
+The real HF download was not completed during this work. The code path is ready, but the exported artifact produced so far is only a dummy proof artifact.
+
+### 2. Current Random-Init Mode Is Intentionally Restricted
+
+This is not a general random-init loader for all diffusion repos yet. It is a narrow functionality-first implementation.
+
+### 3. Only Primary `transformer` Is Required
+
+The current implementation expects a primary `transformer/` directory. Multi-transformer cases may need extra validation when real MiniMax checkpoints are available.
+
+### 4. Test Environment Is Incomplete
+
+To run the actual tests in the repo virtual environment, install at least:
+
+- `pytest`
+- `diffusers`
+
+## Recommended Next Steps
+
+### Option A: Continue Functionality Work First
+
+1. Install missing runtime/test packages in `~/workspace/auto-round/.venv`.
+2. Run the new targeted tests under real `pytest`.
+3. Keep the dummy artifact as a regression check for the random-init path.
+
+### Option B: Move To Real MiniMax Checkpoints
+
+1. Finish downloading the actual MiniMax repository contents.
+2. Confirm the repo layout matches the assumptions:
+   - `model_index.json`
+   - `transformer/`
+   - component subfolders for tokenizer / processor / VAE / encoder pieces
+3. Run the same AutoRound invocation against the real local repo.
+4. Check whether real MiniMax uses:
+   - a single `transformer`
+   - multiple transformer-like components
+   - any config shapes that require loader adjustments
+
+## Suggested Commands
+
+### Check current repo state
+
+```bash
+ssh a100
+cd ~/workspace/auto-round
+git status --short
+```
+
+### Re-run syntax check
+
+```bash
+cd ~/workspace/auto-round
+. .venv/bin/activate
+python -m py_compile \
+  auto_round/autoround.py \
+  auto_round/compressors/base.py \
+  auto_round/context/model.py \
+  auto_round/utils/model.py \
+  test/test_cpu/core/test_entry_contract.py \
+  test/test_cpu/models/test_diffusion.py \
+  test/test_cpu/quantization/test_model_free.py
+```
+
+### Install missing test/runtime packages
+
+```bash
+cd ~/workspace/auto-round
+. .venv/bin/activate
+pip install pytest diffusers
+```
+
+### Run targeted tests
+
+```bash
+cd ~/workspace/auto-round
+. .venv/bin/activate
+python -m pytest -q \
+  test/test_cpu/core/test_entry_contract.py::test_split_entry_kwargs_partitions_owned_fields \
+  test/test_cpu/quantization/test_model_free.py::test_model_free_route_rejects_random_init \
+  test/test_cpu/models/test_diffusion.py::test_diffusion_random_init_loads_transformer_and_preserves_metadata \
+  test/test_cpu/models/test_diffusion.py::test_diffusion_random_init_requires_transformer_dir
+```
+
+### Shape Of The Intended Real Invocation
+
+Example API call:
+
+```python
+from auto_round import AutoRound
+
+autoround = AutoRound(
+    "/path/to/local/MiniMax-style-repo",
+    tokenizer=None,
+    scheme="W4A16",
+    iters=0,
+    disable_opt_rtn=True,
+    model_free=False,
+    init_mode="random",
+    device_map="cpu",
+    enable_torch_compile=False,
+)
+
+autoround.quantize_and_save("/path/to/output")
+```
+
+## Notes About The Dummy Model
+
+The dummy model used for validation was intentionally small and fake. It monkeypatched a local `diffusers` module object and used a minimal transformer implementation with:
+
+- `transformer_blocks` as a `ModuleList`
+- simple linear sublayers
+- a local `save_pretrained(...)`
+
+This was only to validate the AutoRound control flow, block discovery, save path, and export behavior.
+
+## Handoff Summary
+
+If you continue on another node, the most direct path is:
+
+1. open `~/workspace/auto-round`
+2. install `pytest` and `diffusers` in `.venv`
+3. run the targeted tests
+4. finish downloading the real MiniMax checkpoints
+5. run the real local random-init quantization
+6. inspect whether real MiniMax needs support beyond the current single-primary-transformer assumption

--- a/auto_round/algorithms/block_runner.py
+++ b/auto_round/algorithms/block_runner.py
@@ -76,6 +76,8 @@ register_diffusion_output("OvisImageTransformerBlock", ["encoder_hidden_states",
 register_diffusion_output("OvisImageSingleTransformerBlock", ["encoder_hidden_states", "hidden_states"])
 register_diffusion_output("StableAudioDiTBlock", ["hidden_states"])
 register_diffusion_output("WanTransformerBlock", ["hidden_states"])
+register_diffusion_output("MiniMaxH3TransformerBlock", ["hidden_states"])
+register_diffusion_output("MiniMaxH3TokenRefinerBlock", ["hidden_states"])
 
 # GLM DSA full indexer layers return top-k indices for subsequent shared layers.
 register_block_output("GlmMoeDsaDecoderLayer", ["hidden_states", "prev_topk_indices"])

--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -615,12 +615,16 @@ class _CompressorBuilder(object):
         act_bits = resolved_attrs.get("act_bits")
         act_data_type = resolved_attrs.get("act_data_type")
         act_dynamic = resolved_attrs.get("act_dynamic")
-        needs_act_calib = act_bits is not None and act_bits <= 8 and check_need_act_calibration(
-            act_dynamic,
-            act_data_type,
-            act_bits,
-            static_kv_dtype=base_kwargs.get("static_kv_dtype"),
-            static_attention_dtype=base_kwargs.get("static_attention_dtype"),
+        needs_act_calib = (
+            act_bits is not None
+            and act_bits <= 8
+            and check_need_act_calibration(
+                act_dynamic,
+                act_data_type,
+                act_bits,
+                static_kv_dtype=base_kwargs.get("static_kv_dtype"),
+                static_attention_dtype=base_kwargs.get("static_attention_dtype"),
+            )
         )
         if needs_act_calib:
             raise ValueError(

--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import torch
@@ -331,6 +332,7 @@ _ENTRY_KWARG_OWNERS = {
     "batch_size": "base",
     "model_dtype": "base",
     "trust_remote_code": "base",
+    "init_mode": "base",
     "amp": "base",
     "disable_deterministic_algorithms": "base",
     "enable_deterministic_algorithms": "base",
@@ -582,6 +584,50 @@ class _CompressorBuilder(object):
             return [cls._resolve_config(c) for c in config]
         return config
 
+    @staticmethod
+    def _validate_random_init_mode(model, scheme, quant_config, route_kwargs, base_kwargs) -> None:
+        init_mode = str(base_kwargs.get("init_mode", "pretrained")).strip().lower()
+        if init_mode != "random":
+            return
+
+        if route_kwargs.get("model_free", False):
+            raise ValueError("init_mode='random' cannot be combined with model_free=True.")
+        if not isinstance(model, str) or not os.path.isdir(model):
+            raise ValueError("init_mode='random' requires a local diffusion model directory path.")
+
+        from auto_round.algorithms.quantization.rtn.config import RTNConfig
+        from auto_round.auto_scheme.gen_auto_scheme import AutoScheme
+        from auto_round.compressors.utils import check_need_act_calibration
+        from auto_round.utils.model import is_diffusion_model
+
+        if not is_diffusion_model(model, trust_remote_code=base_kwargs.get("trust_remote_code", True)):
+            raise ValueError("init_mode='random' currently supports only local diffusion model directories.")
+
+        if isinstance(scheme, AutoScheme):
+            raise ValueError("init_mode='random' does not support AutoScheme; use a fixed zero-shot scheme instead.")
+        if not isinstance(quant_config, RTNConfig) or getattr(quant_config, "disable_opt_rtn", None) is not True:
+            raise ValueError(
+                "init_mode='random' currently supports only pure RTN zero-shot quantization "
+                "(iters=0, disable_opt_rtn=True)."
+            )
+
+        _, _, resolved_attrs = parse_scheme(scheme, _preview_resolved_attrs(quant_config, scheme))
+        act_bits = resolved_attrs.get("act_bits")
+        act_data_type = resolved_attrs.get("act_data_type")
+        act_dynamic = resolved_attrs.get("act_dynamic")
+        needs_act_calib = act_bits is not None and act_bits <= 8 and check_need_act_calibration(
+            act_dynamic,
+            act_data_type,
+            act_bits,
+            static_kv_dtype=base_kwargs.get("static_kv_dtype"),
+            static_attention_dtype=base_kwargs.get("static_attention_dtype"),
+        )
+        if needs_act_calib:
+            raise ValueError(
+                "init_mode='random' does not support activation-calibration-required schemes. "
+                "Use a pure weight-only zero-shot scheme such as W4A16."
+            )
+
     def __new__(
         cls,
         model: Union[torch.nn.Module, str],
@@ -637,6 +683,7 @@ class _CompressorBuilder(object):
         # static KV/attention quantization. Keep those options visible to the
         # route predicate; otherwise the fast path silently drops them and
         # cannot emit the required export metadata.
+        cls._validate_random_init_mode(model, scheme, quant_config, route_kwargs, base_kwargs)
         route_decision_kwargs = dict(base_kwargs, **route_kwargs, format=format)
         route_scheme = (
             scheme

--- a/auto_round/compressors/base.py
+++ b/auto_round/compressors/base.py
@@ -309,6 +309,7 @@ class BaseOrchestrator(object):
         # Model related
         model_dtype = kwargs.pop("model_dtype", None)
         trust_remote_code = kwargs.pop("trust_remote_code") if "trust_remote_code" in kwargs else True
+        init_mode = kwargs.pop("init_mode", "pretrained")
         quant_nontext_module = kwargs.pop("quant_nontext_module", False)
         device = kwargs.pop("device", None)
         if device is not None:
@@ -407,6 +408,7 @@ class BaseOrchestrator(object):
             model_dtype=model_dtype,
             trust_remote_code=trust_remote_code,
             config=model_config,
+            init_mode=init_mode,
             amp=amp,
             need_calib=self.need_calib,
             formats=self.formats,

--- a/auto_round/context/model.py
+++ b/auto_round/context/model.py
@@ -64,6 +64,7 @@ class ModelContext(BaseContext):
         model_dtype: Optional[Union[str, torch.dtype]] = None,
         trust_remote_code: bool = True,
         config: Optional[AutoConfig] = None,
+        init_mode: str = "pretrained",
         amp: bool = True,
         need_calib: bool = True,
         is_act_quantize: bool = False,
@@ -101,6 +102,7 @@ class ModelContext(BaseContext):
         self.platform = platform
         self.model_dtype = model_dtype
         self.trust_remote_code = trust_remote_code
+        self.init_mode = init_mode
         self.config = config
         self.amp = amp
         self.need_calib = need_calib
@@ -196,7 +198,12 @@ class ModelContext(BaseContext):
         elif is_diffusion_model(self.model):
             self.is_diffusion = True
             self.pipe, self.model = diffusion_load_model(
-                self.model, platform=self.platform, device="cpu", model_dtype=self.model_dtype
+                self.model,
+                platform=self.platform,
+                device="cpu",
+                model_dtype=self.model_dtype,
+                trust_remote_code=self.trust_remote_code,
+                init_mode=self.init_mode,
             )
         elif isinstance(self.model, str):
             config = self.config

--- a/auto_round/export/export_to_llmcompressor/export.py
+++ b/auto_round/export/export_to_llmcompressor/export.py
@@ -62,7 +62,7 @@ def _get_scheme_type(data_type):
     raise NotImplementedError("only support `int` and `fp` data type")
 
 
-def construct_ct_scheme(layer):
+def construct_ct_scheme(layer, targets=None):
     from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme  # pylint: disable=E0401
 
     weights_args = QuantizationArgs(
@@ -87,7 +87,7 @@ def construct_ct_scheme(layer):
             strategy=_get_act_scheme_strategy(layer.act_group_size),
         )
     scheme = QuantizationScheme(
-        targets=[layer.__class__.__name__],
+        targets=targets or [layer.__class__.__name__],
         weights=weights_args,
         input_activations=activations_args,
     )
@@ -147,7 +147,10 @@ def pack_layer(name, model, device=None):
     # explicitly obtain the underlying device to prevent RuntimeError mismatched tensors
     weight_device = layer.weight.device
 
-    scheme = construct_ct_scheme(layer)
+    # Keep packed layers addressable by their actual module names. Using only
+    # the class name ("Linear") makes mixed-bit config groups overlap; the
+    # loader can then apply the wrong unpacking scheme to a packed weight.
+    scheme = construct_ct_scheme(layer, targets=[name])
     setattr(layer, "quantization_scheme", scheme)
     setattr(layer, "weight_scale", torch.nn.Parameter(layer.scale.to(weight_device)))
     if not isinstance(layer.zp, torch.Tensor):

--- a/auto_round/export/formats/backends/llm_compressor.py
+++ b/auto_round/export/formats/backends/llm_compressor.py
@@ -34,6 +34,8 @@ class LLMCompressorFormat(OutputFormat):
         "INT8",
         "INT8_W8A8",
         "FP8_BLOCK",
+        "W2A16",
+        "W2A16G64",
         "W4A16",
         "W8A16",
     ]
@@ -89,13 +91,13 @@ class LLMCompressorFormat(OutputFormat):
     @classmethod
     def check_scheme_args(cls: OutputFormat, scheme: QuantizationScheme) -> bool:
         error_logs = []
-        if scheme.bits not in [4, 8, 16]:
+        if scheme.bits not in [2, 4, 8, 16]:
             error_logs.append(f"bits={scheme.bits}")
         if not re.search("mxfp|fp|nvfp|int", scheme.data_type):
             error_logs.append(f"data_type={scheme.data_type}")
         if scheme.data_type == "fp" and scheme.bits != 8:
             error_logs.append(f"data_type={scheme.data_type}, bits={scheme.bits}")
-        if scheme.data_type == "int" and scheme.bits not in [4, 8]:
+        if scheme.data_type == "int" and scheme.bits not in [2, 4, 8]:
             error_logs.append(f"data_type={scheme.data_type}, bits={scheme.bits}")
         if scheme.super_bits:
             error_logs.append(f"super_bits={scheme.super_bits}")

--- a/auto_round/utils/model.py
+++ b/auto_round/utils/model.py
@@ -808,6 +808,23 @@ def mllm_load_model(
 def _attach_diffusion_pipeline_fn(pipe):
     """Attach a custom pipeline function for diffusion models that need special API calls."""
     pipe_class_name = type(pipe).__name__
+    if pipe_class_name == "MiniMaxH3ModularPipeline":
+
+        def _minimax_h3_pipeline_fn(
+            pipe, prompts, guidance_scale=7.0, num_inference_steps=50, generator=None, **kwargs
+        ):
+            # MiniMax-H3 is a guidance-distilled Modular Diffusers pipeline.  Its
+            # call contract uses ``prompt`` and has no guidance_scale argument.
+            del guidance_scale
+            return pipe(
+                prompt=prompts,
+                num_inference_steps=num_inference_steps,
+                generator=generator,
+                **kwargs,
+            )
+
+        pipe._autoround_pipeline_fn = _minimax_h3_pipeline_fn
+
     if pipe_class_name == "StableAudioPipeline":
 
         def _stable_audio_pipeline_fn(
@@ -963,6 +980,11 @@ def diffusion_load_model(
     init_mode = str(init_mode).strip().lower()
     if init_mode not in {"pretrained", "random"}:
         raise ValueError(f"Unsupported init_mode {init_mode!r} for diffusion models")
+    is_modular_diffusion = (
+        init_mode == "pretrained"
+        and isinstance(pretrained_model_name_or_path, str)
+        and os.path.exists(os.path.join(pretrained_model_name_or_path, "modular_model_index.json"))
+    )
     if init_mode == "random":
         check_diffusers_installed()
         if not isinstance(pretrained_model_name_or_path, str) or not os.path.isdir(pretrained_model_name_or_path):
@@ -995,7 +1017,36 @@ def diffusion_load_model(
         return pipe, pipe.model
 
     pipelines = LazyImport("diffusers.pipelines")
-    if init_mode == "pretrained" and isinstance(pretrained_model_name_or_path, str):
+    if is_modular_diffusion:
+        check_diffusers_installed()
+        from diffusers import ModularPipeline
+
+        pipe = ModularPipeline.from_pretrained(
+            pretrained_model_name_or_path,
+            workflow="t2va",
+            local_files_only=True,
+            trust_remote_code=trust_remote_code,
+        )
+        component_dtype = {
+            "bf16": torch.bfloat16,
+            "bfloat16": torch.bfloat16,
+            "fp16": torch.float16,
+            "float16": torch.float16,
+            "f16": torch.float16,
+            "fp32": torch.float32,
+            "float32": torch.float32,
+            "f32": torch.float32,
+        }.get(str(model_dtype).lower(), None)
+        # ``from_pretrained(workflow=...)`` already prunes the block graph to
+        # the selected workflow.  Passing the workflow again to
+        # ``load_components`` would try to prune the resulting sequential block
+        # a second time and fails in the current Modular Diffusers API.
+        load_kwargs = {"local_files_only": True}
+        if component_dtype is not None:
+            load_kwargs["dtype"] = component_dtype
+        pipe.load_components(**load_kwargs)
+        pipe_config = pipe.config
+    elif init_mode == "pretrained" and isinstance(pretrained_model_name_or_path, str):
         model_index = os.path.join(pretrained_model_name_or_path, "model_index.json")
         with open(model_index, "r", encoding="utf-8") as file:
             config = json.load(file)
@@ -1393,6 +1444,9 @@ def is_diffusion_model(model_or_path: Union[str, object], trust_remote_code: boo
         elif os.path.exists(os.path.join(model_or_path, "model_index.json")):
             check_diffusers_installed()
             index_file = os.path.join(model_or_path, "model_index.json")
+        elif os.path.exists(os.path.join(model_or_path, "modular_model_index.json")):
+            check_diffusers_installed()
+            index_file = os.path.join(model_or_path, "modular_model_index.json")
         return index_file is not None
     elif not isinstance(model_or_path, torch.nn.Module):
         check_diffusers_installed()

--- a/auto_round/utils/model.py
+++ b/auto_round/utils/model.py
@@ -15,6 +15,7 @@ import collections
 import inspect
 import json
 import os
+import shutil
 import re
 from collections import UserDict
 from pathlib import Path
@@ -824,6 +825,118 @@ def _attach_diffusion_pipeline_fn(pipe):
         pipe._autoround_pipeline_fn = _stable_audio_pipeline_fn
 
 
+def _copy_path(src: str, dst: str) -> None:
+    os.makedirs(os.path.dirname(dst), exist_ok=True)
+    if os.path.isdir(src):
+        shutil.copytree(src, dst, dirs_exist_ok=True)
+    elif os.path.isfile(src):
+        shutil.copy2(src, dst)
+
+
+class _SourceCopyComponentProxy:
+    def __init__(self, source_dir: str):
+        self.source_dir = source_dir
+
+    def save_pretrained(self, save_directory: str, **kwargs):
+        _copy_path(self.source_dir, save_directory)
+
+
+class _ConfigOnlyDiffusionPipeline:
+    def __init__(self, source_dir: str, model_index: dict, components: dict[str, object]):
+        self._autoround_source_dir = source_dir
+        self.config = UserDict(dict(model_index))
+        self.config.setdefault("_name_or_path", source_dir)
+        self.components = collections.OrderedDict()
+        for name, component in components.items():
+            self.components[name] = component
+            setattr(self, name, component)
+
+    @property
+    def dtype(self):
+        for component in self.components.values():
+            if isinstance(component, torch.nn.Module):
+                param = next(component.parameters(), None)
+                if param is not None:
+                    return param.dtype
+        return torch.float32
+
+    def to(self, *args, **kwargs):
+        for component in self.components.values():
+            if isinstance(component, torch.nn.Module):
+                component.to(*args, **kwargs)
+        return self
+
+    def load_config(self, *args, **kwargs):
+        return dict(self.config)
+
+    def save_config(self, save_directory: str):
+        os.makedirs(save_directory, exist_ok=True)
+        for name in os.listdir(self._autoround_source_dir):
+            if name in self.components or name == ".cache":
+                continue
+            _copy_path(os.path.join(self._autoround_source_dir, name), os.path.join(save_directory, name))
+        config_save_pretrained(self.config, "model_index.json", save_directory)
+
+
+def _instantiate_random_init_component(component_dir: str, source_lib: str, class_name: str, trust_remote_code: bool):
+    if source_lib == "diffusers":
+        import diffusers
+
+        cls = getattr(diffusers, class_name, None)
+        if cls is None or not hasattr(cls, "from_config"):
+            raise ValueError(f"Could not resolve diffusers class {class_name!r} for {component_dir}")
+        with open(os.path.join(component_dir, "config.json"), "r", encoding="utf-8") as f:
+            config = json.load(f)
+        return cls.from_config(config)
+
+    if source_lib == "transformers":
+        config = transformers.AutoConfig.from_pretrained(component_dir, trust_remote_code=trust_remote_code)
+        cls = getattr(transformers, class_name, None)
+        if cls is not None and hasattr(cls, "_from_config"):
+            return cls._from_config(config)
+        return transformers.AutoModel.from_config(config, trust_remote_code=trust_remote_code)
+
+    raise ValueError(f"Unsupported component source library {source_lib!r} for {component_dir}")
+
+
+def _build_random_init_diffusion_pipeline(model_dir: str, trust_remote_code: bool = True):
+    model_index_path = os.path.join(model_dir, "model_index.json")
+    if not os.path.exists(model_index_path):
+        raise FileNotFoundError(f"init_mode='random' requires model_index.json under {model_dir}")
+
+    with open(model_index_path, "r", encoding="utf-8") as f:
+        model_index = json.load(f)
+
+    components = collections.OrderedDict()
+    for name, value in model_index.items():
+        if name.startswith("_") or not isinstance(value, list) or len(value) < 2:
+            continue
+
+        component_dir = os.path.join(model_dir, name)
+        if not os.path.isdir(component_dir):
+            if name.startswith("transformer"):
+                raise FileNotFoundError(
+                    f"init_mode='random' requires a local {name}/ directory with config.json under {model_dir}"
+                )
+            continue
+
+        if name.startswith("transformer"):
+            config_path = os.path.join(component_dir, "config.json")
+            if not os.path.exists(config_path):
+                raise FileNotFoundError(f"init_mode='random' requires {config_path}")
+            components[name] = _instantiate_random_init_component(component_dir, value[0], value[1], trust_remote_code)
+        else:
+            components[name] = _SourceCopyComponentProxy(component_dir)
+
+    if "transformer" not in components:
+        raise ValueError(
+            "init_mode='random' currently requires a primary transformer/ component in model_index.json."
+        )
+
+    pipe = _ConfigOnlyDiffusionPipeline(model_dir, model_index, components)
+    return pipe, pipe.transformer
+
+
 def diffusion_load_model(
     pretrained_model_name_or_path: str,
     platform: str = "hf",
@@ -832,6 +945,7 @@ def diffusion_load_model(
     use_auto_mapping: bool = False,
     trust_remote_code: bool = True,
     model_dtype: str = None,
+    init_mode: str = "pretrained",
     **kwargs,
 ):
     from functools import partial
@@ -845,6 +959,20 @@ def diffusion_load_model(
         raise NotImplementedError(
             f"auto_round current only support hf as platform for diffusion model, but get {platform}"
         )
+
+    init_mode = str(init_mode).strip().lower()
+    if init_mode not in {"pretrained", "random"}:
+        raise ValueError(f"Unsupported init_mode {init_mode!r} for diffusion models")
+    if init_mode == "random":
+        check_diffusers_installed()
+        if not isinstance(pretrained_model_name_or_path, str) or not os.path.isdir(pretrained_model_name_or_path):
+            raise ValueError(
+                "init_mode='random' for diffusion models requires a local model directory path with model_index.json"
+            )
+        pipe, model = _build_random_init_diffusion_pipeline(pretrained_model_name_or_path, trust_remote_code)
+        pipe_config = pipe.load_config(pretrained_model_name_or_path)
+    else:
+        pipe_config = None
 
     device_str, use_auto_mapping = get_device_and_parallelism(device)
     torch_dtype = "auto"
@@ -867,7 +995,7 @@ def diffusion_load_model(
         return pipe, pipe.model
 
     pipelines = LazyImport("diffusers.pipelines")
-    if isinstance(pretrained_model_name_or_path, str):
+    if init_mode == "pretrained" and isinstance(pretrained_model_name_or_path, str):
         model_index = os.path.join(pretrained_model_name_or_path, "model_index.json")
         with open(model_index, "r", encoding="utf-8") as file:
             config = json.load(file)
@@ -886,11 +1014,11 @@ def diffusion_load_model(
         )
         pipe_config = pipe.load_config(pretrained_model_name_or_path)
 
-    elif isinstance(pretrained_model_name_or_path, pipelines.pipeline_utils.DiffusionPipeline):
+    elif init_mode == "pretrained" and isinstance(pretrained_model_name_or_path, pipelines.pipeline_utils.DiffusionPipeline):
         pipe = pretrained_model_name_or_path
         pipe_config = pipe.load_config(pipe.config["_name_or_path"])
 
-    else:
+    elif init_mode == "pretrained":
         raise ValueError(
             f"Only support str or DiffusionPipeline class for model, but get {type(pretrained_model_name_or_path)}"
         )
@@ -2517,6 +2645,8 @@ def is_model_free_route(
     has_static_attention_quantization = any(
         kwargs.get(key) is not None for key in ("static_kv_dtype", "static_attention_dtype")
     )
+    if str(kwargs.get("init_mode", "pretrained")).strip().lower() == "random":
+        return False
     if has_static_attention_quantization:
         return False
     if explicit:

--- a/auto_round/utils/model.py
+++ b/auto_round/utils/model.py
@@ -15,8 +15,8 @@ import collections
 import inspect
 import json
 import os
-import shutil
 import re
+import shutil
 from collections import UserDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
@@ -946,9 +946,7 @@ def _build_random_init_diffusion_pipeline(model_dir: str, trust_remote_code: boo
             components[name] = _SourceCopyComponentProxy(component_dir)
 
     if "transformer" not in components:
-        raise ValueError(
-            "init_mode='random' currently requires a primary transformer/ component in model_index.json."
-        )
+        raise ValueError("init_mode='random' currently requires a primary transformer/ component in model_index.json.")
 
     pipe = _ConfigOnlyDiffusionPipeline(model_dir, model_index, components)
     return pipe, pipe.transformer
@@ -1065,7 +1063,9 @@ def diffusion_load_model(
         )
         pipe_config = pipe.load_config(pretrained_model_name_or_path)
 
-    elif init_mode == "pretrained" and isinstance(pretrained_model_name_or_path, pipelines.pipeline_utils.DiffusionPipeline):
+    elif init_mode == "pretrained" and isinstance(
+        pretrained_model_name_or_path, pipelines.pipeline_utils.DiffusionPipeline
+    ):
         pipe = pretrained_model_name_or_path
         pipe_config = pipe.load_config(pipe.config["_name_or_path"])
 

--- a/test/test_cpu/core/test_entry_contract.py
+++ b/test/test_cpu/core/test_entry_contract.py
@@ -20,10 +20,17 @@ def test_split_entry_kwargs_partitions_owned_fields():
     processor = object()
 
     grouped = _split_entry_kwargs(
-        {"dataset": ["sample"], "scale_dtype": "fp32", "processor": processor, "model_free": False}
+        {
+            "dataset": ["sample"],
+            "scale_dtype": "fp32",
+            "processor": processor,
+            "model_free": False,
+            "init_mode": "random",
+        }
     )
 
     assert grouped["base"]["dataset"] == ["sample"]
+    assert grouped["base"]["init_mode"] == "random"
     assert grouped["compressor"]["scale_dtype"] == "fp32"
     assert grouped["mllm"]["processor"] is processor
     assert grouped["route"]["model_free"] is False

--- a/test/test_cpu/export/test_llmc_format.py
+++ b/test/test_cpu/export/test_llmc_format.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -75,6 +76,34 @@ class TestLLMC:
 
         f = safe_open(os.path.join(quantized_model_path, "model.safetensors"), framework="pt")
         assert len(f.get_tensor("model.decoder.layers.0.fc1.weight_scale").shape) == 2
+
+    def test_llmcompressor_mixed_woq_uses_layer_targets(self):
+        from auto_round.export.export_to_llmcompressor.export import construct_ct_scheme
+
+        w2_layer = SimpleNamespace(
+            bits=2,
+            data_type="int",
+            sym=True,
+            group_size=64,
+            act_bits=16,
+            act_data_type=None,
+        )
+        w4_layer = SimpleNamespace(
+            bits=4,
+            data_type="int",
+            sym=True,
+            group_size=128,
+            act_bits=16,
+            act_data_type=None,
+        )
+
+        w2_scheme = construct_ct_scheme(w2_layer, targets=["model.layers.0.self_attn.q_proj"])
+        w4_scheme = construct_ct_scheme(w4_layer, targets=["lm_head"])
+
+        assert w2_scheme.targets == ["model.layers.0.self_attn.q_proj"]
+        assert w4_scheme.targets == ["lm_head"]
+        assert w2_scheme.weights.num_bits == 2
+        assert w4_scheme.weights.num_bits == 4
 
     def test_autoround_llmcompressor_fp8(self, tmp_path):
         ## quantize the model

--- a/test/test_cpu/models/test_diffusion.py
+++ b/test/test_cpu/models/test_diffusion.py
@@ -1,11 +1,15 @@
 import os
 import shutil
+import sys
+import types
+from collections import UserDict
 
 import pytest
 import torch
 from packaging import version
 
 from auto_round import AutoRound
+from auto_round.utils import model as model_utils
 
 from ...helpers import get_model_path, transformers_version
 
@@ -53,6 +57,108 @@ def test_flux(setup_flux):
     # skip model saving since it takes much time
     autoround.quantize()
     shutil.rmtree(output_dir, ignore_errors=True)
+
+
+class _AttrConfig(UserDict):
+    def __getattr__(self, name):
+        try:
+            return self.data[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name, value):
+        if name in {"data", "save_pretrained"}:
+            super().__setattr__(name, value)
+        else:
+            self.data[name] = value
+
+
+class _FakeSaveableModel(torch.nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = _AttrConfig(config)
+        hidden_size = int(config.get("hidden_size", 8))
+        self.proj = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+
+    def save_pretrained(self, save_directory, **kwargs):
+        os.makedirs(save_directory, exist_ok=True)
+        torch.save(self.state_dict(), os.path.join(save_directory, "diffusion_pytorch_model.bin"))
+
+
+class FakeTransformer2DModel(_FakeSaveableModel):
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
+
+def _write_json(path, payload):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        import json
+
+        json.dump(payload, f)
+
+
+def _make_random_init_repo(tmp_path):
+    model_dir = tmp_path / "mini_max_dummy"
+    model_index = {
+        "_class_name": "MiniMaxDummyPipeline",
+        "_diffusers_version": "0.0.0",
+        "transformer": ["diffusers", "FakeTransformer2DModel"],
+        "processor": ["custom", "DummyProcessor"],
+        "tokenizer": ["custom", "DummyTokenizer"],
+    }
+    _write_json(model_dir / "model_index.json", model_index)
+    _write_json(model_dir / "transformer" / "config.json", {"hidden_size": 8, "torch_dtype": "float32"})
+    _write_json(model_dir / "processor" / "processor_config.json", {"type": "dummy"})
+    _write_json(model_dir / "tokenizer" / "tokenizer_config.json", {"type": "dummy"})
+    with open(model_dir / "README.md", "w", encoding="utf-8") as f:
+        f.write("dummy pipeline\n")
+    return model_dir
+
+
+def test_diffusion_random_init_loads_transformer_and_preserves_metadata(tmp_path, monkeypatch):
+    model_dir = _make_random_init_repo(tmp_path)
+    fake_diffusers = types.SimpleNamespace(FakeTransformer2DModel=FakeTransformer2DModel)
+
+    monkeypatch.setattr(model_utils, "check_diffusers_installed", lambda: None)
+    monkeypatch.setattr(model_utils, "_check_accelerate_version", lambda: None)
+    monkeypatch.setitem(sys.modules, "diffusers", fake_diffusers)
+
+    pipe, model = model_utils.diffusion_load_model(str(model_dir), init_mode="random", device="cpu")
+
+    assert model is pipe.transformer
+    assert isinstance(model, FakeTransformer2DModel)
+
+    output_dir = tmp_path / "saved"
+    model.save_pretrained(output_dir / "transformer")
+    pipe.processor.save_pretrained(output_dir / "processor")
+    pipe.tokenizer.save_pretrained(output_dir / "tokenizer")
+    pipe.save_config(output_dir)
+
+    assert (output_dir / "transformer" / "config.json").exists()
+    assert (output_dir / "processor" / "processor_config.json").exists()
+    assert (output_dir / "tokenizer" / "tokenizer_config.json").exists()
+    assert (output_dir / "README.md").exists()
+    assert (output_dir / "model_index.json").exists()
+
+
+def test_diffusion_random_init_requires_transformer_dir(tmp_path, monkeypatch):
+    model_dir = tmp_path / "missing_transformer"
+    _write_json(
+        model_dir / "model_index.json",
+        {
+            "_class_name": "MiniMaxDummyPipeline",
+            "transformer": ["diffusers", "FakeTransformer2DModel"],
+        },
+    )
+
+    monkeypatch.setattr(model_utils, "check_diffusers_installed", lambda: None)
+    monkeypatch.setattr(model_utils, "_check_accelerate_version", lambda: None)
+    monkeypatch.setitem(sys.modules, "diffusers", types.SimpleNamespace(FakeTransformer2DModel=FakeTransformer2DModel))
+
+    with pytest.raises(FileNotFoundError, match="transformer/ directory"):
+        model_utils.diffusion_load_model(str(model_dir), init_mode="random", device="cpu")
 
 
 # def test_flux_calib(setup_flux):

--- a/test/test_cpu/quantization/test_model_free.py
+++ b/test/test_cpu/quantization/test_model_free.py
@@ -120,6 +120,10 @@ def test_model_free_route_rejects_static_attention_quantization(dtype_key, expli
     assert not is_model_free_route("model", "W4A16", 0, True, kwargs)
 
 
+def test_model_free_route_rejects_random_init():
+    assert not is_model_free_route("model", "W4A16", 0, True, {"init_mode": "random"})
+
+
 _LLAMA_CFG = {"architectures": ["LlamaForCausalLM"], "model_type": "llama"}
 _DEFAULT_SCHEME = {"bits": 4, "group_size": 128, "sym": True, "data_type": "int"}
 

--- a/tools/minimax_h3_mxfp8_packed_smoke.py
+++ b/tools/minimax_h3_mxfp8_packed_smoke.py
@@ -31,13 +31,11 @@ try:
 except RuntimeError:
     pass
 
+import minimax_h3_diffusers_smoke as smoke
 from diffusers import ComponentsManager, ModularPipeline
 
 from auto_round.experimental.qmodules import MXFP4QuantLinear, MXFP8QuantLinear
 from auto_round.schemes import preset_name_to_scheme
-
-import minimax_h3_diffusers_smoke as smoke
-
 
 ROOT = Path(__file__).resolve().parents[1]
 MODEL = Path(os.environ.get("MINIMAX_H3_MODEL", ROOT / "artifacts/minimax_h3_real_pretrained"))
@@ -138,11 +136,7 @@ def main() -> None:
     )
     pipe.load_components(local_files_only=True, dtype=torch.bfloat16)
     index = json.loads(index_path.read_text())
-    layer_names = sorted(
-        key[: -len(".weight_scale")]
-        for key in index["weight_map"]
-        if key.endswith(".weight_scale")
-    )
+    layer_names = sorted(key[: -len(".weight_scale")] for key in index["weight_map"] if key.endswith(".weight_scale"))
     modules = _replace_linears(pipe.transformer, layer_names)
     _load_packed_weights(pipe.transformer, modules)
     print(f"Installed {len(modules)} packed {SCHEME} linear modules", flush=True)

--- a/tools/minimax_h3_mxfp8_packed_smoke.py
+++ b/tools/minimax_h3_mxfp8_packed_smoke.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Smoke-test MXFP8 packed weights through AutoRound's quantized linear module."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import imageio.v2 as imageio
+import numpy as np
+import torch
+from safetensors import safe_open
+
+# Register the local torchvision compatibility op before importing Diffusers.
+try:
+    _TORCHVISION_LIB = torch.library.Library("torchvision", "DEF")
+    _TORCHVISION_LIB.define("nms(Tensor boxes, Tensor scores, float iou_threshold) -> Tensor")
+except RuntimeError:
+    pass
+
+from diffusers import ComponentsManager, ModularPipeline
+
+from auto_round.experimental.qmodules import MXFP4QuantLinear, MXFP8QuantLinear
+from auto_round.schemes import preset_name_to_scheme
+
+import minimax_h3_diffusers_smoke as smoke
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODEL = Path(os.environ.get("MINIMAX_H3_MODEL", ROOT / "artifacts/minimax_h3_real_pretrained"))
+SCHEME = os.environ.get("MINIMAX_H3_MXFP_SCHEME", "MXFP8").upper()
+if SCHEME not in {"MXFP4", "MXFP8"}:
+    raise ValueError(f"Unsupported MXFP smoke scheme: {SCHEME}")
+PACKED = Path(
+    os.environ.get(
+        "MINIMAX_H3_MXFP_PACKED",
+        ROOT / f"artifacts/minimax_h3_{SCHEME.lower()}_packed_pretrained",
+    )
+)
+OUTPUT = Path(
+    os.environ.get("MINIMAX_H3_MXFP_SMOKE_OUTPUT", ROOT / f"artifacts/minimax_h3_{SCHEME.lower()}_packed_smoke")
+)
+STEPS = int(os.environ.get("MINIMAX_H3_SMOKE_STEPS", "50"))
+QUANT_CLASS = MXFP4QuantLinear if SCHEME == "MXFP4" else MXFP8QuantLinear
+WEIGHT_SUFFIX = ".weight_packed" if SCHEME == "MXFP4" else ".weight"
+
+
+def _get_module(root: torch.nn.Module, name: str) -> torch.nn.Module:
+    module = root
+    for part in name.split("."):
+        module = getattr(module, part)
+    return module
+
+
+def _replace_linears(transformer: torch.nn.Module, names: list[str]) -> dict[str, torch.nn.Module]:
+    config = preset_name_to_scheme("MXFP8")
+    replaced = {}
+    for name in names:
+        if "." in name:
+            parent_name, child_name = name.rsplit(".", 1)
+            parent = _get_module(transformer, parent_name)
+        else:
+            parent = transformer
+            child_name = name
+        original = getattr(parent, child_name)
+        if not isinstance(original, torch.nn.Linear):
+            raise TypeError(f"Expected Linear at transformer.{name}, got {type(original).__name__}")
+        quantized = QUANT_CLASS.from_original(config, original)
+        setattr(parent, child_name, quantized)
+        replaced[name] = quantized
+    return replaced
+
+
+def _load_packed_weights(transformer: torch.nn.Module, modules: dict[str, torch.nn.Module]) -> None:
+    index_path = PACKED / "transformer/model.safetensors.index.json"
+    index = json.loads(index_path.read_text())
+    shard_names = sorted(set(index["weight_map"].values()))
+    for shard_name in shard_names:
+        shard_path = PACKED / "transformer" / shard_name
+        with safe_open(str(shard_path), framework="pt", device="cpu") as shard:
+            for key in shard.keys():
+                if not key.endswith(".weight_scale"):
+                    continue
+                layer_name = key[: -len(".weight_scale")]
+                if layer_name not in modules:
+                    raise KeyError(f"Packed MXFP8 layer is not present in the transformer: {layer_name}")
+                module = modules[layer_name]
+                packed_weight = shard.get_tensor(f"{layer_name}{WEIGHT_SUFFIX}")
+                if SCHEME == "MXFP4":
+                    module.weight_packed.copy_(packed_weight)
+                else:
+                    module.weight.copy_(packed_weight)
+                module.weight_scale.copy_(shard.get_tensor(key).view(torch.uint8))
+        print(f"Loaded packed {SCHEME} shard {shard_name}", flush=True)
+
+
+def _save_video(video: np.ndarray) -> str:
+    frames = video[0] if video.ndim == 5 else video
+    if frames.shape[1] in (1, 3, 4):
+        frames = np.moveaxis(frames, 1, -1)
+    frames = (np.clip(frames[..., :3], 0.0, 1.0) * 255).round().astype(np.uint8)
+    path = OUTPUT / f"minimax_h3_{SCHEME.lower()}_50steps.mp4"
+    imageio.mimwrite(str(path), frames, fps=24, codec="libx264", quality=8, macro_block_size=None)
+    return str(path)
+
+
+def main() -> None:
+    if os.environ.get("CUDA_VISIBLE_DEVICES") != "7":
+        raise RuntimeError("Set CUDA_VISIBLE_DEVICES=7 so the job uses the required physical GPU.")
+    if not torch.cuda.is_available() or torch.cuda.device_count() != 1:
+        raise RuntimeError(
+            "GPU 7 is not available under CUDA_VISIBLE_DEVICES=7: "
+            f"is_available={torch.cuda.is_available()}, device_count={torch.cuda.device_count()}"
+        )
+    index_path = PACKED / "transformer/model.safetensors.index.json"
+    if not index_path.is_file():
+        raise FileNotFoundError(f"Expected packed MXFP8 index: {index_path}")
+
+    components_manager = ComponentsManager()
+    pipe = ModularPipeline.from_pretrained(
+        str(MODEL),
+        workflow="t2va",
+        local_files_only=True,
+        components_manager=components_manager,
+    )
+    pipe.load_components(local_files_only=True, dtype=torch.bfloat16)
+    index = json.loads(index_path.read_text())
+    layer_names = sorted(
+        key[: -len(".weight_scale")]
+        for key in index["weight_map"]
+        if key.endswith(".weight_scale")
+    )
+    modules = _replace_linears(pipe.transformer, layer_names)
+    _load_packed_weights(pipe.transformer, modules)
+    print(f"Installed {len(modules)} packed {SCHEME} linear modules", flush=True)
+    components_manager.enable_auto_cpu_offload(device="cuda:0", memory_reserve_margin="8GB")
+
+    smoke.OUTPUT = OUTPUT
+    smoke.PROMPT_TSV = ROOT / "tools/minimax_h3_fp8_prompt.tsv"
+    OUTPUT.mkdir(parents=True, exist_ok=True)
+    generator = torch.Generator(device="cuda").manual_seed(0)
+    result = pipe(
+        prompt=smoke._load_prompt(),
+        height=384,
+        width=672,
+        num_frames=124,
+        num_inference_steps=STEPS,
+        generator=generator,
+        output_type="pt",
+    )
+    video = smoke._to_numpy(result.get("videos"))
+    audio = smoke._to_numpy(result.get("audios", result.get("audio")))
+    if video is None or not torch.isfinite(torch.from_numpy(video)).all():
+        raise RuntimeError("MXFP8 packed smoke produced missing or non-finite video output")
+    frame_paths = smoke._save_video_frames(video)
+    if audio is not None:
+        if not torch.isfinite(torch.from_numpy(audio)).all():
+            raise RuntimeError("MXFP8 packed smoke produced non-finite audio output")
+        np.save(OUTPUT / "audio.npy", audio)
+    video_path = _save_video(video)
+    metadata = {
+        "model": str(MODEL),
+        "packed_model": str(PACKED),
+        "scheme": SCHEME,
+        "steps": STEPS,
+        "height": 384,
+        "width": 672,
+        "num_frames": 124,
+        "quantized_linear_modules": len(modules),
+        "video_shape": list(video.shape),
+        "video_min": float(video.min()),
+        "video_max": float(video.max()),
+        "video_mean": float(video.mean()),
+        "audio_shape": None if audio is None else list(audio.shape),
+        "video_path": video_path,
+        "frame_paths": frame_paths,
+    }
+    (OUTPUT / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n")
+    print(json.dumps(metadata, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/minimax_h3_native_vae_layout.py
+++ b/tools/minimax_h3_native_vae_layout.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Build the native MiniMax-H3 FL2VA layout around an AutoRound export."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+
+_SHARED_COMPONENTS = ("transformer", "tokenizer", "processor", "text_encoder", "scheduler", "audio_scheduler")
+
+
+def _resolve_native_component(official_fl2va: Path, name: str) -> Path:
+    candidates = [official_fl2va / name]
+    if name == "video_vae":
+        candidates.append(official_fl2va / "vae")
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    expected = " or ".join(str(candidate) for candidate in candidates)
+    raise FileNotFoundError(f"Native MiniMax-H3 component {name!r} not found at {expected}")
+
+
+def repack_native_vae(checkpoint: str | Path, official_fl2va: str | Path) -> Path:
+    """Add a self-contained native-VAE ``FL2VA`` partition to *checkpoint*.
+
+    AutoRound exports the transformer and shared components in a modular
+    Diffusers repository.  The VAE is not quantized, so the exported Diffusers
+    VAE is replaced only in the Omni-facing partition by the original release
+    remote-code components.  Shared non-VAE components remain linked to the
+    AutoRound export, avoiding a second copy of the large transformer.
+    """
+
+    checkpoint = Path(checkpoint).resolve()
+    official_fl2va = Path(official_fl2va).resolve()
+    # Accept either the release's model root or its FL2VA subdirectory.  The
+    # latter is convenient for a downloaded task-specific snapshot, while the
+    # former is what users commonly have after downloading the full model.
+    if (official_fl2va / "FL2VA").is_dir():
+        official_fl2va = official_fl2va / "FL2VA"
+    if not checkpoint.is_dir():
+        raise FileNotFoundError(f"AutoRound checkpoint directory not found: {checkpoint}")
+    if not official_fl2va.is_dir():
+        raise FileNotFoundError(f"Official MiniMax-H3 FL2VA directory not found: {official_fl2va}")
+
+    partition = checkpoint / "FL2VA"
+    if partition.exists():
+        raise FileExistsError(f"Refusing to overwrite existing Omni partition: {partition}")
+
+    for name in _SHARED_COMPONENTS:
+        source = checkpoint / name
+        if not source.exists():
+            raise FileNotFoundError(f"AutoRound export is missing shared component {source}")
+
+    partition.mkdir()
+    manifest = {
+        "_class_name": "MiniMaxH3Pipeline",
+        "_minimax_h3": {
+            "partition": "fl2va",
+            "tasks": ["t2va", "fl2va"],
+            "sigma_shift_scales": {"video": 12.0, "audio": 3.0},
+        },
+    }
+    (partition / "model_index.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    for name in _SHARED_COMPONENTS:
+        (partition / name).symlink_to(Path("..") / name)
+    for name in ("video_vae", "audio_vae"):
+        shutil.copytree(_resolve_native_component(official_fl2va, name), partition / name)
+    return partition

--- a/tools/minimax_h3_native_vae_layout.py
+++ b/tools/minimax_h3_native_vae_layout.py
@@ -19,7 +19,6 @@ import json
 import shutil
 from pathlib import Path
 
-
 _SHARED_COMPONENTS = ("transformer", "tokenizer", "processor", "text_encoder", "scheduler", "audio_scheduler")
 
 

--- a/tools/minimax_h3_repack_native_vae.py
+++ b/tools/minimax_h3_repack_native_vae.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Repack an existing AutoRound MiniMax-H3 export for native Omni loading."""
+
+from __future__ import annotations
+
+import argparse
+
+from minimax_h3_native_vae_layout import repack_native_vae
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", required=True, help="Existing AutoRound export to update in place")
+    parser.add_argument(
+        "--official-fl2va",
+        required=True,
+        help="Original MiniMax-H3 model root or its FL2VA release directory",
+    )
+    args = parser.parse_args()
+    partition = repack_native_vae(args.checkpoint, args.official_fl2va)
+    print(f"Created native Omni partition at {partition}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/minimax_h3_w4a16_pretrained.py
+++ b/tools/minimax_h3_w4a16_pretrained.py
@@ -26,17 +26,14 @@ try:
 except RuntimeError:
     pass
 
-from auto_round import AutoRound
-
 from minimax_h3_native_vae_layout import repack_native_vae
 
+from auto_round import AutoRound
 
 ROOT = Path(__file__).resolve().parents[1]
 MODEL = Path(os.environ.get("MINIMAX_H3_MODEL", ROOT / "artifacts/minimax_h3_real_pretrained"))
 PROMPT_TSV = Path(os.environ.get("MINIMAX_H3_PROMPT_TSV", ROOT / "tools/minimax_h3_fp8_prompt.tsv"))
-OUTPUT = Path(
-    os.environ.get("MINIMAX_H3_W4A16_OUTPUT", ROOT / "artifacts/minimax_h3_w4a16_packed_pretrained")
-)
+OUTPUT = Path(os.environ.get("MINIMAX_H3_W4A16_OUTPUT", ROOT / "artifacts/minimax_h3_w4a16_packed_pretrained"))
 OFFICIAL_FL2VA = os.environ.get("MINIMAX_H3_OFFICIAL_FL2VA")
 
 

--- a/tools/minimax_h3_w4a16_pretrained.py
+++ b/tools/minimax_h3_w4a16_pretrained.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Export MiniMax-H3 weights to packed W4A16 with a native Omni FL2VA partition."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import torch
+
+try:
+    _TORCHVISION_LIB = torch.library.Library("torchvision", "DEF")
+    _TORCHVISION_LIB.define("nms(Tensor boxes, Tensor scores, float iou_threshold) -> Tensor")
+except RuntimeError:
+    pass
+
+from auto_round import AutoRound
+
+from minimax_h3_native_vae_layout import repack_native_vae
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODEL = Path(os.environ.get("MINIMAX_H3_MODEL", ROOT / "artifacts/minimax_h3_real_pretrained"))
+PROMPT_TSV = Path(os.environ.get("MINIMAX_H3_PROMPT_TSV", ROOT / "tools/minimax_h3_fp8_prompt.tsv"))
+OUTPUT = Path(
+    os.environ.get("MINIMAX_H3_W4A16_OUTPUT", ROOT / "artifacts/minimax_h3_w4a16_packed_pretrained")
+)
+OFFICIAL_FL2VA = os.environ.get("MINIMAX_H3_OFFICIAL_FL2VA")
+
+
+def main() -> None:
+    requested_gpu = os.environ.get("MINIMAX_H3_GPU", "7")
+    if os.environ.get("CUDA_VISIBLE_DEVICES") != requested_gpu:
+        raise RuntimeError(f"Set CUDA_VISIBLE_DEVICES={requested_gpu} for this job.")
+    if not torch.cuda.is_available() or torch.cuda.device_count() != 1:
+        raise RuntimeError(
+            f"GPU {requested_gpu} is not available under CUDA_VISIBLE_DEVICES={requested_gpu}: "
+            f"is_available={torch.cuda.is_available()}, device_count={torch.cuda.device_count()}"
+        )
+    if not (MODEL / "modular_model_index.json").is_file():
+        raise FileNotFoundError(f"Expected converted pretrained Modular Diffusers repo: {MODEL}")
+    if not PROMPT_TSV.is_file():
+        raise FileNotFoundError(f"Expected calibration prompt TSV: {PROMPT_TSV}")
+    if not OFFICIAL_FL2VA or not Path(OFFICIAL_FL2VA).is_dir():
+        raise FileNotFoundError(
+            "Set MINIMAX_H3_OFFICIAL_FL2VA to the original release FL2VA directory so the exported "
+            "checkpoint keeps Omni's native VAE contract."
+        )
+
+    autoround = AutoRound(
+        str(MODEL),
+        scheme="W4A16",
+        dataset=str(PROMPT_TSV),
+        nsamples=1,
+        batch_size=1,
+        iters=0,
+        device_map=0,
+        model_dtype="bf16",
+        num_inference_steps=50,
+        low_gpu_mem_usage=True,
+        enable_torch_compile=False,
+        disable_opt_rtn=True,
+    )
+    autoround.quantize_and_save(str(OUTPUT), format="auto_round:auto_gptq", inplace=True)
+    partition = repack_native_vae(OUTPUT, OFFICIAL_FL2VA)
+    print(f"Wrote packed W4A16 checkpoint to {OUTPUT}; Omni partition: {partition}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- preserve module-specific targets when exporting packed weight-only layers
- enable W2A16 and W2A16G64 for the LLM-Compressor format
- add a regression test for mixed W2/W4 metadata

## Root cause

Mixed W2/W4 exports previously assigned both schemes to `targets: ["Linear"]`. On reload, compressed_tensors could apply the W4 unpacking scheme to W2-packed weights, causing projection shape mismatches.

## Validation

- focused regression test passed
- Qwen3-8B W2A16G64 + W4A16 export completed
- exported model reloaded and ran a forward pass successfully
- q_proj restored as 2-bit and lm_head as 4-bit

Target branch is `yi/random-init-diffusion-handoff` because the feature branch was the source of this fix; this keeps unrelated changes out of the PR.
