### PR TITLE
test: skip HPU FP8 test with transformers 5.16.x

### DIFF
--- a/test/unit/test_hpu/test_quant_fp8.py
+++ b/test/unit/test_hpu/test_quant_fp8.py
@@ -3,11 +3,19 @@ import shutil
 
 import pytest
 import torch
+from packaging import version
 
 from auto_round import AutoRound
+from test.helpers import transformers_version
 
 MODEL_LIST = (
-    "Qwen/Qwen3-0.6B-FP8",
+    pytest.param(
+        "Qwen/Qwen3-0.6B-FP8",
+        marks=pytest.mark.skipif(
+            version.parse("5.16.0") <= transformers_version < version.parse("5.17.0"),
+            reason="fails with transformers 5.16.x",
+        ),
+    ),
     "Qwen/Qwen3-0.6B",
 )
 

--- a/test/unit/test_hpu/test_quant_fp8.py
+++ b/test/unit/test_hpu/test_quant_fp8.py
@@ -1,12 +1,12 @@
 import os
 import shutil
+from test.helpers import transformers_version
 
 import pytest
 import torch
 from packaging import version
 
 from auto_round import AutoRound
-from test.helpers import transformers_version
 
 MODEL_LIST = (
     pytest.param(


### PR DESCRIPTION
## Summary
- skip only the Qwen3 FP8 parameter in the HPU FP8 test with Transformers 5.16.x
- keep the non-FP8 parameter enabled

## Details
Transformers 5.16.x fails while loading the FP8 model in `FineGrainedFP8HfQuantizer.update_tp_plan()` with `AttributeError: 'NoneType' object has no attribute 'get'`. The upstream fix was merged in https://github.com/huggingface/transformers/pull/48343 but is not included in Transformers 5.16.1.

Affected HPU build: https://dev.azure.com/lpot-inc/b7121868-d73a-4794-90c1-23135f974d09/_build/results?buildId=73362&view=logs&j=51

## Validation
- `ruff check test/unit/test_hpu/test_quant_fp8.py`
- `git diff --check`