### PR TITLE
feat(orchestrator): add reference_output to quantize_block to skip collect_reference

### DIFF
--- a/auto_round/algorithms/composer.py
+++ b/auto_round/algorithms/composer.py
@@ -362,6 +362,7 @@ class AlgorithmComposer:
         block_ctx: BlockContext,
         q_inputs=None,
         input_ids=None,
+        reference_output=None,
         **kwargs,
     ) -> tuple:
         """Run the full per-block algorithm pipeline: calibration → quantization → collection.
@@ -414,13 +415,13 @@ class AlgorithmComposer:
         for pre in self.preprocessors:
             pre.pre_quantize_block(block_ctx)
 
-        reference_output = None
         reference_next_input = None
         # ── Step 3: Quantizer calibration (act_max, imatrix, etc.) ─────────────
         if fp_inputs is not None:
             with torch.no_grad():
                 quant_hooks = self._get_fp_act_hooks(block)
-                reference_output = block_forward_fn(block, fp_inputs, input_others)
+                if reference_output is None:
+                    reference_output = block_forward_fn(block, fp_inputs, input_others)
                 reference_next_input = getattr(block_forward_fn, "last_output_dict", None) or reference_output
                 for h in quant_hooks:
                     h.remove()

--- a/auto_round/compressors/orchestrator.py
+++ b/auto_round/compressors/orchestrator.py
@@ -960,6 +960,7 @@ class CompressionOrchestrator(BaseOrchestrator):
         q_input: Union[torch.Tensor, dict, None] = None,
         device: Union[str, torch.device] = "cpu",
         auto_offload: bool = True,
+        reference_output=None,
     ) -> Any:
         """Quantize a single decoded block of the model (public API for LLM-Compressor).
 
@@ -983,6 +984,11 @@ class CompressionOrchestrator(BaseOrchestrator):
             device: Target device for quantization (e.g. ``"cuda:0"``).
             auto_offload: When *True*, use the device-map-aware offloading path;
                 otherwise move ``block`` directly to ``device``.
+            reference_output: Optional pre-computed FP16 reference outputs (list of
+                tensors, one per calibration sample). When provided, the internal
+                collect_reference forward pass is skipped, saving significant peak
+                CPU RAM on large models. Supplied by LLM-Compressor's SequentialPipeline
+                via ``AutoRoundModifier.set_fp_ref_outputs()``. Requires auto-round ≥ 0.14.2.
 
         Returns:
             tuple: ``(q_outputs, reference_output)`` where *q_outputs* is the
@@ -1109,6 +1115,7 @@ class CompressionOrchestrator(BaseOrchestrator):
             input_others,
             block_ctx=ctx,
             q_inputs=q_input,
+            reference_output=reference_output,
         )
 
         # ── Cleanup ───────────────────────────────────────────────────────────

--- a/auto_round/compressors/utils.py
+++ b/auto_round/compressors/utils.py
@@ -155,7 +155,9 @@ def block_forward(
     # Use the block's actual parameter name for the first positional argument.
     import inspect as _inspect
 
-    param_names = [p for p in _inspect.signature(block.forward).parameters.keys() if p != "self"]
+    # For DDP-wrapped blocks, inspect the underlying module's signature
+    _actual_block = getattr(block, "module", block)
+    param_names = [p for p in _inspect.signature(_actual_block.forward).parameters.keys() if p != "self"]
     block_input_kwarg = param_names[0] if param_names else "hidden_states"
     if block_input_kwarg not in input_others:
         input_others[block_input_kwarg] = input_ids

--- a/test/unit/common/compressors/test_reference_output.py
+++ b/test/unit/common/compressors/test_reference_output.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+"""Unit tests: compress_block skips the collect_reference forward pass when
+reference_output is pre-seeded (intel/auto-round#2288)."""
+
+from unittest.mock import MagicMock
+
+import torch
+
+from auto_round import RTNConfig
+from auto_round.algorithms.composer import AlgorithmComposer, BlockContext
+
+
+def _make_ctx():
+    return BlockContext(
+        model=None,
+        block_names=["model.layers.0"],
+        block_name="model.layers.0",
+        block_index=0,
+    )
+
+
+def _patch_composer(composer, fp_inputs):
+    """Replace heavy internals with lightweight no-ops."""
+    mock_forward = MagicMock(return_value=fp_inputs)
+    mock_forward.last_output_dict = None
+    mock_forward.enable_torch_compile = False
+    composer.block_forward = mock_forward
+    composer.block_quantizer.quantize_block = MagicMock()
+    composer.block_quantizer.enable_quanted_input = False
+    composer._get_fp_act_hooks = MagicMock(return_value=[])
+    composer._get_q_act_hooks = MagicMock(return_value=[])
+    composer.preprocessors = []
+    return mock_forward
+
+
+class TestCompressBlockReferenceOutputSkip:
+    """Verify that a pre-seeded reference_output bypasses the Step-3 forward pass."""
+
+    def setup_method(self):
+        self.composer = AlgorithmComposer([RTNConfig()])
+        self.ctx = _make_ctx()
+        self.block = torch.nn.Linear(4, 4)
+        self.fp_inputs = [torch.zeros(1, 4)]
+        self.input_others = {}
+
+    def test_forward_skipped_when_reference_output_provided(self):
+        """block_forward must NOT be called in Step 3 when reference_output is given."""
+        pre_computed = [torch.ones(1, 4)]
+        mock_forward = _patch_composer(self.composer, self.fp_inputs)
+
+        self.composer.compress_block(
+            self.block,
+            self.fp_inputs,
+            self.input_others,
+            block_ctx=self.ctx,
+            reference_output=pre_computed,
+        )
+
+        mock_forward.assert_not_called()
+
+    def test_forward_called_when_reference_output_is_none(self):
+        """block_forward MUST be called in Step 3 when reference_output=None (default)."""
+        mock_forward = _patch_composer(self.composer, self.fp_inputs)
+
+        self.composer.compress_block(
+            self.block,
+            self.fp_inputs,
+            self.input_others,
+            block_ctx=self.ctx,
+            reference_output=None,
+        )
+
+        mock_forward.assert_called_once()
+
+    def test_seeded_reference_output_propagates_to_return_value(self):
+        """The returned reference_next_input must be the pre-seeded tensors, not a
+        freshly computed one, so the caller's cache and the quantizer see the same object."""
+        pre_computed = [torch.ones(1, 4) * 7.0]
+        _patch_composer(self.composer, self.fp_inputs)
+
+        _, ref_next = self.composer.compress_block(
+            self.block,
+            self.fp_inputs,
+            self.input_others,
+            block_ctx=self.ctx,
+            reference_output=pre_computed,
+        )
+
+        assert ref_next is pre_computed


### PR DESCRIPTION
## Description

Adds an optional `reference_output` parameter to `CompressionOrchestrator.quantize_block`
and `AlgorithmComposer.compress_block`. When provided, the internal FP16 forward pass
("collect_reference" / Step 3) is skipped and the caller-supplied tensors are used
directly. When omitted (`None`), behaviour is **unchanged**.

This eliminates a ~39 GB/rank CPU RAM duplication when LLM-Compressor's
`SequentialPipeline` uses AutoRound with `propagate_error=False` (the default) on
large models (e.g. 122B MoE, N=8192, 8-GPU DDP), where the block's FP16 outputs are
already cached in `IntermediatesCache` and are mathematically identical to what
`collect_reference` would produce.

Also fixes `block_forward()` to unwrap DDP-wrapped blocks before inspecting the
`.forward` signature (`getattr(block, "module", block)`), preventing `TypeError` when
the block is wrapped by `torch.nn.parallel.DistributedDataParallel`.

## Type of Change

New feature (backward-compatible API extension)

## Related Issues

Fixes #2288

LLM-Compressor companion PR: https://github.com/vllm-project/llm-compressor/pull/3130
LLM-Compressor Issue: https://github.com/vllm-project/llm-compressor/issues/3129

## Checklist Before Submitting

- [x] My code has been tested locally (Qwen3-8B W4A16, nsamples=16, iters=5 — all 37 blocks quantized successfully with `reference_output` pre-seeded from llm-compressor).
- [x] Documentation has been updated as needed (extended docstring on `quantize_block`).
- [x] New or updated tests are included where applicable (unit test for `compress_block` with pre-seeded `reference_output` to be added).
- [x] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.