### PR TITLE
fix: remove stale quantizer access in dual-transformer diffusion

### DIFF
--- a/auto_round/compressors/diffusion_mixin.py
+++ b/auto_round/compressors/diffusion_mixin.py
@@ -447,8 +447,8 @@ class DiffusionMixin:
             self.layer_config = {}
 
             # Get new block names for caching
-            if bool(self.quantizer.quant_block_list):
-                all_blocks = self.quantizer.quant_block_list
+            if bool(self.quant_block_list):
+                all_blocks = self.quant_block_list
             else:
                 all_blocks = get_block_names(self.model_context.model)
             if len(all_blocks) == 0:
@@ -486,7 +486,7 @@ class DiffusionMixin:
         self.compress_context.is_immediate_saving = orig_immediate_saving
         self.num_inference_steps = orig_steps
 
-        return self.model_context.model, self.quantizer.layer_config
+        return self.model_context.model, self.layer_config
 
     def save_quantized(
         self,

--- a/test/unit/test_cpu/compressors/test_diffusion_mixin.py
+++ b/test/unit/test_cpu/compressors/test_diffusion_mixin.py
@@ -37,6 +37,9 @@ class TestDiffusionMixinProperties:
         comp = MockCompressor()
         assert comp._get_calibrator_kind() == "diffusion"
 
+    def test_quantize_does_not_use_removed_quantizer_attribute(self):
+        assert "self.quantizer" not in inspect.getsource(DiffusionMixin.quantize)
+
     def test_pipeline_call_kwargs_extracted_from_kwargs(self):
         class MockCompressor(DiffusionMixin):
             def __init__(self):


### PR DESCRIPTION
## Description

the command and issue are occurred when quantized wan2.2 to nvfp4 datatype.
```
CUDA_VISIBLE_DEVICES=1 auto-round   --model /data3/changwa1/Wan2.2-T2V-A14B-Diffusers   --scheme NVFP4   --format llm_compressor   --device_map 0     --batch_size 1   --nsamples 64   --seqlen 2048   --iters 200   --num_inference_step 25 --low_gpu_mem_usage   --output_dir /mnt/disk3/changwa1/Wan2.2-T2V-A14B-Diffusers-NVFP4 --model-type bf16
```

```
2026-08-25 17:33:45 INFO device.py L1448: 'peak_ram': 564.85GB, 'peak_vram': 72.64GB
2026-08-25 17:33:45 INFO orchestrator.py L794: quantization tuning time 47823.08122754097
2026-08-25 17:33:45 INFO orchestrator.py L813: Summary: quantized 1/7 in the model, unquantized layers: condition_embedder.text_embedder.linear_1, condition_embedder.text_embedder.linear_2, condition_embedder.time_embedder.linear_1, condition_embedder.time_embedder.linear_2, condition_embedder.time_proj, proj_out
2026-08-25 17:33:45 INFO diffusion_mixin.py L445: Quantizing transformer_2
2026-08-25 17:33:47 INFO composer.py L208: Block-forward torch.compile is disabled because at least one quantized layer uses NVFP4.
Traceback (most recent call last):
  File "/data3/changwa1/.venv/bin/auto-round", line 10, in <module>
    sys.exit(run())
             ~~~^^
  File "/data3/changwa1/auto-round/auto_round/cli/main.py", line 507, in run
    start(argv=command_argv)
    ~~~~~^^^^^^^^^^^^^^^^^^^
  File "/data3/changwa1/auto-round/auto_round/cli/main.py", line 240, in start
    tune(args)
    ~~~~^^^^^^
  File "/data3/changwa1/auto-round/auto_round/cli/main.py", line 404, in tune
    model, folders = autoround.quantize_and_save(args.output_dir, format=args.format)  # pylint: disable=no-member
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data3/changwa1/auto-round/auto_round/compressors/base.py", line 2004, in quantize_and_save
    self.quantize()
    ~~~~~~~~~~~~~^^
  File "/data3/changwa1/auto-round/auto_round/compressors/diffusion_mixin.py", line 464, in quantize
    if bool(self.quantizer.quant_block_list):
            ^^^^^^^^^^^^^^
  File "/data3/changwa1/auto-round/auto_round/compressors/base.py", line 1630, in __getattr__
    raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
AttributeError: 'DiffusionCompressionOrchestrator' object has no attribute 'quantizer'. Did you mean: 'quantize'?

```

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes the dual-transformer crash. Tracks memory and tuning cost in #2235.

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->