### PR TITLE
feat: add opt-in diffusion tuning cache prefetch

### DIFF
--- a/auto_round/algorithms/quantization/sign_round/quantizer.py
+++ b/auto_round/algorithms/quantization/sign_round/quantizer.py
@@ -473,61 +473,107 @@ class SignRoundQuantizer(BaseQuantizer):
             else None
         )
 
-        for i in range(self.iters):
-            if self.enable_alg_ext and self.scheme.data_type.endswith("dq"):
-                for n, m in block.named_modules():
-                    m.cur_iter = i
-            total_loss = 0
-            global_indices = index_sampler.next_batch()
-            if valid_token_mask:
-                num_elm = self._get_non_zero_cnt(valid_token_mask, global_indices)
+        tuning_cache = None
+        # Only opt-in diffusion tuning can enter the CUDA staging path.
+        cache_budget = getattr(self.model_context, "diffusion_tuning_cache_size", 0)
+        use_tuning_cache = (
+            getattr(self.model_context, "is_diffusion", False)
+            and (cache_budget == "auto" or cache_budget > 0)
+            and self.compress_context.low_gpu_mem_usage
+            and str(device).startswith("cuda")
+            and len(device_manager.device_list) == 1
+            and (loss_device is None or torch.device(loss_device) == torch.device(device))
+        )
 
-            for batch_start in range(0, len(global_indices), batch_size):
-                indices = global_indices[batch_start : batch_start + batch_size]
-                ref_output = torch.cat([fp_outputs[i] for i in indices], dim=0).to(loss_device)
-                pred_output = block_fwd.forward(block, active_inputs, input_others, indices, _fwd_cache_device)
-                if loss_device is not None:
-                    pred_output = pred_output.to(loss_device)
-                if (
-                    block_ctx.block_index == block_ctx.block_cnt - 1
-                    and self.enable_lfq
-                    and input_ids is not None
-                    and self._is_text_decoder_block(block_ctx.block_name)
-                ):
-                    loss = self.lfq_loss(pred_output, torch.cat([input_ids[i] for i in indices], dim=0))
-                else:
-                    loss = self._get_loss(pred_output, ref_output, indices, mse_loss, device, valid_token_mask)
-                num_elm = 1 if num_elm <= 0 else num_elm
-                total_loss += loss.item() / num_elm
+        try:
+            for i in range(self.iters):
+                # Auto observes a complete forward/backward/optimizer iteration
+                # on the legacy path before allocating any extra GPU buffers.
+                if use_tuning_cache and i == (1 if cache_budget == "auto" else 0):
+                    from auto_round.compressors.diffusion.tuning_cache import DiffusionTuningCache
 
-                if mid_iter_mem_check:
-                    # clear memory to avoid OOM due to memory fragmentation
-                    clear_memory_if_reached_threshold(threshold=0.5, device_list=device_manager.device_list)
+                    tuning_cache = DiffusionTuningCache.create(
+                        block,
+                        block_fwd,
+                        active_inputs,
+                        input_others,
+                        fp_outputs,
+                        index_sampler,
+                        self.iters - i,
+                        cache_budget,
+                        device,
+                    )
+                if self.enable_alg_ext and self.scheme.data_type.endswith("dq"):
+                    for n, m in block.named_modules():
+                        m.cur_iter = i
+                total_loss = 0
+                global_indices = index_sampler.next_batch()
+                if valid_token_mask:
+                    num_elm = self._get_non_zero_cnt(valid_token_mask, global_indices)
 
-                self._scale_loss_and_backward(scaler, loss)
+                for batch_start in range(0, len(global_indices), batch_size):
+                    indices = global_indices[batch_start : batch_start + batch_size]
+                    staged = tuning_cache.get(indices) if tuning_cache is not None else None
+                    if staged is None:
+                        ref_output = torch.cat([fp_outputs[i] for i in indices], dim=0).to(loss_device)
+                        pred_output = block_fwd.forward(block, active_inputs, input_others, indices, _fwd_cache_device)
+                    else:
+                        ref_output = staged[2]
+                        pred_output = tuning_cache.forward(block, staged, _fwd_cache_device)
+                    if loss_device is not None:
+                        pred_output = pred_output.to(loss_device)
+                    if (
+                        block_ctx.block_index == block_ctx.block_cnt - 1
+                        and self.enable_lfq
+                        and input_ids is not None
+                        and self._is_text_decoder_block(block_ctx.block_name)
+                    ):
+                        loss = self.lfq_loss(pred_output, torch.cat([input_ids[i] for i in indices], dim=0))
+                    else:
+                        loss = self._get_loss(pred_output, ref_output, indices, mse_loss, device, valid_token_mask)
+                    num_elm = 1 if num_elm <= 0 else num_elm
+                    total_loss += loss.item() / num_elm
 
-                if mid_iter_mem_check:
-                    # clear memory to avoid OOM due to memory fragmentation
-                    clear_memory_if_reached_threshold(threshold=0.8, device_list=device_manager.device_list)
+                    if mid_iter_mem_check:
+                        # clear memory to avoid OOM due to memory fragmentation
+                        clear_memory_if_reached_threshold(threshold=0.5, device_list=device_manager.device_list)
 
-            if i == 0:
-                init_loss = total_loss
-            current_lr = optimizer.param_groups[0]["lr"]
-            logger.debug("iter %d loss: %.3e lr: %s", i, total_loss, current_lr)
+                    self._scale_loss_and_backward(scaler, loss)
 
-            if total_loss < best_loss:
-                best_loss = total_loss
+                    if mid_iter_mem_check:
+                        # clear memory to avoid OOM due to memory fragmentation
+                        clear_memory_if_reached_threshold(threshold=0.8, device_list=device_manager.device_list)
+
+                if i == 0:
+                    init_loss = total_loss
+                current_lr = optimizer.param_groups[0]["lr"]
+                logger.debug("iter %d loss: %.3e lr: %s", i, total_loss, current_lr)
+
+                if total_loss < best_loss:
+                    best_loss = total_loss
+                    if not self.not_use_best_mse:
+                        best_params = (
+                            tuning_cache.collect_best_params()
+                            if tuning_cache is not None and tuning_cache.best is not None
+                            else collect_best_params(block, self.compress_context.cache_device)
+                        )
+                        last_best_iter = i
+                if self.not_use_best_mse and i == self.iters - 1:
+                    best_params = (
+                        tuning_cache.collect_best_params()
+                        if tuning_cache is not None and tuning_cache.best is not None
+                        else collect_best_params(block, self.compress_context.cache_device)
+                    )
+
                 if not self.not_use_best_mse:
-                    best_params = collect_best_params(block, self.compress_context.cache_device)
-                    last_best_iter = i
-            if self.not_use_best_mse and i == self.iters - 1:
-                best_params = collect_best_params(block, self.compress_context.cache_device)
+                    if 0 < self.dynamic_max_gap <= i - last_best_iter:
+                        break
+                sync_gradients()
+                self._step(scaler, optimizer, lr_schedule)
 
-            if not self.not_use_best_mse:
-                if 0 < self.dynamic_max_gap <= i - last_best_iter:
-                    break
-            sync_gradients()
-            self._step(scaler, optimizer, lr_schedule)
+        finally:
+            if tuning_cache is not None:
+                tuning_cache.close()
 
         last_loss = total_loss
         best_iter = self.iters

--- a/auto_round/autoround.py
+++ b/auto_round/autoround.py
@@ -355,6 +355,7 @@ _ENTRY_KWARG_OWNERS = {
     "num_inference_steps": "diffusion",
     "calib_num_inference_steps": "diffusion",
     "generator_seed": "diffusion",
+    "diffusion_tuning_cache_size": "diffusion",
 }
 
 _SCHEME_FIELDS = set(QuantizationScheme.get_attributes())

--- a/auto_round/cli/main.py
+++ b/auto_round/cli/main.py
@@ -99,6 +99,7 @@ def _build_entry_model_type_kwargs(args) -> dict:
         "num_inference_steps": args.num_inference_steps,
         "calib_num_inference_steps": args.calib_num_inference_steps,
         "generator_seed": args.generator_seed,
+        "diffusion_tuning_cache_size": args.diffusion_tuning_cache_size,
     }
 
 

--- a/auto_round/cli/parser.py
+++ b/auto_round/cli/parser.py
@@ -296,6 +296,14 @@ def build_quantize_parser(*, prog: str = "auto_round quantize") -> argparse.Argu
         help="Number of denoising steps for diffusion generation/evaluation.",
     )
     diff.add_argument("--generator_seed", default=None, type=int, help="Random seed used for diffusion generation.")
+    diff.add_argument(
+        "--diffusion_tuning_cache_size",
+        default=0,
+        type=lambda value: value if value == "auto" else float(value),
+        help="Extra GPU buffer budget in GiB for single-CUDA diffusion SignRound prefetch with low_gpu_mem_usage. "
+        "Use 'auto' to select a budget after the first tuning iteration; 0 preserves the existing path. "
+        "This is not a limit on total GPU memory.",
+    )
 
     # ---- Common Quantization Arguments ----
     quant_group = parser.add_argument_group("Common Quantization Arguments")

--- a/auto_round/compressors/diffusion/README.md
+++ b/auto_round/compressors/diffusion/README.md
@@ -42,6 +42,9 @@ autoround.quantize_and_save(output_dir, format="fake", inplace=True)
   control the calibration schedule.
 - `guidance_scale`: controls how much the image generation process follows the text prompt.
 - `generator_seed`: a seed that controls the initial noise from which an image is generated.
+- `diffusion_tuning_cache_size`: opt-in extra GPU buffer budget in GiB for diffusion SignRound prefetch.
+  It only takes effect with `low_gpu_mem_usage=True` on single-GPU SignRound flow (`enable_quanted_input=False`
+  and no custom `layer_config`). This value reserves additional temporary buffers and is not a cap on total VRAM.
 
 For more hyperparameters, refer to [Homepage Detailed Hyperparameters](../../../README.md#quantization-scheme--configuration).
 
@@ -57,8 +60,14 @@ auto-round \
     --batch_size 1 \
     --dataset coco2014 \
     --calib_num_inference_steps 8 \
+    --low_gpu_mem_usage \
+    --diffusion_tuning_cache_size auto \
     --output_dir ./tmp_autoround
 ```
+
+Use `--diffusion_tuning_cache_size` only when `--low_gpu_mem_usage` is enabled on single-GPU SignRound
+(`--enable_quanted_input` disabled and no custom `--layer_config`). The GiB value controls extra prefetch buffers,
+not total GPU memory.
 
 ### Diffusion Support Matrix
 

--- a/auto_round/compressors/diffusion/tuning_cache.py
+++ b/auto_round/compressors/diffusion/tuning_cache.py
@@ -1,0 +1,217 @@
+# # Copyright (C) 2026 Intel Corporation
+# # SPDX-License-Identifier: Apache-2.0
+
+"""Opt-in, bounded CUDA staging for diffusion SignRound batches."""
+
+import queue
+import random
+import threading
+
+import torch
+from torch.utils._pytree import tree_flatten, tree_map
+
+from auto_round.logger import logger
+
+
+def _batch_plan(sampler, iters, batch_size):
+    """Forecast the cyclic sampler without advancing it or the global RNG."""
+    rng = random.Random()
+    rng.setstate(random.getstate())
+    indices, position = list(sampler.indices), sampler.index
+    for _ in range(iters):
+        if position + sampler.batch_size > sampler.nsamples:
+            rng.shuffle(indices)
+            position = 0
+        selected = indices[position : position + sampler.batch_size]
+        position += sampler.batch_size
+        for start in range(0, len(selected), batch_size):
+            yield selected[start : start + batch_size]
+
+
+def _signature(batch):
+    leaves, spec = tree_flatten(batch)
+    signature = []
+    for value in leaves:
+        if isinstance(value, torch.Tensor):
+            if value.device.type != "cpu" or value.layout != torch.strided:
+                return None
+            signature.append((value.shape, value.dtype))
+        elif value is None or isinstance(value, (str, bool, int, float)):
+            signature.append((type(value), value))
+        else:
+            return None
+    return spec, signature
+
+
+def _nbytes(batch):
+    return sum(t.numel() * t.element_size() for t in tree_flatten(batch)[0] if isinstance(t, torch.Tensor))
+
+
+def _auto_budget_bytes(free_bytes):
+    # Keep the warmed allocator pool for activations/workspace, and leave at
+    # least half the unreserved memory (and at least 1 GiB) as additional margin.
+    return max(0, min(free_bytes // 2, free_bytes - 2**30))
+
+
+class DiffusionTuningCache:
+    """Two reusable host/device slots, with optional in-place best snapshots.
+
+    The budget covers these persistent CUDA buffers only, not the training
+    activations/workspace. Pinned host memory is bounded by the two batch slots.
+    The caller must close the cache after backward, including on early exit.
+    """
+
+    @classmethod
+    def create(cls, block, runner, inputs, others, outputs, sampler, iters, budget_gib, device):
+        if runner.batch_size != 1 or not isinstance(inputs, dict) or iters <= 0:
+            return None
+        cache = cls()
+        cache.runner, cache.inputs, cache.others, cache.outputs = runner, inputs, others, outputs
+        cache.device = torch.device(device)
+        cache.plan = iter(_batch_plan(sampler, iters, runner.batch_size))
+        # Start the generator now, before the original sampler advances.
+        first = next(cache.plan)
+        template = cache._select(first)
+        cache.signature = _signature(template)
+        if cache.signature is None:
+            return None
+        cache.sources = (
+            block.params
+            if hasattr(block, "orig_layer")
+            else {name: module.params for name, module in block.named_modules() if hasattr(module, "orig_layer")}
+        )
+        staging_bytes = 2 * _nbytes(template)
+        best_bytes = _nbytes(cache.sources)
+        if budget_gib == "auto":
+            torch.cuda.synchronize(cache.device)
+        free_bytes = torch.cuda.mem_get_info(cache.device)[0]
+        budget = (
+            _auto_budget_bytes(free_bytes) if budget_gib == "auto" else int(min(budget_gib, free_bytes / 2**30) * 2**30)
+        )
+        if budget_gib == "auto":
+            logger.info("Diffusion tuning auto cache budget after warmup: %.2f GiB.", budget / 2**30)
+        if staging_bytes > budget:
+            logger.info("Diffusion tuning prefetch skipped: two batch buffers exceed the cache budget.")
+            return None
+        cache.stop = threading.Event()
+        cache.free, cache.ready = queue.Queue(), queue.Queue()
+        cache.slots, cache.current, cache.thread = [], None, None
+        cache.best = None
+        cache.stream = torch.cuda.Stream(device=cache.device)
+        try:
+            for slot_id in range(2):
+                host = tree_map(
+                    lambda t: torch.empty_like(t, device="cpu", pin_memory=True) if isinstance(t, torch.Tensor) else t,
+                    template,
+                )
+                gpu = tree_map(
+                    lambda t: torch.empty_like(t, device=cache.device) if isinstance(t, torch.Tensor) else t, template
+                )
+                cache.slots.append(dict(host=host, gpu=gpu, ready=torch.cuda.Event(), finished=None))
+                cache.free.put(slot_id)
+            if staging_bytes + best_bytes <= budget:
+                cache.best = tree_map(lambda t: torch.empty_like(t, device=cache.device), cache.sources)
+            # Allocations happen on the compute stream; hand them to the copy stream.
+            cache.stream.wait_stream(torch.cuda.current_stream(cache.device))
+            cache.thread = threading.Thread(target=cache._produce, args=(first,), daemon=True)
+            cache.thread.start()
+        except torch.OutOfMemoryError:
+            cache.close()
+            logger.info("Diffusion tuning prefetch skipped: buffer allocation ran out of memory.")
+            return None
+        logger.info(
+            "Diffusion tuning prefetch enabled with %.2f GiB of GPU buffers; best parameters on %s.",
+            (staging_bytes + (best_bytes if cache.best is not None else 0)) / 2**30,
+            "GPU" if cache.best is not None else "CPU",
+        )
+        return cache
+
+    def _select(self, indices):
+        inputs, others = self.runner.select_batch(self.inputs, self.others, torch.tensor(indices, dtype=torch.long))
+        return inputs, others, self.outputs[indices[0]]
+
+    def _produce(self, first):
+        try:
+            with torch.cuda.device(self.device):
+                indices = first
+                while not self.stop.is_set():
+                    try:
+                        slot_id = self.free.get(timeout=0.1)
+                    except queue.Empty:
+                        continue
+                    slot = self.slots[slot_id]
+                    if slot["finished"] is not None:
+                        slot["finished"].synchronize()
+                    batch = self._select(indices)
+                    if _signature(batch) != self.signature:
+                        self.ready.put(None)
+                        return
+                    with torch.cuda.stream(self.stream):
+                        source = tree_flatten(batch)[0]
+                        host = tree_flatten(slot["host"])[0]
+                        gpu = tree_flatten(slot["gpu"])[0]
+                        for src, pinned, dest in zip(source, host, gpu):
+                            if isinstance(src, torch.Tensor):
+                                pinned.copy_(src)
+                                dest.copy_(pinned, non_blocking=True)
+                        slot["ready"].record(self.stream)
+                    self.ready.put((list(indices), slot_id))
+                    indices = next(self.plan, None)
+                    if indices is None:
+                        return
+        except Exception as error:
+            self.ready.put(error)
+
+    def get(self, indices):
+        if self.stop.is_set():
+            return None
+        if self.current is not None:
+            slot = self.slots[self.current]
+            slot["finished"] = torch.cuda.Event()
+            slot["finished"].record(torch.cuda.current_stream(self.device))
+            self.free.put(self.current)
+            self.current = None
+        item = self.ready.get(timeout=60)
+        if isinstance(item, Exception):
+            raise item
+        if item is None or item[0] != list(indices):
+            # Dynamic shapes or a custom forward using Python RNG can invalidate
+            # the forecast. Consume the actual sampler batch on the original path.
+            self.close()
+            logger.info("Diffusion tuning prefetch stopped: batch structure or sample order changed.")
+            return None
+        _, self.current = item
+        slot = self.slots[self.current]
+        torch.cuda.current_stream(self.device).wait_event(slot["ready"])
+        return slot["gpu"]
+
+    def forward(self, block, batch, cache_device):
+        inputs, others, _ = batch
+        shared = self.runner.shared_cache_keys
+        inputs = {
+            key: [value] if isinstance(value, torch.Tensor) or key in shared else value for key, value in inputs.items()
+        }
+        others = {
+            key: (
+                [value]
+                if key != "positional_inputs" and (isinstance(value, (torch.Tensor, list)) or key in shared)
+                else value
+            )
+            for key, value in others.items()
+        }
+        return self.runner.forward(block, inputs, others, [0], cache_device)
+
+    def collect_best_params(self):
+        for dest, source in zip(tree_flatten(self.best)[0], tree_flatten(self.sources)[0]):
+            dest.copy_(source.detach())
+        return self.best
+
+    def close(self):
+        self.stop.set()
+        if self.thread is not None:
+            self.thread.join()
+        # Both streams can still reference buffers on exceptions/early stopping.
+        self.stream.synchronize()
+        torch.cuda.current_stream(self.device).synchronize()
+        self.slots.clear()
+        self.current = None

--- a/auto_round/compressors/diffusion/tuning_cache.py
+++ b/auto_round/compressors/diffusion/tuning_cache.py
@@ -182,7 +182,15 @@ class DiffusionTuningCache:
             slot["finished"].record(torch.cuda.current_stream(self.device))
             self.free.put(self.current)
             self.current = None
-        item = self.ready.get(timeout=60)
+        try:
+            item = self.ready.get(timeout=60)
+        except queue.Empty:
+            # Prefetch is an optional optimization. If the producer cannot
+            # keep up, release its buffers and let the caller use the legacy
+            # synchronous path for the current batch.
+            self.close()
+            logger.info("Diffusion tuning prefetch timed out; falling back to the legacy path.")
+            return None
         if isinstance(item, Exception):
             raise item
         if item is None or item[0] != list(indices):

--- a/auto_round/compressors/diffusion/tuning_cache.py
+++ b/auto_round/compressors/diffusion/tuning_cache.py
@@ -1,5 +1,16 @@
-# # Copyright (C) 2026 Intel Corporation
-# # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Opt-in, bounded CUDA staging for diffusion SignRound batches."""
 

--- a/auto_round/compressors/diffusion_mixin.py
+++ b/auto_round/compressors/diffusion_mixin.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import math
 import os
 from typing import Any, Optional, Union
 
@@ -44,6 +45,10 @@ class DiffusionMixin:
         num_inference_steps: Number of denoising steps for diffusion generation or evaluation
         calib_num_inference_steps: Number of denoising steps used to collect calibration inputs
         generator_seed: Seed for initial noise generation
+        diffusion_tuning_cache_size: Extra persistent GPU buffer budget in GiB for
+            single-CUDA SignRound prefetch with low_gpu_mem_usage; 0 disables it.
+            "auto" selects a conservative budget after the first tuning iteration.
+            Training activations/workspace are not included in this budget.
 
     Design note:
         ``ModelContext._load_model()`` loads the diffusion pipeline and sets
@@ -59,12 +64,22 @@ class DiffusionMixin:
         num_inference_steps: int = 50,
         calib_num_inference_steps: int = 8,
         generator_seed: Optional[int] = None,
+        diffusion_tuning_cache_size: Union[float, str] = 0,
         **kwargs,
     ) -> None:
         if num_inference_steps < 1:
             raise ValueError("num_inference_steps must be a positive integer.")
         if calib_num_inference_steps < 1:
             raise ValueError("calib_num_inference_steps must be a positive integer.")
+        if diffusion_tuning_cache_size != "auto":
+            try:
+                diffusion_tuning_cache_size = float(diffusion_tuning_cache_size)
+                if not math.isfinite(diffusion_tuning_cache_size) or diffusion_tuning_cache_size < 0:
+                    raise ValueError
+            except (TypeError, ValueError):
+                raise ValueError(
+                    "diffusion_tuning_cache_size must be 'auto' or finite and non-negative (GiB)."
+                ) from None
 
         # Store diffusion-specific attributes
         self.guidance_scale = guidance_scale
@@ -119,6 +134,7 @@ class DiffusionMixin:
 
         # Call parent class __init__ (will be Compressor, ImatrixCompressor, etc)
         super().__init__(*args, **kwargs)
+        self.model_context.diffusion_tuning_cache_size = diffusion_tuning_cache_size
 
         pipe = getattr(self.model_context, "pipe", None)
         model = getattr(self.model_context, "model", None)

--- a/test/unit/common/compressors/test_diffusion_mixin.py
+++ b/test/unit/common/compressors/test_diffusion_mixin.py
@@ -28,8 +28,10 @@ class TestDiffusionMixinProperties:
         assert params.get("num_inference_steps") == 50
         assert params.get("calib_num_inference_steps") == 8
         assert params.get("generator_seed") is None
+        assert params.get("diffusion_tuning_cache_size") == 0
 
-    def test_generation_and_calibration_steps_are_independent(self):
+    @pytest.mark.parametrize("budget", [2, "auto"])
+    def test_generation_and_calibration_steps_are_independent(self, budget):
         class Parent:
             def __init__(self, *args, **kwargs):
                 self.model_context = SimpleNamespace(pipe=None, model=None)
@@ -37,16 +39,21 @@ class TestDiffusionMixinProperties:
         class MockCompressor(DiffusionMixin, Parent):
             pass
 
-        comp = MockCompressor(num_inference_steps=20, calib_num_inference_steps=7)
+        comp = MockCompressor(num_inference_steps=20, calib_num_inference_steps=7, diffusion_tuning_cache_size=budget)
 
         assert comp.num_inference_steps == 20
         assert comp.calib_num_inference_steps == 7
+        assert comp.model_context.diffusion_tuning_cache_size == budget
 
     @pytest.mark.parametrize(
         ("kwargs", "match"),
         [
             ({"calib_num_inference_steps": 0}, "calib_num_inference_steps"),
             ({"num_inference_steps": 0}, "num_inference_steps"),
+            ({"diffusion_tuning_cache_size": -1}, "diffusion_tuning_cache_size"),
+            ({"diffusion_tuning_cache_size": float("nan")}, "diffusion_tuning_cache_size"),
+            ({"diffusion_tuning_cache_size": float("inf")}, "diffusion_tuning_cache_size"),
+            ({"diffusion_tuning_cache_size": "invalid"}, "diffusion_tuning_cache_size"),
         ],
     )
     def test_rejects_non_positive_inference_steps(self, kwargs, match):

--- a/test/unit/common/compressors/test_diffusion_tuning_cache.py
+++ b/test/unit/common/compressors/test_diffusion_tuning_cache.py
@@ -1,74 +1,32 @@
 import random
-from types import SimpleNamespace
 
 import pytest
 import torch
 
 from auto_round.algorithms.block_runner import BlockForwardRunner
-from auto_round.algorithms.composer import BlockContext
-from auto_round.algorithms.quantization.sign_round.config import SignRoundConfig
-from auto_round.algorithms.quantization.sign_round.quantizer import SignRoundQuantizer
-from auto_round.compressors.diffusion.tuning_cache import DiffusionTuningCache, _auto_budget_bytes, _batch_plan, _nbytes
+from auto_round.compressors.diffusion.tuning_cache import DiffusionTuningCache, _batch_plan
 from auto_round.compressors.utils import IndexSampler
-from auto_round.context.compress import CompressContext
-from auto_round.schemes import W4A16
-from auto_round.utils.device_manager import device_manager
 
 
-@pytest.mark.parametrize("nsamples,global_batch", [(5, 1), (5, 2), (4, 4)])
-def test_prefetch_plan_preserves_sampler_and_rng(nsamples, global_batch):
+@pytest.mark.parametrize("global_batch", [1, 2])
+def test_prefetch_plan_preserves_sampler_and_rng(global_batch):
     state = random.getstate()
     try:
-        random.seed(31)
-        sampler = IndexSampler(nsamples, global_batch)
+        sampler = IndexSampler(5, global_batch)
         before = random.getstate()
         predicted = list(_batch_plan(sampler, 8, 1))
         assert random.getstate() == before
         assert sampler.index == 0
-        actual = [[i] for _ in range(8) for i in sampler.next_batch()]
-        assert predicted == actual
+        assert predicted == [[i] for _ in range(8) for i in sampler.next_batch()]
     finally:
         random.setstate(state)
 
 
-class TinyBlock(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.proj = torch.nn.Linear(32, 32)
-
-    def forward(self, hidden_states, temb=None):
-        return self.proj(hidden_states) + temb
-
-
-def test_tensor_backed_cache_selection():
-    cache = DiffusionTuningCache()
-    cache.runner = BlockForwardRunner(batch_size=1, device="cpu", cache_device="cpu", amp=False, is_diffusion=True)
-    cache.inputs = {"hidden_states": torch.arange(24).reshape(3, 2, 4)}
-    cache.others = {"temb": torch.arange(12).reshape(3, 4), "positional_inputs": []}
-    cache.outputs = [torch.ones(1, 2, 4) * i for i in range(3)]
-    inputs, others, reference = cache._select([1])
-    torch.testing.assert_close(inputs["hidden_states"], cache.inputs["hidden_states"][1:2])
-    torch.testing.assert_close(others["temb"], cache.others["temb"][1:2])
-    torch.testing.assert_close(reference, cache.outputs[1])
-
-
-def test_prefetched_forward_preserves_scalar_inputs():
-    class ScaleBlock(torch.nn.Module):
-        def forward(self, hidden_states, scale):
-            return hidden_states * scale
-
-    cache = DiffusionTuningCache()
-    cache.runner = BlockForwardRunner(batch_size=1, device="cpu", cache_device="cpu", amp=False, is_diffusion=True)
-    hidden = torch.ones(1, 2, 4)
-    batch = ({"hidden_states": hidden, "scale": 2.0}, {"positional_inputs": []}, hidden)
-    torch.testing.assert_close(cache.forward(ScaleBlock(), batch, "cpu"), 2 * hidden)
-
-
-@pytest.mark.parametrize("shared", [True, False])
-def test_prefetched_forward_preserves_list_conditioning(shared):
-    class ConditionedBlock(torch.nn.Module):
-        def forward(self, hidden_states, freqs):
-            return hidden_states + freqs[0] + freqs[1]
+@pytest.mark.parametrize("shared", [False, True])
+def test_prefetched_batch_preserves_input_structure(shared):
+    class Block(torch.nn.Module):
+        def forward(self, hidden_states, scale, temb, freqs):
+            return hidden_states * scale + temb + freqs[0] + freqs[1]
 
     cache = DiffusionTuningCache()
     cache.runner = BlockForwardRunner(
@@ -79,262 +37,14 @@ def test_prefetched_forward_preserves_list_conditioning(shared):
         is_diffusion=True,
         shared_cache_keys=("freqs",) if shared else (),
     )
-    cache.inputs = {"hidden_states": [torch.ones(1, 2, 4)]}
-    cache.others = {"freqs": [[torch.ones(1, 2, 4), torch.ones(1, 2, 4) * 2]], "positional_inputs": []}
-    cache.outputs = cache.inputs["hidden_states"]
-    expected = cache.runner.forward(ConditionedBlock(), cache.inputs, cache.others, [0], "cpu")
-    batch = cache._select([0])
-    torch.testing.assert_close(cache.forward(ConditionedBlock(), batch, "cpu"), expected)
-
-
-def _tune(monkeypatch, device, budget, *, diffusion=True, low_mem=True, grad_acc=1, gap=-1, last=False, iters=8):
-    torch.manual_seed(12)
-    random.seed(34)
-    monkeypatch.setattr(device_manager, "device", device)
-    monkeypatch.setattr(device_manager, "_device_list", [device])
-    block = TinyBlock().to(device).eval().requires_grad_(False)
-    inputs = {"hidden_states": [torch.randn(1, 8, 32) for _ in range(5)]}
-    others = {"temb": [torch.randn(1, 8, 32) for _ in range(5)], "positional_inputs": []}
-    outputs = [
-        block(x.to(device), t.to(device)).detach().cpu() for x, t in zip(inputs["hidden_states"], others["temb"])
-    ]
-    scheme = W4A16.copy()
-    for key, value in scheme.to_dict().items():
-        setattr(block.proj, key, value)
-    block.proj.scale_dtype = torch.float32
-    CompressContext.reset_context()
-    cc = CompressContext(low_gpu_mem_usage=low_mem, enable_torch_compile=False)
-    config = SignRoundConfig(
-        scheme=scheme,
-        iters=iters,
-        lr=0.005,
-        minmax_lr=0.005,
-        gradient_accumulate_steps=grad_acc,
-        dynamic_max_gap=gap,
-        not_use_best_mse=last,
-    )
-    quantizer = SignRoundQuantizer(config)
-    quantizer.bind(
-        SimpleNamespace(
-            model_context=SimpleNamespace(
-                model=block,
-                is_diffusion=diffusion,
-                amp=False,
-                amp_dtype=torch.float32,
-                diffusion_tuning_cache_size=budget,
-            ),
-            compress_context=cc,
-            calibration_context=SimpleNamespace(batch_size=1, batch_dim=0),
-            scale_dtype=torch.float32,
-            scheme_context=scheme,
-        )
-    )
-    runner = BlockForwardRunner(
-        batch_size=1, device=device, cache_device="cpu", amp=False, is_diffusion=True, enable_torch_compile=False
-    )
-    quantizer.bind_block_forward_runner(runner)
-    trace = []
-    get_loss = quantizer._get_loss
-
-    def record_loss(pred, ref, indices, *args):
-        loss = get_loss(pred, ref, indices, *args)
-        trace.append((list(indices), loss.detach().cpu().item()))
-        return loss
-
-    quantizer._get_loss = record_loss
-    best = quantizer.quantize_block(
-        block,
-        inputs,
-        others,
-        outputs,
-        None,
-        BlockContext(model=block, block_names=["blocks.0"], block_index=0, block_cnt=1, block_name="blocks.0"),
-    )
-    assert runner.cache_device == "cpu"
-    return {k: v.detach().cpu().clone() for k, v in block.state_dict().items()}, trace, best
-
-
-def test_cpu_does_not_enter_prefetch(monkeypatch):
-    def forbidden(*args, **kwargs):
-        pytest.fail("CPU execution must not initialize CUDA prefetch")
-
-    monkeypatch.setattr(DiffusionTuningCache, "create", forbidden)
-    expected, trace, _ = _tune(monkeypatch, "cpu", 0)
-    actual, other_trace, _ = _tune(monkeypatch, "cpu", 1)
-    assert trace == other_trace
-    assert all(torch.equal(v, actual[k]) for k, v in expected.items())
-
-
-cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
-
-
-@cuda
-@pytest.mark.parametrize("budget", [0.01, "auto"])
-@pytest.mark.parametrize("grad_acc,gap,last", [(1, -1, False), (2, -1, False), (1, 1, False), (1, -1, True)])
-def test_cuda_tuning_equivalence_and_cleanup(monkeypatch, grad_acc, gap, last, budget):
-    caches = []
-    original = DiffusionTuningCache.create
-
-    def capture(*args, **kwargs):
-        cache = original(*args, **kwargs)
-        if cache is not None:
-            caches.append(cache)
-        return cache
-
-    monkeypatch.setattr(DiffusionTuningCache, "create", capture)
-    expected, trace, _ = _tune(monkeypatch, "cuda:0", 0, grad_acc=grad_acc, gap=gap, last=last)
-    actual, other_trace, best = _tune(monkeypatch, "cuda:0", budget, grad_acc=grad_acc, gap=gap, last=last)
-    assert len(caches) == 1
-    assert trace == other_trace
-    assert all(torch.equal(v, actual[k]) for k, v in expected.items())
-    assert caches[0].best["proj"]["value"].is_cuda
-    assert not caches[0].thread.is_alive()
-    assert caches[0].slots == []
-
-
-@cuda
-@pytest.mark.parametrize(
-    "budget,diffusion,low_mem",
-    [(0, True, True), (1, False, True), (1, True, False), ("auto", False, True), ("auto", True, False)],
-)
-def test_cuda_legacy_paths_do_not_create_cache(monkeypatch, budget, diffusion, low_mem):
-    def forbidden(*args, **kwargs):
-        pytest.fail("Legacy paths must not initialize prefetch")
-
-    monkeypatch.setattr(DiffusionTuningCache, "create", forbidden)
-    _tune(monkeypatch, "cuda:0", budget, diffusion=diffusion, low_mem=low_mem)
-
-
-@cuda
-def test_budget_fallback_keeps_quantization(monkeypatch):
-    expected, trace, _ = _tune(monkeypatch, "cuda:0", 0)
-    actual, other_trace, best = _tune(monkeypatch, "cuda:0", 1e-9)
-    assert trace == other_trace
-    assert all(torch.equal(v, actual[k]) for k, v in expected.items())
-    assert not best["proj"]["value"].is_cuda
-
-
-@cuda
-def test_training_exception_closes_worker(monkeypatch):
-    caches = []
-    original = DiffusionTuningCache.create
-
-    def capture(*args, **kwargs):
-        cache = original(*args, **kwargs)
-        caches.append(cache)
-        return cache
-
-    monkeypatch.setattr(DiffusionTuningCache, "create", capture)
-
-    def fail(*args, **kwargs):
-        raise RuntimeError("injected training failure")
-
-    monkeypatch.setattr(SignRoundQuantizer, "_get_loss", fail)
-    with pytest.raises(RuntimeError, match="injected training failure"):
-        _tune(monkeypatch, "cuda:0", 0.01)
-    assert len(caches) == 1
-    assert not caches[0].thread.is_alive()
-    assert caches[0].slots == []
-
-
-def _cache_fixture():
-    block = torch.nn.Linear(4, 4).cuda()
-    block.orig_layer = object()
-    block.params = {"value": torch.ones(4, device="cuda:0")}
-    runner = BlockForwardRunner(batch_size=1, device="cuda:0", cache_device="cpu", amp=False, is_diffusion=True)
-    inputs = {"hidden_states": [torch.full((1, 2, 4), float(i)) for i in range(3)]}
-    outputs = [t.clone() for t in inputs["hidden_states"]]
-    others = {"positional_inputs": []}
-    sampler = IndexSampler(3, 1)
-    sampler.indices = [0, 1, 2]
-    return block, runner, inputs, others, outputs, sampler
-
-
-@cuda
-def test_staging_only_budget_and_dynamic_shape_fallback():
-    block, runner, inputs, others, outputs, sampler = _cache_fixture()
-    # The first batch fits, but the next batch has a different sequence length.
-    inputs["hidden_states"][1] = torch.ones(1, 3, 4)
-    outputs[1] = inputs["hidden_states"][1].clone()
-    staging_bytes = 2 * (_nbytes(inputs["hidden_states"][0]) + _nbytes(outputs[0]))
-    cache = DiffusionTuningCache.create(
-        block, runner, inputs, others, outputs, sampler, 3, staging_bytes / 2**30, "cuda:0"
-    )
-    assert cache is not None and cache.best is None
-    try:
-        batch = cache.get(sampler.next_batch())
-        torch.testing.assert_close(batch[0]["hidden_states"].cpu(), inputs["hidden_states"][0])
-        assert cache.get(sampler.next_batch()) is None
-        assert not cache.thread.is_alive()
-    finally:
-        cache.close()
-
-
-@cuda
-def test_allocation_oom_falls_back(monkeypatch):
-    args = _cache_fixture()
-    empty = torch.empty_like
-
-    def fail_gpu(t, **kwargs):
-        if str(kwargs.get("device", "")).startswith("cuda"):
-            raise torch.OutOfMemoryError("injected allocation failure")
-        return empty(t, **kwargs)
-
-    monkeypatch.setattr(torch, "empty_like", fail_gpu)
-    assert DiffusionTuningCache.create(*args, 3, 0.01, "cuda:0") is None
-
-
-@cuda
-def test_changed_sample_order_falls_back():
-    args = _cache_fixture()
-    cache = DiffusionTuningCache.create(*args, 3, 0.01, "cuda:0")
-    try:
-        assert cache.get([2]) is None
-        assert not cache.thread.is_alive()
-    finally:
-        cache.close()
-
-
-@pytest.mark.parametrize("free_gib,expected_gib", [(0.5, 0), (1, 0), (1.5, 0.5), (2, 1), (10, 5)])
-def test_auto_budget_preserves_headroom(free_gib, expected_gib):
-    assert _auto_budget_bytes(int(free_gib * 2**30)) == expected_gib * 2**30
-
-
-@cuda
-def test_auto_waits_for_full_optimizer_iteration(monkeypatch):
-    steps = []
-    original_step = SignRoundQuantizer._step
-    original_create = DiffusionTuningCache.create
-
-    def step(self, *args):
-        result = original_step(self, *args)
-        steps.append(1)
-        return result
-
-    def create(*args, **kwargs):
-        assert len(steps) == 1
-        return original_create(*args, **kwargs)
-
-    monkeypatch.setattr(SignRoundQuantizer, "_step", step)
-    monkeypatch.setattr(DiffusionTuningCache, "create", create)
-    _tune(monkeypatch, "cuda:0", "auto", grad_acc=2)
-    assert len(steps) == 8
-
-
-@cuda
-def test_auto_low_headroom_keeps_legacy_result(monkeypatch):
-    expected, trace, _ = _tune(monkeypatch, "cuda:0", 0)
-    monkeypatch.setattr(torch.cuda, "mem_get_info", lambda device: (2**30, 32 * 2**30))
-    actual, other_trace, best = _tune(monkeypatch, "cuda:0", "auto")
-    assert trace == other_trace
-    assert all(torch.equal(v, actual[k]) for k, v in expected.items())
-    assert not best["proj"]["value"].is_cuda
-
-
-@cuda
-def test_auto_single_iteration_needs_no_cache(monkeypatch):
-    def forbidden(*args, **kwargs):
-        pytest.fail("One iteration leaves nothing to prefetch")
-
-    monkeypatch.setattr(DiffusionTuningCache, "create", forbidden)
-    _tune(monkeypatch, "cuda:0", "auto", iters=1)
+    cache.inputs = {"hidden_states": torch.arange(24).reshape(3, 2, 4), "scale": 2.0}
+    cache.others = {
+        "temb": torch.ones(3, 2, 4),
+        "freqs": [[torch.ones(1, 2, 4), torch.ones(1, 2, 4) * 2] for _ in range(3)],
+        "positional_inputs": [],
+    }
+    cache.outputs = [torch.ones(1, 2, 4) * i for i in range(3)]
+    batch = cache._select([1])
+    expected = cache.runner.forward(Block(), cache.inputs, cache.others, [1], "cpu")
+    torch.testing.assert_close(cache.forward(Block(), batch, "cpu"), expected)
+    torch.testing.assert_close(batch[2], cache.outputs[1])

--- a/test/unit/common/compressors/test_diffusion_tuning_cache.py
+++ b/test/unit/common/compressors/test_diffusion_tuning_cache.py
@@ -1,0 +1,340 @@
+import random
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from auto_round.algorithms.block_runner import BlockForwardRunner
+from auto_round.algorithms.composer import BlockContext
+from auto_round.algorithms.quantization.sign_round.config import SignRoundConfig
+from auto_round.algorithms.quantization.sign_round.quantizer import SignRoundQuantizer
+from auto_round.compressors.diffusion.tuning_cache import DiffusionTuningCache, _auto_budget_bytes, _batch_plan, _nbytes
+from auto_round.compressors.utils import IndexSampler
+from auto_round.context.compress import CompressContext
+from auto_round.schemes import W4A16
+from auto_round.utils.device_manager import device_manager
+
+
+@pytest.mark.parametrize("nsamples,global_batch", [(5, 1), (5, 2), (4, 4)])
+def test_prefetch_plan_preserves_sampler_and_rng(nsamples, global_batch):
+    state = random.getstate()
+    try:
+        random.seed(31)
+        sampler = IndexSampler(nsamples, global_batch)
+        before = random.getstate()
+        predicted = list(_batch_plan(sampler, 8, 1))
+        assert random.getstate() == before
+        assert sampler.index == 0
+        actual = [[i] for _ in range(8) for i in sampler.next_batch()]
+        assert predicted == actual
+    finally:
+        random.setstate(state)
+
+
+class TinyBlock(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = torch.nn.Linear(32, 32)
+
+    def forward(self, hidden_states, temb=None):
+        return self.proj(hidden_states) + temb
+
+
+def test_tensor_backed_cache_selection():
+    cache = DiffusionTuningCache()
+    cache.runner = BlockForwardRunner(batch_size=1, device="cpu", cache_device="cpu", amp=False, is_diffusion=True)
+    cache.inputs = {"hidden_states": torch.arange(24).reshape(3, 2, 4)}
+    cache.others = {"temb": torch.arange(12).reshape(3, 4), "positional_inputs": []}
+    cache.outputs = [torch.ones(1, 2, 4) * i for i in range(3)]
+    inputs, others, reference = cache._select([1])
+    torch.testing.assert_close(inputs["hidden_states"], cache.inputs["hidden_states"][1:2])
+    torch.testing.assert_close(others["temb"], cache.others["temb"][1:2])
+    torch.testing.assert_close(reference, cache.outputs[1])
+
+
+def test_prefetched_forward_preserves_scalar_inputs():
+    class ScaleBlock(torch.nn.Module):
+        def forward(self, hidden_states, scale):
+            return hidden_states * scale
+
+    cache = DiffusionTuningCache()
+    cache.runner = BlockForwardRunner(batch_size=1, device="cpu", cache_device="cpu", amp=False, is_diffusion=True)
+    hidden = torch.ones(1, 2, 4)
+    batch = ({"hidden_states": hidden, "scale": 2.0}, {"positional_inputs": []}, hidden)
+    torch.testing.assert_close(cache.forward(ScaleBlock(), batch, "cpu"), 2 * hidden)
+
+
+@pytest.mark.parametrize("shared", [True, False])
+def test_prefetched_forward_preserves_list_conditioning(shared):
+    class ConditionedBlock(torch.nn.Module):
+        def forward(self, hidden_states, freqs):
+            return hidden_states + freqs[0] + freqs[1]
+
+    cache = DiffusionTuningCache()
+    cache.runner = BlockForwardRunner(
+        batch_size=1,
+        device="cpu",
+        cache_device="cpu",
+        amp=False,
+        is_diffusion=True,
+        shared_cache_keys=("freqs",) if shared else (),
+    )
+    cache.inputs = {"hidden_states": [torch.ones(1, 2, 4)]}
+    cache.others = {"freqs": [[torch.ones(1, 2, 4), torch.ones(1, 2, 4) * 2]], "positional_inputs": []}
+    cache.outputs = cache.inputs["hidden_states"]
+    expected = cache.runner.forward(ConditionedBlock(), cache.inputs, cache.others, [0], "cpu")
+    batch = cache._select([0])
+    torch.testing.assert_close(cache.forward(ConditionedBlock(), batch, "cpu"), expected)
+
+
+def _tune(monkeypatch, device, budget, *, diffusion=True, low_mem=True, grad_acc=1, gap=-1, last=False, iters=8):
+    torch.manual_seed(12)
+    random.seed(34)
+    monkeypatch.setattr(device_manager, "device", device)
+    monkeypatch.setattr(device_manager, "_device_list", [device])
+    block = TinyBlock().to(device).eval().requires_grad_(False)
+    inputs = {"hidden_states": [torch.randn(1, 8, 32) for _ in range(5)]}
+    others = {"temb": [torch.randn(1, 8, 32) for _ in range(5)], "positional_inputs": []}
+    outputs = [
+        block(x.to(device), t.to(device)).detach().cpu() for x, t in zip(inputs["hidden_states"], others["temb"])
+    ]
+    scheme = W4A16.copy()
+    for key, value in scheme.to_dict().items():
+        setattr(block.proj, key, value)
+    block.proj.scale_dtype = torch.float32
+    CompressContext.reset_context()
+    cc = CompressContext(low_gpu_mem_usage=low_mem, enable_torch_compile=False)
+    config = SignRoundConfig(
+        scheme=scheme,
+        iters=iters,
+        lr=0.005,
+        minmax_lr=0.005,
+        gradient_accumulate_steps=grad_acc,
+        dynamic_max_gap=gap,
+        not_use_best_mse=last,
+    )
+    quantizer = SignRoundQuantizer(config)
+    quantizer.bind(
+        SimpleNamespace(
+            model_context=SimpleNamespace(
+                model=block,
+                is_diffusion=diffusion,
+                amp=False,
+                amp_dtype=torch.float32,
+                diffusion_tuning_cache_size=budget,
+            ),
+            compress_context=cc,
+            calibration_context=SimpleNamespace(batch_size=1, batch_dim=0),
+            scale_dtype=torch.float32,
+            scheme_context=scheme,
+        )
+    )
+    runner = BlockForwardRunner(
+        batch_size=1, device=device, cache_device="cpu", amp=False, is_diffusion=True, enable_torch_compile=False
+    )
+    quantizer.bind_block_forward_runner(runner)
+    trace = []
+    get_loss = quantizer._get_loss
+
+    def record_loss(pred, ref, indices, *args):
+        loss = get_loss(pred, ref, indices, *args)
+        trace.append((list(indices), loss.detach().cpu().item()))
+        return loss
+
+    quantizer._get_loss = record_loss
+    best = quantizer.quantize_block(
+        block,
+        inputs,
+        others,
+        outputs,
+        None,
+        BlockContext(model=block, block_names=["blocks.0"], block_index=0, block_cnt=1, block_name="blocks.0"),
+    )
+    assert runner.cache_device == "cpu"
+    return {k: v.detach().cpu().clone() for k, v in block.state_dict().items()}, trace, best
+
+
+def test_cpu_does_not_enter_prefetch(monkeypatch):
+    def forbidden(*args, **kwargs):
+        pytest.fail("CPU execution must not initialize CUDA prefetch")
+
+    monkeypatch.setattr(DiffusionTuningCache, "create", forbidden)
+    expected, trace, _ = _tune(monkeypatch, "cpu", 0)
+    actual, other_trace, _ = _tune(monkeypatch, "cpu", 1)
+    assert trace == other_trace
+    assert all(torch.equal(v, actual[k]) for k, v in expected.items())
+
+
+cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+@cuda
+@pytest.mark.parametrize("budget", [0.01, "auto"])
+@pytest.mark.parametrize("grad_acc,gap,last", [(1, -1, False), (2, -1, False), (1, 1, False), (1, -1, True)])
+def test_cuda_tuning_equivalence_and_cleanup(monkeypatch, grad_acc, gap, last, budget):
+    caches = []
+    original = DiffusionTuningCache.create
+
+    def capture(*args, **kwargs):
+        cache = original(*args, **kwargs)
+        if cache is not None:
+            caches.append(cache)
+        return cache
+
+    monkeypatch.setattr(DiffusionTuningCache, "create", capture)
+    expected, trace, _ = _tune(monkeypatch, "cuda:0", 0, grad_acc=grad_acc, gap=gap, last=last)
+    actual, other_trace, best = _tune(monkeypatch, "cuda:0", budget, grad_acc=grad_acc, gap=gap, last=last)
+    assert len(caches) == 1
+    assert trace == other_trace
+    assert all(torch.equal(v, actual[k]) for k, v in expected.items())
+    assert caches[0].best["proj"]["value"].is_cuda
+    assert not caches[0].thread.is_alive()
+    assert caches[0].slots == []
+
+
+@cuda
+@pytest.mark.parametrize(
+    "budget,diffusion,low_mem",
+    [(0, True, True), (1, False, True), (1, True, False), ("auto", False, True), ("auto", True, False)],
+)
+def test_cuda_legacy_paths_do_not_create_cache(monkeypatch, budget, diffusion, low_mem):
+    def forbidden(*args, **kwargs):
+        pytest.fail("Legacy paths must not initialize prefetch")
+
+    monkeypatch.setattr(DiffusionTuningCache, "create", forbidden)
+    _tune(monkeypatch, "cuda:0", budget, diffusion=diffusion, low_mem=low_mem)
+
+
+@cuda
+def test_budget_fallback_keeps_quantization(monkeypatch):
+    expected, trace, _ = _tune(monkeypatch, "cuda:0", 0)
+    actual, other_trace, best = _tune(monkeypatch, "cuda:0", 1e-9)
+    assert trace == other_trace
+    assert all(torch.equal(v, actual[k]) for k, v in expected.items())
+    assert not best["proj"]["value"].is_cuda
+
+
+@cuda
+def test_training_exception_closes_worker(monkeypatch):
+    caches = []
+    original = DiffusionTuningCache.create
+
+    def capture(*args, **kwargs):
+        cache = original(*args, **kwargs)
+        caches.append(cache)
+        return cache
+
+    monkeypatch.setattr(DiffusionTuningCache, "create", capture)
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("injected training failure")
+
+    monkeypatch.setattr(SignRoundQuantizer, "_get_loss", fail)
+    with pytest.raises(RuntimeError, match="injected training failure"):
+        _tune(monkeypatch, "cuda:0", 0.01)
+    assert len(caches) == 1
+    assert not caches[0].thread.is_alive()
+    assert caches[0].slots == []
+
+
+def _cache_fixture():
+    block = torch.nn.Linear(4, 4).cuda()
+    block.orig_layer = object()
+    block.params = {"value": torch.ones(4, device="cuda:0")}
+    runner = BlockForwardRunner(batch_size=1, device="cuda:0", cache_device="cpu", amp=False, is_diffusion=True)
+    inputs = {"hidden_states": [torch.full((1, 2, 4), float(i)) for i in range(3)]}
+    outputs = [t.clone() for t in inputs["hidden_states"]]
+    others = {"positional_inputs": []}
+    sampler = IndexSampler(3, 1)
+    sampler.indices = [0, 1, 2]
+    return block, runner, inputs, others, outputs, sampler
+
+
+@cuda
+def test_staging_only_budget_and_dynamic_shape_fallback():
+    block, runner, inputs, others, outputs, sampler = _cache_fixture()
+    # The first batch fits, but the next batch has a different sequence length.
+    inputs["hidden_states"][1] = torch.ones(1, 3, 4)
+    outputs[1] = inputs["hidden_states"][1].clone()
+    staging_bytes = 2 * (_nbytes(inputs["hidden_states"][0]) + _nbytes(outputs[0]))
+    cache = DiffusionTuningCache.create(
+        block, runner, inputs, others, outputs, sampler, 3, staging_bytes / 2**30, "cuda:0"
+    )
+    assert cache is not None and cache.best is None
+    try:
+        batch = cache.get(sampler.next_batch())
+        torch.testing.assert_close(batch[0]["hidden_states"].cpu(), inputs["hidden_states"][0])
+        assert cache.get(sampler.next_batch()) is None
+        assert not cache.thread.is_alive()
+    finally:
+        cache.close()
+
+
+@cuda
+def test_allocation_oom_falls_back(monkeypatch):
+    args = _cache_fixture()
+    empty = torch.empty_like
+
+    def fail_gpu(t, **kwargs):
+        if str(kwargs.get("device", "")).startswith("cuda"):
+            raise torch.OutOfMemoryError("injected allocation failure")
+        return empty(t, **kwargs)
+
+    monkeypatch.setattr(torch, "empty_like", fail_gpu)
+    assert DiffusionTuningCache.create(*args, 3, 0.01, "cuda:0") is None
+
+
+@cuda
+def test_changed_sample_order_falls_back():
+    args = _cache_fixture()
+    cache = DiffusionTuningCache.create(*args, 3, 0.01, "cuda:0")
+    try:
+        assert cache.get([2]) is None
+        assert not cache.thread.is_alive()
+    finally:
+        cache.close()
+
+
+@pytest.mark.parametrize("free_gib,expected_gib", [(0.5, 0), (1, 0), (1.5, 0.5), (2, 1), (10, 5)])
+def test_auto_budget_preserves_headroom(free_gib, expected_gib):
+    assert _auto_budget_bytes(int(free_gib * 2**30)) == expected_gib * 2**30
+
+
+@cuda
+def test_auto_waits_for_full_optimizer_iteration(monkeypatch):
+    steps = []
+    original_step = SignRoundQuantizer._step
+    original_create = DiffusionTuningCache.create
+
+    def step(self, *args):
+        result = original_step(self, *args)
+        steps.append(1)
+        return result
+
+    def create(*args, **kwargs):
+        assert len(steps) == 1
+        return original_create(*args, **kwargs)
+
+    monkeypatch.setattr(SignRoundQuantizer, "_step", step)
+    monkeypatch.setattr(DiffusionTuningCache, "create", create)
+    _tune(monkeypatch, "cuda:0", "auto", grad_acc=2)
+    assert len(steps) == 8
+
+
+@cuda
+def test_auto_low_headroom_keeps_legacy_result(monkeypatch):
+    expected, trace, _ = _tune(monkeypatch, "cuda:0", 0)
+    monkeypatch.setattr(torch.cuda, "mem_get_info", lambda device: (2**30, 32 * 2**30))
+    actual, other_trace, best = _tune(monkeypatch, "cuda:0", "auto")
+    assert trace == other_trace
+    assert all(torch.equal(v, actual[k]) for k, v in expected.items())
+    assert not best["proj"]["value"].is_cuda
+
+
+@cuda
+def test_auto_single_iteration_needs_no_cache(monkeypatch):
+    def forbidden(*args, **kwargs):
+        pytest.fail("One iteration leaves nothing to prefetch")
+
+    monkeypatch.setattr(DiffusionTuningCache, "create", forbidden)
+    _tune(monkeypatch, "cuda:0", "auto", iters=1)

--- a/test/unit/common/compressors/test_diffusion_tuning_cache.py
+++ b/test/unit/common/compressors/test_diffusion_tuning_cache.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import random
 
 import pytest

--- a/test/unit/common/core/test_entry_normalization.py
+++ b/test/unit/common/core/test_entry_normalization.py
@@ -14,6 +14,16 @@ def _types(configs):
     return [type(config).__name__ for config in configs]
 
 
+@pytest.mark.parametrize("value,expected", [("auto", "auto"), ("2", 2.0), ("0", 0.0)])
+def test_diffusion_cache_cli_and_entry_routing(value, expected):
+    from auto_round.cli.main import _build_entry_model_type_kwargs
+    from auto_round.cli.parser import build_quantize_parser
+
+    args = build_quantize_parser().parse_args(["--diffusion_tuning_cache_size", value])
+    grouped = _split_entry_kwargs(_build_entry_model_type_kwargs(args))
+    assert grouped["diffusion"]["diffusion_tuning_cache_size"] == expected
+
+
 def test_split_entry_kwargs_partitions_owned_fields():
     processor = object()
 
@@ -25,6 +35,7 @@ def test_split_entry_kwargs_partitions_owned_fields():
             "model_free": False,
             "num_inference_steps": 20,
             "calib_num_inference_steps": 8,
+            "diffusion_tuning_cache_size": 2,
         }
     )
 
@@ -34,6 +45,7 @@ def test_split_entry_kwargs_partitions_owned_fields():
     assert grouped["route"]["model_free"] is False
     assert grouped["diffusion"]["num_inference_steps"] == 20
     assert grouped["diffusion"]["calib_num_inference_steps"] == 8
+    assert grouped["diffusion"]["diffusion_tuning_cache_size"] == 2
 
 
 def test_split_entry_kwargs_ignores_unknown_fields(monkeypatch):

--- a/test/unit/test_cuda/models/test_diffusion.py
+++ b/test/unit/test_cuda/models/test_diffusion.py
@@ -61,8 +61,21 @@ class TestAutoRound:
         autoround.quantize_and_save(tmp_path)
 
     @require_optimum
-    def test_diffusion_tune(self, tiny_flux_model_path, tmp_path):
+    @pytest.mark.parametrize("low_gpu_mem_usage,cache_size", [(False, 0), (True, "auto"), (True, 1e-9)])
+    def test_diffusion_tune(self, tiny_flux_model_path, tmp_path, monkeypatch, low_gpu_mem_usage, cache_size):
         from diffusers import AutoPipelineForText2Image
+
+        from auto_round.compressors.diffusion.tuning_cache import DiffusionTuningCache
+
+        caches = []
+        create_cache = DiffusionTuningCache.create
+
+        def capture_cache(*args, **kwargs):
+            cache = create_cache(*args, **kwargs)
+            caches.append(cache)
+            return cache
+
+        monkeypatch.setattr(DiffusionTuningCache, "create", capture_cache)
 
         ## load the model
         pipe = AutoPipelineForText2Image.from_pretrained(tiny_flux_model_path)
@@ -86,14 +99,24 @@ class TestAutoRound:
             pipe,
             tokenizer=None,
             scheme="MXFP4",
-            iters=1,
+            iters=2,
             nsamples=1,
             calib_num_inference_steps=2,
             layer_config=layer_config,
             dataset="coco2014",
+            low_gpu_mem_usage=low_gpu_mem_usage,
+            diffusion_tuning_cache_size=cache_size,
         )
         # skip model saving since it takes much time
         autoround.quantize_and_save(tmp_path)
+
+        if cache_size == "auto":
+            assert any(cache is not None for cache in caches)
+            assert all(not cache.thread.is_alive() and not cache.slots for cache in caches if cache is not None)
+        elif cache_size:
+            assert caches and all(cache is None for cache in caches)
+        else:
+            assert not caches
 
     @pytest.mark.skip_ci(reason="Architecture: Download large model; Time-consuming")
     def test_diffusion_model_checker(self):


### PR DESCRIPTION
## Motivation                                                                                                                                                                                             
                                                                                                                                                                                                            
  Repeated CPU-to-GPU cache transfers can become a bottleneck during Wan2.2 tuning with `low_gpu_mem_usage=True`.

  For Wan2.2 T2V-A14B at 480×832 resolution and 81 frames:
  - Video tokens: 21 × 30 × 52 = 32,760.
  - One BF16 hidden-state tensor: 32,760 × 5,120 × 2 bytes ≈ 0.312 GiB.
  - A cached block input and reference output together occupy approximately 0.625 GiB per sample, assuming both are BF16.
  - For 128 cached samples, these tensors alone require approximately 80 GiB, excluding conditioning tensors, model weights, and tuning activations.

  Keeping these caches on CPU reduces GPU memory usage, but repeatedly transferring selected batches can leave the GPU waiting for data.


## Description
  Add `diffusion_tuning_cache_size` to enable bounded prefetching with two reusable buffers and optional GPU storage for best-parameter snapshots. Set it to `"auto"` to determine the budget after warmup,
  or specify a budget in GiB. Insufficient memory falls back to the existing path.

  Disabled by default and limited to single-GPU diffusion SignRound tuning.

  Usage example (single-GPU Wan2.2 T2V-A14B):

  ```bash
  CUDA_VISIBLE_DEVICES=0 auto-round \
      --model Wan-AI/Wan2.2-T2V-A14B-Diffusers \
      --scheme MXFP4 \
      --model_dtype bf16 \
      --format fake \
      --batch_size 1 \
      --dataset coco2014 \
      --calib_num_inference_steps 8 \
      --low_gpu_mem_usage \
      --diffusion_tuning_cache_size auto \
      --output_dir ./wan2.2-a14b-mxfp4
  ```

  `auto` selects the extra GPU cache budget after the first tuning iteration. Alternatively, use a numeric value such as `8` for an 8 GiB cache budget. This budget applies to the additional cache buffers,
  not total GPU memory usage.

  The feature requires `low_gpu_mem_usage`. Omit `diffusion_tuning_cache_size` or set it to `0` to retain the existing behavior.

## performance improve with wan2.2 T2V
device: b300

main branch, quantize transformer about need 5 hours 44 mins.
```
CUDA_VISIBLE_DEVICES=0  auto_round   --model /models/Wan2.2-T2V-A14B-Diffusers   --model_dtype bf16   --scheme MXFP4   --iters 50   --nsamples 32   --batch_size 1    --calib_num_inference_steps 8   --format llm_compressor   --device 0   --disable_low_cpu_mem_usage   --output_dir /models/changwa1/wan22-mxfp4-n32-i50   --low_gpu_mem_usage 
```
```
2026-09-10 02:07:13 INFO orchestrator.py L619: caching done
Quantizing blocks.0:   0%|                                                                               | 0/40 [00:06<?, ?it/s]
quantized 10/10 layers in the block, loss iter 0: 3.508e-03 -> iter 48: 6.870e-04
2026-09-10 02:17:52 INFO device.py L1450: 'peak_ram': 619.49GB, 'peak_vram': 28.9GB
Quantizing blocks.1:   2%|█▋                                                                  | 1/40 [10:47<7:01:00, 647.70s/it]
quantized 10/10 layers in the block, loss iter 0: 4.217e-03 -> iter 35: 2.298e-03
2026-09-10 02:27:47 INFO device.py L1450: 'peak_ram': 632.47GB, 'peak_vram': 28.9GB
Quantizing blocks.2:   5%|███▍                                                                | 2/40 [20:34<6:27:26, 611.75s/it]
quantized 10/10 layers in the block, loss iter 0: 1.036e-02 -> iter 49: 3.589e-03
2026-09-10 02:37:16 INFO device.py L1450: 'peak_ram': 632.47GB, 'peak_vram': 28.9GB
Quantizing blocks.3:   8%|█████                                                               | 3/40 [30:02<6:05:06, 592.07s/it]
quantized 10/10 layers in the block, loss iter 0: 6.333e-03 -> iter 43: 4.098e-03
...
Quantizing blocks.37:  92%|█████████████████████████████████████████████████████████████     | 37/40 [5:16:13<25:55, 518.51s/it]
quantized 10/10 layers in the block, loss iter 0: 1.815e-01 -> iter 42: 7.170e-02
2026-09-10 07:32:53 INFO device.py L1450: 'peak_ram': 632.47GB, 'peak_vram': 28.9GB
Quantizing blocks.38:  95%|██████████████████████████████████████████████████████████████▋   | 38/40 [5:25:40<17:45, 532.96s/it]
quantized 10/10 layers in the block, loss iter 0: 3.492e-01 -> iter 46: 4.190e-02
2026-09-10 07:42:23 INFO device.py L1450: 'peak_ram': 632.47GB, 'peak_vram': 28.9GB
Quantizing blocks.39:  98%|████████████████████████████████████████████████████████████████▎ | 39/40 [5:35:10<09:04, 544.10s/it]
quantized 10/10 layers in the block, loss iter 0: 6.446e-02 -> iter 39: 4.421e-02
2026-09-10 07:51:25 INFO device.py L1450: 'peak_ram': 632.47GB, 'peak_vram': 28.9GB
Quantizing done: 100%|███████████████████████████████████████████████████████████████████████| 40/40 [5:44:36<00:00, 516.90s/it]
2026-09-10 07:51:49 INFO device.py L1450: 'peak_ram': 632.47GB, 'peak_vram': 28.9GB
2026-09-10 07:51:49 INFO orchestrator.py L808: quantization tuning time 20676.152049064636
2026-09-10 07:51:49 INFO orchestrator.py L827: Summary: quantized 401/407 in the model, unquantized layers: condition_embedder.text_embedder.linear_1, condition_embedder.text_embedder.linear_2, condition_embedder.time_embedder.linear_1, condition_embedder.time_embedder.linear_2, condition_embedder.time_proj, proj_out
```
with this pr, reduce to about 2 hours 45 min.
```
CUDA_VISIBLE_DEVICES=1  auto_round   --model /models/Wan2.2-T2V-A14B-Diffusers   --model_dtype bf16   --scheme MXFP4   --iters 50   --nsamples 32   --batch_size 1    --calib_num_inference_steps 8   --format llm_compressor   --device 0   --disable_low_cpu_mem_usage   --output_dir /models/changwa1/wan22-mxfp4-n32-i50-prefetch   --low_gpu_mem_usage --diffusion_tuning_cache_size auto
```
```
2026-09-10 10:51:12 INFO orchestrator.py L619: caching done
Quantizing blocks.0:   0%|                                                                               | 0/40 [00:05<?, ?it/s]2026-09-10 10:53:41 INFO tuning_cache.py L92: Diffusion tuning auto cache budget after warmup: 120.20 GiB.
2026-09-10 10:53:42 INFO tuning_cache.py L122: Diffusion tuning prefetch enabled with 2.68 GiB of GPU buffers; best parameters on GPU.
quantized 10/10 layers in the block, loss iter 0: 3.771e-03 -> iter 48: 3.993e-04
2026-09-10 10:55:29 INFO device.py L1560: 'peak_ram': 256.99GB, 'peak_vram': 28.11GB
Quantizing blocks.1:   2%|█▋                                                                  | 1/40 [04:23<2:51:10, 263.34s/it]
quantized 10/10 layers in the block, loss iter 0: 1.610e-02 -> iter 30: 1.638e-03
2026-09-10 10:59:34 INFO device.py L1560: 'peak_ram': 268.48GB, 'peak_vram': 28.15GB
Quantizing blocks.2:   5%|███▍                                                                | 2/40 [08:22<2:37:42, 249.01s/it]
quantized 10/10 layers in the block, loss iter 0: 6.369e-03 -> iter 42: 2.355e-03
2026-09-10 11:04:08 INFO device.py L1560: 'peak_ram': 268.48GB, 'peak_vram': 28.15GB
Quantizing blocks.3:   8%|█████                                                               | 3/40 [12:56<2:40:35, 260.43s/it]
quantized 10/10 layers in the block, loss iter 0: 5.187e-03 -> iter 48: 3.225e-03
...
Quantizing blocks.38:  95%|██████████████████████████████████████████████████████████████▋   | 38/40 [2:38:22<07:47, 233.64s/it]
quantized 10/10 layers in the block, loss iter 0: 1.369e-01 -> iter 45: 3.600e-02
2026-09-10 13:33:10 INFO device.py L1560: 'peak_ram': 268.48GB, 'peak_vram': 28.15GB
Quantizing blocks.39:  98%|████████████████████████████████████████████████████████████████▎ | 39/40 [2:41:58<03:48, 228.30s/it]
quantized 10/10 layers in the block, loss iter 0: 1.710e-01 -> iter 39: 3.392e-02
2026-09-10 13:36:50 INFO device.py L1560: 'peak_ram': 268.48GB, 'peak_vram': 28.15GB
Quantizing done: 100%|███████████████████████████████████████████████████████████████████████| 40/40 [2:45:51<00:00, 248.78s/it]
2026-09-10 13:37:03 INFO device.py L1560: 'peak_ram': 268.48GB, 'peak_vram': 28.15GB
2026-09-10 13:37:03 INFO orchestrator.py L808: quantization tuning time 9951.35483789444
2026-09-10 13:37:03 INFO orchestrator.py L827: Summary: quantized 401/407 in the model, unquantized layers: condition_embedder.text_embedder.linear_1, condition_embedder.text_embedder.linear_2, condition_embedder.time_embedder.linear_1, condition_embedder.time_embedder.linear_2, condition_embedder.time_proj, proj_out

```


## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

New feature

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #2279 

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
