### PR TITLE
fix: recreate calibrator for secondary diffusion transformers

### DIFF
--- a/auto_round/compressors/diffusion_mixin.py
+++ b/auto_round/compressors/diffusion_mixin.py
@@ -352,6 +352,9 @@ class DiffusionMixin:
             self.model_context.model = transformer
             self.model_context.quantized = False
             self._post_init_done = False
+            # Calibrators snapshot the active model at construction time. Recreate
+            # it so transformer_2 block hooks are not installed on the primary model.
+            self.calibration = None
 
             # Dispatch the pipeline for the secondary transformer without recasting it.
             self._align_device_and_dtype_for_secondary(comp_name)


### PR DESCRIPTION
## Description

Fix multi-transformer diffusion quantization failing with KeyError: 'blocks.0'.

When switching from the primary transformer to transformer_2, the existing calibrator still references the primary model. Recreate the calibrator so calibration hooks are registered on the active transformer and block inputs are cached correctly.

```
2026-09-10 08:33:30 INFO orchestrator.py L619: caching done
0%| | 0/40 [00:00<?, ?it/s]Traceback (most recent call last):
File "/models/changwa1/.venv/bin/auto_round", line 10, in <module>
sys.exit(run())
^^^^^
File "/models/changwa1/auto-round/auto_round/cli/main.py", line 520, in run
start(argv=command_argv)
File "/models/changwa1/auto-round/auto_round/cli/main.py", line 246, in start
tune(args)
File "/models/changwa1/auto-round/auto_round/cli/main.py", line 413, in tune
model, folders = autoround.quantize_and_save( # pylint: disable=no-member
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/models/changwa1/auto-round/auto_round/compressors/base.py", line 2187, in quantize_and_save
self.quantize()
File "/models/changwa1/auto-round/auto_round/compressors/diffusion_mixin.py", line 400, in quantize
super().quantize()
File "/models/changwa1/auto-round/auto_round/compressors/orchestrator.py", line 405, in quantize
return self._quantize_data_driven()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/models/changwa1/auto-round/auto_round/compressors/orchestrator.py", line 699, in _quantize_data_driven
inputs = all_inputs[block_names[0]]
~~~~~~~~~~^^^^^^^^^^^^^^^^
KeyError: 'blocks.0'
0%|
```

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #2338 

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
