### PR TITLE
fix: remove stale quantizer access in dual-transformer diffusion

### DIFF
--- a/auto_round/compressors/diffusion_mixin.py
+++ b/auto_round/compressors/diffusion_mixin.py
@@ -459,8 +459,8 @@ class DiffusionMixin:
             self.layer_config = {}
 
             # Get new block names for caching
-            if bool(self.quantizer.quant_block_list):
-                all_blocks = self.quantizer.quant_block_list
+            if bool(self.quant_block_list):
+                all_blocks = self.quant_block_list
             else:
                 all_blocks = get_block_names(self.model_context.model)
             if len(all_blocks) == 0:
@@ -498,7 +498,7 @@ class DiffusionMixin:
         self.compress_context.is_immediate_saving = orig_immediate_saving
         self.num_inference_steps = orig_steps
 
-        return self.model_context.model, self.quantizer.layer_config
+        return self.model_context.model, self.layer_config
 
     def save_quantized(
         self,

--- a/test/unit/common/compressors/test_diffusion_mixin.py
+++ b/test/unit/common/compressors/test_diffusion_mixin.py
@@ -37,6 +37,9 @@ class TestDiffusionMixinProperties:
         comp = MockCompressor()
         assert comp._get_calibrator_kind() == "diffusion"
 
+    def test_quantize_does_not_use_removed_quantizer_attribute(self):
+        assert "self.quantizer" not in inspect.getsource(DiffusionMixin.quantize)
+
     def test_pipeline_call_kwargs_extracted_from_kwargs(self):
         class MockCompressor(DiffusionMixin):
             def __init__(self):


### PR DESCRIPTION
## Summary

- Use orchestrator-owned `quant_block_list` and `layer_config` in the dual-transformer diffusion path.
- Avoid the missing `self.quantizer` crash when quantizing `transformer_2`.
- Add a regression test for stale `self.quantizer` access.

This forwards the fix from #2230, which was merged into `v0.15.0rc`, to `main`.

## Validation

- 9 focused tests passed.
- All pre-commit hooks passed.

Related: #2230