### PR TITLE
test: skip FP8 tests with transformers 5.16.x

### DIFF
--- a/test/unit/test_cuda/models/test_fp8_model.py
+++ b/test/unit/test_cuda/models/test_fp8_model.py
@@ -19,6 +19,10 @@ from auto_round.utils.weight_handler import (
 DEVICE_CAPABILITY = torch.cuda.get_device_capability()
 
 
+@pytest.mark.skipif(
+    version.parse("5.16.0") <= transformers_version < version.parse("5.17.0"),
+    reason="fails with transformers 5.16.x",
+)
 class TestAutoRound:
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Description

Skip the FP8 model test class with Transformers 5.16.x due to an upstream FP8 TP regression. The fix is included in 5.16.1.

The issue has been fixed and merged upstream in https://github.com/huggingface/transformers/pull/48343, so Transformers 5.17.0 and later are not skipped.