### PR TITLE
fix: skip activation fake-quant in FakeActQuantLinear when act quantization is not configured

### DIFF
--- a/auto_round/experimental/qmodules/fake.py
+++ b/auto_round/experimental/qmodules/fake.py
@@ -69,6 +69,10 @@ class FakeActQuantLinear(QModuleBase):
         return
 
     def qdq_input(self, activation: torch.Tensor) -> torch.Tensor:
+        # No activation quantization configured (e.g. weight-only GGUF-style schemes where
+        # act_bits defaults to 16 / act_data_type is None) -> skip activation fake-quant.
+        if self.config.act_data_type is None or (self.config.act_bits is not None and self.config.act_bits >= 16):
+            return activation
         quant_func, _ = get_quant_func(
             dtype=self.config.act_data_type,
             bits=self.config.act_bits,


### PR DESCRIPTION
…zation is not configured

## Description

Please briefly describe your main changes, the motivation.

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
