### PR TITLE
fix: warm up Triton CUDA driver before mocking device capability

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -71,6 +71,44 @@ def pytest_unconfigure(config):
     os.environ.update(config.stash[backup_env])
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _warmup_triton_cuda_driver():
+    """Force Triton's CUDA driver singleton to snapshot the *real* device capability.
+
+    Triton's ``GPUDriver.__init__`` (triton/backends/driver.py) does::
+
+        self.get_device_capability = torch.cuda.get_device_capability
+
+    This copies the function object once, when the process-wide
+    ``triton.runtime.driver.active`` singleton is first constructed. If that
+    first construction happens to occur while some test has patched
+    ``torch.cuda.get_device_capability`` (e.g. ``mock_fp8_capable_device``
+    faking an FP8-capable device), the mocked return value gets baked in
+    *permanently* for the rest of the process -- unaffected by the patch
+    being un-applied later. Every subsequent Triton kernel is then compiled
+    for that fake architecture, causing
+    ``RuntimeError: Triton Error [CUDA]: no kernel image is available for
+    execution on the device`` on the *real* hardware regardless of its actual
+    compute capability (reproduced on both sm80 and sm120).
+    See https://github.com/intel/auto-round/issues/2048.
+
+    Triggering the singleton construction here -- as an autouse, session
+    scoped fixture that pytest always instantiates before any function scoped
+    fixture -- guarantees it captures the real capability before any test
+    gets a chance to mock it.
+    """
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return
+        import triton
+
+        triton.runtime.driver.active.get_current_target()
+    except Exception:
+        pass
+
+
 @pytest.fixture(autouse=True)
 def disable_torch_compile_by_default(request, monkeypatch):
     """Use a no-op torch.compile by default to reduce test overhead and flakiness.

--- a/test/unit/test_cuda/models/test_fp8_model.py
+++ b/test/unit/test_cuda/models/test_fp8_model.py
@@ -72,7 +72,6 @@ class TestAutoRound:
         model = convert_module_to_hp_if_necessary(model)
         assert type(model.model.layers[0].mlp.up_proj) is torch.nn.Linear, "FP8Linear layer was not converted to Linear"
 
-    @pytest.mark.skip_ci(reason="triton issue")  # https://github.com/intel/auto-round/issues/2048
     def test_small_model_rtn_generation(self, mock_fp8_capable_device, tiny_fp8_qwen_model_path):
         ar = AutoRound(tiny_fp8_qwen_model_path, iters=0, disable_opt_rtn=True)
         _, quantized_model_path = ar.quantize_and_save(output_dir=self.save_dir)


### PR DESCRIPTION
This pull request addresses a critical issue related to Triton's CUDA driver singleton capturing a mocked device capability during test runs, which could lead to kernel compilation errors on real hardware. The main changes ensure the singleton is initialized with the real device capability before any test can apply mocks, and re-enables a previously skipped test now that the issue is mitigated.

**Test reliability improvements:**

* Added a session-scoped, autouse pytest fixture (`_warmup_triton_cuda_driver`) in `test/conftest.py` to force Triton's CUDA driver singleton to snapshot the real device capability before any test can mock `torch.cuda.get_device_capability`, preventing permanent contamination of the driver state during tests.

**Test coverage:**

* Re-enabled the `test_small_model_rtn_generation` test in `test/unit/test_cuda/models/test_fp8_model.py` by removing the `@pytest.mark.skip_ci` decorator, since the underlying Triton issue is now addressed.