### PR TITLE
Increase memory limits for the build process in the CI pipeline

### DIFF
--- a/.azure-pipelines/template/lib-build-template.yml
+++ b/.azure-pipelines/template/lib-build-template.yml
@@ -91,6 +91,8 @@ stages:
                     -e HOME=/tmp \
                     --cpuset-cpus="${NUMA_CPUSET:-0-15}" \
                     --cpuset-mems="${NUMA_NODE:-0}" \
+                    --memory="128g" \
+                    --memory-swap="128g" \
                     -v $(Build.SourcesDirectory):/auto-round \
                     -v /opt/intel/oneapi:/opt/intel/oneapi \
                     -w /auto-round/auto_round_extension/ark \


### PR DESCRIPTION
## Description

This pull request makes a small update to the `.azure-pipelines/template/lib-build-template.yml` pipeline configuration. The change sets explicit memory and swap limits for the Docker container used during the build process.

* Pipeline resource allocation:
  * Added `--memory="128g"` and `--memory-swap="128g"` options to the Docker run command to limit container memory usage and swap, improving resource management during builds.

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

