### PR TITLE
fix: preserve layer config for secondary diffusion transformers

### DIFF
--- a/auto_round/compressors/diffusion_mixin.py
+++ b/auto_round/compressors/diffusion_mixin.py
@@ -365,7 +365,6 @@ class DiffusionMixin:
             # Get block names for new transformer
             all_blocks = get_block_names(self.model_context.model)
             self.quant_block_list = find_matching_blocks(self.model_context.model, all_blocks, None)
-            self.layer_config = {}
 
             # Get new block names for caching
             if bool(self.quant_block_list):


### PR DESCRIPTION
## Description

Fix secondary transformer packing in multi-transformer diffusion pipelines.

```
transformer: ~7.45 GiB
400 weight_packed tensors
400 weight_scale tensors
MXFP4 packing applied correctly
transformer_2: ~26.67 GiB
0 weight_packed tensors
0 weight_scale tensors
Weights remain in BF16, but​ the config is incorrectly tagged as mxfp4-pack-quantized
```

After post_init() is executed for the secondary transformer, the layer configuration is already built. However, the code subsequently executes:
```
self.layer_config = {}
```
This causes the following issues:
Quantization logic does not process any secondary transformer layers.
The log shows packing: 0it.
The BF16 transformer_2 is incorrectly labeled as MXFP4 in the final configuration.
## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #2339 

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
