### PR TITLE
fix: update quantization configuration handling in FakeFormat and related tests

### DIFF
--- a/auto_round/experimental/qmodules/fake.py
+++ b/auto_round/experimental/qmodules/fake.py
@@ -69,10 +69,6 @@ class FakeActQuantLinear(QModuleBase):
         return
 
     def qdq_input(self, activation: torch.Tensor) -> torch.Tensor:
-        # No activation quantization configured (e.g. weight-only GGUF-style schemes where
-        # act_bits defaults to 16 / act_data_type is None) -> skip activation fake-quant.
-        if self.config.act_data_type is None or (self.config.act_bits is not None and self.config.act_bits >= 16):
-            return activation
         quant_func, _ = get_quant_func(
             dtype=self.config.act_data_type,
             bits=self.config.act_bits,

--- a/auto_round/export/formats/backends/fake.py
+++ b/auto_round/export/formats/backends/fake.py
@@ -119,16 +119,18 @@ class FakeFormat(OutputFormat):
         if config_act_bits is not None and config_act_bits <= 8:
             has_fake_act_quant = True
 
-        quantization_config = _serialize_quantization_config_value(dict(serialization_dict or {}))
-        quantization_config["quant_method"] = "auto-round"
         if has_fake_act_quant:
+            quantization_config = _serialize_quantization_config_value(dict(serialization_dict or {}))
+            quantization_config["quant_method"] = "auto-round"
             quantization_config["packing_format"] = "auto_round:fake"
-        quantization_config["block_name_to_quantize"] = quantization_config.pop("to_quant_block_names", None)
-        from auto_round.export.utils import filter_quantization_config
+            quantization_config["block_name_to_quantize"] = quantization_config.pop("to_quant_block_names", None)
+            from auto_round.export.utils import filter_quantization_config
 
-        filter_quantization_config(quantization_config)
-        if hasattr(model, "config") and model.config is not None:
-            model.config.quantization_config = quantization_config
+            filter_quantization_config(quantization_config)
+            if hasattr(model, "config") and model.config is not None:
+                model.config.quantization_config = quantization_config
+        elif hasattr(model, "config") and model.config is not None and hasattr(model.config, "quantization_config"):
+            delattr(model.config, "quantization_config")
 
         if not has_meta_device:
             model = model.to("cpu")

--- a/test/unit/test_cpu/export/test_fake_format.py
+++ b/test/unit/test_cpu/export/test_fake_format.py
@@ -58,8 +58,11 @@ class _SaveableModel(torch.nn.Module):
     def save_pretrained(self, output_dir):
         os.makedirs(output_dir, exist_ok=True)
         torch.save(self.state_dict(), os.path.join(output_dir, "pytorch_model.bin"))
+        config = {}
+        if hasattr(self.config, "quantization_config"):
+            config["quantization_config"] = self.config.quantization_config
         with open(os.path.join(output_dir, "config.json"), "w") as config_file:
-            json.dump({"quantization_config": self.config.quantization_config}, config_file)
+            json.dump(config, config_file)
 
 
 def test_fake_format_unwraps_quantized_layers_before_save(tmp_path):
@@ -211,7 +214,7 @@ def test_transformers_load_replaces_fake_linear(tmp_path):
     assert not torch.equal(q_proj.qdq_input(activation), activation)
 
 
-def test_fake_format_keeps_woq_packing_format(tmp_path):
+def test_fake_format_omits_woq_quantization_config(tmp_path):
     model = _SaveableModel()
     output_dir = str(tmp_path / "woq_model")
 
@@ -232,10 +235,9 @@ def test_fake_format_keeps_woq_packing_format(tmp_path):
     )
 
     with open(os.path.join(output_dir, "config.json")) as config_file:
-        quantization_config = json.load(config_file)["quantization_config"]
+        config = json.load(config_file)
 
-    assert quantization_config["packing_format"] == "auto_round:auto_gptq"
-    assert "act_bits" not in quantization_config
+    assert "quantization_config" not in config
 
 
 def test_fake_format_still_saves_when_env_disabled(tmp_path):


### PR DESCRIPTION
## Description

This pull request refines how quantization configuration is handled and serialized for models using fake quantization, particularly focusing on omitting unnecessary quantization config for weight-only quantization (WOQ) models. It also updates related tests to ensure correct behavior and output.

**Quantization configuration handling:**

* The logic in `save_quantized` now ensures that `quantization_config` is only attached to the model config when fake activation quantization is present; it is removed otherwise, preventing unintended serialization for WOQ models.
* The `qdq_input` method in `fake.py` is simplified by removing the redundant early return for unquantized activations, relying instead on the quantization function selection logic.

**Test updates:**

* The test for WOQ models is renamed and updated to assert that `quantization_config` is omitted from the saved config file, reflecting the new serialization logic. [[1]](diffhunk://#diff-51247e203e78207192be8819bc8e5bbc3e28c2f5a92cdb52067e06e4f0542d09L214-R217) [[2]](diffhunk://#diff-51247e203e78207192be8819bc8e5bbc3e28c2f5a92cdb52067e06e4f0542d09L235-R240)
* The model saving logic in the test helper now only writes `quantization_config` to `config.json` if it exists, preventing empty or unnecessary config entries.

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
