### PR TITLE
fix: preserve llm compressor layer targets

### DIFF
--- a/auto_round/export/export_to_llmcompressor/export.py
+++ b/auto_round/export/export_to_llmcompressor/export.py
@@ -62,7 +62,7 @@ def _get_scheme_type(data_type):
     raise NotImplementedError("only support `int` and `fp` data type")
 
 
-def construct_ct_scheme(layer):
+def construct_ct_scheme(layer, targets=None):
     from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme  # pylint: disable=E0401
 
     weights_args = QuantizationArgs(
@@ -87,7 +87,7 @@ def construct_ct_scheme(layer):
             strategy=_get_act_scheme_strategy(layer.act_group_size),
         )
     scheme = QuantizationScheme(
-        targets=[layer.__class__.__name__],
+        targets=targets or [layer.__class__.__name__],
         weights=weights_args,
         input_activations=activations_args,
     )
@@ -147,7 +147,10 @@ def pack_layer(name, model, device=None):
     # explicitly obtain the underlying device to prevent RuntimeError mismatched tensors
     weight_device = layer.weight.device
 
-    scheme = construct_ct_scheme(layer)
+    # Keep packed layers addressable by their actual module names. Using only
+    # the class name ("Linear") makes mixed-bit config groups overlap; the
+    # loader can then apply the wrong unpacking scheme to a packed weight.
+    scheme = construct_ct_scheme(layer, targets=[name])
     setattr(layer, "quantization_scheme", scheme)
     setattr(layer, "weight_scale", torch.nn.Parameter(layer.scale.to(weight_device)))
     if not isinstance(layer.zp, torch.Tensor):

--- a/test/unit/test_cpu/export/test_llmc_format.py
+++ b/test/unit/test_cpu/export/test_llmc_format.py
@@ -1,9 +1,8 @@
 import json
 import os
 import shutil
-from types import SimpleNamespace
-
 from test.helpers import forbid_threaded_packing, get_model_path, opt_name_or_path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -243,7 +242,9 @@ class TestLLMC:
         config_groups = quantization_config["config_groups"]
         # Packed layers are represented by their concrete module paths.
         for group_targets in (g["targets"] for g in config_groups.values()):
-            assert all("." in target for target in group_targets), f"Unexpected targets in config_groups: {group_targets}"
+            assert all(
+                "." in target for target in group_targets
+            ), f"Unexpected targets in config_groups: {group_targets}"
 
         assert quantization_config["kv_cache_scheme"] is not None
         assert getattr(compressed_model.model.decoder.layers[0].self_attn, "q_scale", None) is not None

--- a/test/unit/test_cpu/export/test_llmc_format.py
+++ b/test/unit/test_cpu/export/test_llmc_format.py
@@ -1,6 +1,8 @@
 import json
 import os
 import shutil
+from types import SimpleNamespace
+
 from test.helpers import forbid_threaded_packing, get_model_path, opt_name_or_path
 
 import pytest
@@ -76,6 +78,34 @@ class TestLLMC:
 
         f = safe_open(os.path.join(quantized_model_path, "model.safetensors"), framework="pt")
         assert len(f.get_tensor("model.decoder.layers.0.fc1.weight_scale").shape) == 2
+
+    def test_llmcompressor_mixed_woq_uses_layer_targets(self):
+        from auto_round.export.export_to_llmcompressor.export import construct_ct_scheme
+
+        w2_layer = SimpleNamespace(
+            bits=2,
+            data_type="int",
+            sym=True,
+            group_size=64,
+            act_bits=16,
+            act_data_type=None,
+        )
+        w4_layer = SimpleNamespace(
+            bits=4,
+            data_type="int",
+            sym=True,
+            group_size=128,
+            act_bits=16,
+            act_data_type=None,
+        )
+
+        w2_scheme = construct_ct_scheme(w2_layer, targets=["model.layers.0.self_attn.q_proj"])
+        w4_scheme = construct_ct_scheme(w4_layer, targets=["lm_head"])
+
+        assert w2_scheme.targets == ["model.layers.0.self_attn.q_proj"]
+        assert w4_scheme.targets == ["lm_head"]
+        assert w2_scheme.weights.num_bits == 2
+        assert w4_scheme.weights.num_bits == 4
 
     def test_autoround_llmcompressor_fp8(self, tmp_path):
         ## quantize the model
@@ -211,9 +241,9 @@ class TestLLMC:
             quantized_model_path, trust_remote_code=True
         ).quantization_config
         config_groups = quantization_config["config_groups"]
-        # Only Linear layers should be in config_groups.
+        # Packed layers are represented by their concrete module paths.
         for group_targets in (g["targets"] for g in config_groups.values()):
-            assert "Linear" in group_targets, f"Unexpected non-Linear targets in config_groups: {group_targets}"
+            assert all("." in target for target in group_targets), f"Unexpected targets in config_groups: {group_targets}"
 
         assert quantization_config["kv_cache_scheme"] is not None
         assert getattr(compressed_model.model.decoder.layers[0].self_attn, "q_scale", None) is not None


### PR DESCRIPTION

https://github.com/intel/auto-round/issues/2188

## Description

Please briefly describe your main changes, the motivation.

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
