### PR TITLE
Refine device operations into a unified DeviceManager and ARDevice abstraction 

### DIFF
--- a/auto_round/algorithms/transforms/hadamard/inplace/apply.py
+++ b/auto_round/algorithms/transforms/hadamard/inplace/apply.py
@@ -35,6 +35,7 @@ from auto_round.algorithms.transforms.hadamard.inplace.model_config import (
     _resolve,
     infer_mapping_from_model,
 )
+from auto_round.utils.device_manager import get_current_device_manager
 
 # ---------------------------------------------------------------------------
 # Low-level primitives (model-agnostic via RotationMapping)
@@ -406,8 +407,7 @@ def _rotate_weights(
             _rotate_linear_by_Q(lm_head, Q, side="input", compute_device=compute_device)
 
     gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
+    get_current_device_manager().empty_cache()
 
     # ---- Per-layer rotation ----
     layers = _resolve(model, mapping.layers_attr)
@@ -639,12 +639,12 @@ def _rotate_weights(
                     had_matrix=_online_had(intermediate_size),
                 )
 
-        # Per-layer cleanup: drop fp64 temporaries and CUDA caching allocator
-        # blocks so peak memory stays at ~1 layer's worth instead of accumulating
-        # across all 32+ decoder layers (was the main cause of 33 GB RAM on 8B).
+        # Per-layer cleanup: drop fp64 temporaries and accelerator caching
+        # allocator blocks so peak memory stays at ~1 layer's worth instead of
+        # accumulating across all 32+ decoder layers (was the main cause of
+        # 33 GB RAM on 8B).
         gc.collect()
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+        get_current_device_manager().empty_cache()
 
 
 # ---------------------------------------------------------------------------

--- a/auto_round/algorithms/transforms/hadamard/inplace/hooks.py
+++ b/auto_round/algorithms/transforms/hadamard/inplace/hooks.py
@@ -23,19 +23,17 @@ except ImportError:
 def _resolve_compute_device(compute_device) -> torch.device:
     """Return *compute_device* if explicitly given, otherwise auto-detect GPU.
 
-    When ``compute_device`` is ``None`` the function checks for CUDA / XPU
-    availability and returns the first accelerator it finds so that heavy
-    matrix operations are offloaded to GPU even when the model weights live
-    on CPU.  Falls back to ``torch.device("cpu")`` when no accelerator is
-    present.
+    When ``compute_device`` is ``None`` the active accelerator reported by the
+    device manager is used, so heavy matrix operations are offloaded to it even
+    when the model weights live on CPU.  Backends excluded from implicit
+    selection (see ``ARDevice.auto_select_by_default``) and CPU-only hosts fall
+    back to ``torch.device("cpu")``.
     """
     if compute_device is not None:
         return torch.device(compute_device) if not isinstance(compute_device, torch.device) else compute_device
-    if torch.cuda.is_available():
-        return torch.device("cuda:0")
-    if hasattr(torch, "xpu") and torch.xpu.is_available():
-        return torch.device("xpu:0")
-    return torch.device("cpu")
+    from auto_round.utils.device_manager import get_active_device
+
+    return get_active_device()
 
 
 BUILTIN_ROTATION_PRESETS = {"quarot_hadamard", "hadamard", "random_hadamard"}

--- a/auto_round/algorithms/transforms/spinquant/preprocessor.py
+++ b/auto_round/algorithms/transforms/spinquant/preprocessor.py
@@ -134,7 +134,9 @@ class SpinQuantConfig(BaseRotationConfig):
 
     def __post_init__(self):
         if self.device is None:
-            self.device = "cuda" if torch.cuda.is_available() else "cpu"
+            from auto_round.utils.device_manager import get_major_device
+
+            self.device = get_major_device()
         if self.rotation_size is not None:
             if self.rotation_size <= 0:
                 raise ValueError(f"rotation_size must be positive, got {self.rotation_size}")
@@ -606,8 +608,9 @@ class SpinQuantPreprocessor:
         )
 
         del original_model
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+        from auto_round.utils.device_manager import get_current_device_manager
+
+        get_current_device_manager().empty_cache()
 
     def _get_embed_tokens(self) -> Optional[nn.Module]:
         """Get embedding module, supporting both model.embed_tokens and model.model.embed_tokens."""

--- a/auto_round/algorithms/transforms/spinquant/training.py
+++ b/auto_round/algorithms/transforms/spinquant/training.py
@@ -490,7 +490,9 @@ class RotationTrainerConfig:
 
     def __post_init__(self):
         if self.device is None:
-            self.device = "cuda" if torch.cuda.is_available() else "cpu"
+            from auto_round.utils.device_manager import get_major_device
+
+            self.device = get_major_device()
 
 
 class RotationTrainerCallback:
@@ -880,8 +882,9 @@ class RotationTrainer:
         if self._original_model is not None:
             del self._original_model
             self._original_model = None
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
+            from auto_round.utils.device_manager import get_current_device_manager
+
+            get_current_device_manager().empty_cache()
         self.model.eval()
 
     def _trigger_event(self, event_name: str, **kwargs) -> None:

--- a/auto_round/calibration/llm.py
+++ b/auto_round/calibration/llm.py
@@ -100,7 +100,10 @@ class LLMCalibrator(Calibrator):
                 if hasattr(self.model, "hf_device_map") and len(self.model.hf_device_map) > 1:
                     dispatch_model(self.model, device_map=self.model.hf_device_map)
                 else:
-                    if str(self.model.device) == "cpu" and get_ar_device(device_manager.device).supports_device_map_dispatch:
+                    if (
+                        str(self.model.device) == "cpu"
+                        and get_ar_device(device_manager.device).supports_device_map_dispatch
+                    ):
                         no_split_modules = list(getattr(self.model, "_no_split_modules", []))
                         devices = parse_available_devices(device_manager.device_map)
 

--- a/auto_round/calibration/llm.py
+++ b/auto_round/calibration/llm.py
@@ -46,7 +46,7 @@ from auto_round.utils import (
     to_dtype,
 )
 from auto_round.utils.device import parse_available_devices
-from auto_round.utils.device_manager import device_manager
+from auto_round.utils.device_manager import device_manager, get_ar_device
 
 
 @register_calibrator("llm")
@@ -100,7 +100,7 @@ class LLMCalibrator(Calibrator):
                 if hasattr(self.model, "hf_device_map") and len(self.model.hf_device_map) > 1:
                     dispatch_model(self.model, device_map=self.model.hf_device_map)
                 else:
-                    if str(self.model.device) == "cpu" and (not device_manager.device.startswith("hpu")):
+                    if str(self.model.device) == "cpu" and get_ar_device(device_manager.device).supports_device_map_dispatch:
                         no_split_modules = list(getattr(self.model, "_no_split_modules", []))
                         devices = parse_available_devices(device_manager.device_map)
 

--- a/auto_round/inference/convert_model.py
+++ b/auto_round/inference/convert_model.py
@@ -44,7 +44,6 @@ from auto_round.utils import (
     get_block_names,
     get_checkpoint_conversion_mapping,
     get_module,
-    is_hpex_available,
     is_transformers_version_greater_or_equal_5,
     set_module,
 )
@@ -164,26 +163,15 @@ def get_available_devices():
     """
     Returns a list of available devices in the current environment.
 
+    Any backend PyTorch exposes (cuda/xpu/hpu/mps/npu/...) is discovered by the
+    device manager, so no per-device probing is needed here.
+
     Returns:
         List[str]: A list of device identifiers like "cuda", "hpu", "xpu", "cpu".
     """
-    devices = []
+    from auto_round.utils.device_manager import get_available_device_types
 
-    if torch.cuda.is_available():
-        devices.append("cuda")
-
-    if is_hpex_available():
-        devices.append("hpu")
-
-    if hasattr(torch, "xpu") and torch.xpu.is_available():
-        devices.append("xpu")
-
-    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-        devices.append("mps")
-
-    devices.append("cpu")  # Always available
-
-    return devices
+    return [*get_available_device_types(), "cpu"]  # CPU is always available
 
 
 def _remap_paths_for_text_model(model, quant_block_list, extra_config):

--- a/auto_round/utils/common.py
+++ b/auto_round/utils/common.py
@@ -387,7 +387,9 @@ def _patch_nvfp4_e5m3_compressed_tensors_quantizer():
         from auto_round.inference.convert_model import convert_hf_model
 
         model.config.quantization_config = self.compressor.quantization_config
-        target_device = "cuda" if torch.cuda.is_available() else "cpu"
+        from auto_round.utils.device_manager import get_major_device
+
+        target_device = get_major_device()
         model, _ = convert_hf_model(model, target_device=target_device)
         self.run_compressed = True
         return model

--- a/auto_round/utils/device.py
+++ b/auto_round/utils/device.py
@@ -19,6 +19,7 @@ import re
 import shutil
 import sys
 import tempfile
+from collections.abc import Mapping
 from contextlib import ContextDecorator, contextmanager
 from functools import lru_cache
 from threading import Lock
@@ -32,21 +33,46 @@ from accelerate.utils import get_balanced_memory, get_max_memory
 
 from auto_round.logger import logger
 from auto_round.utils.device_manager import (
+    ARDevice,
     clear_memory,
     detect_device_count,
     get_ar_device,
     get_available_device_types,
     get_current_device_manager,
+    get_current_device_type,
     get_device_memory,
     get_major_device,
 )
 from auto_round.utils.model import check_to_quantized, get_block_names, get_layer_features, get_module
 
-DEVICE_ENVIRON_VARIABLE_MAPPING = {
-    "cuda": "CUDA_VISIBLE_DEVICES",
-    "xpu": "ZE_AFFINITY_MASK",
-    "hpu": "HABANA_VISIBLE_MODULES",
-}
+
+class _VisibleDevicesEnvMapping(Mapping):
+    """``{device_type: env var}`` view backed by the :class:`ARDevice` registry.
+
+    Keeps the historical ``DEVICE_ENVIRON_VARIABLE_MAPPING[...]`` / ``in`` usage
+    working while making a new backend's env var come from its handle, so no
+    table has to be edited when a device is added.
+    """
+
+    @staticmethod
+    def _env_var(device_type: str) -> Optional[str]:
+        device_cls = ARDevice._registry.get(device_type)
+        return device_cls.visible_devices_env_var if device_cls is not None else None
+
+    def __getitem__(self, device_type: str) -> str:
+        env_var = self._env_var(device_type)
+        if env_var is None:
+            raise KeyError(device_type)
+        return env_var
+
+    def __iter__(self):
+        return (dtype for dtype, cls in ARDevice._registry.items() if cls.visible_devices_env_var)
+
+    def __len__(self) -> int:
+        return sum(1 for _ in iter(self))
+
+
+DEVICE_ENVIRON_VARIABLE_MAPPING = _VisibleDevicesEnvMapping()
 
 # Note on HPU usage:
 # There are two modes available for enabling auto-round on HPU:
@@ -290,40 +316,59 @@ def check_is_cpu(device):
 def is_pipeline_parallel_supported(device_type: str) -> bool:
     """Whether multi-card (naive pipeline) parallel tuning is enabled.
 
-    Split out of ``get_device_and_parallelism`` so the parallelism policy stays a
-    standalone concern instead of living on the device manager.  Currently only
-    CUDA supports multi-card pipeline parallel tuning.
+    The policy itself lives on the backend handle
+    (:attr:`ARDevice.supports_pipeline_parallel`), so a new device declares it
+    once instead of being special-cased here.
     """
-    return device_type == "cuda"
+    return get_ar_device(device_type).supports_pipeline_parallel
+
+
+def set_visible_devices(device: str, device_type: Optional[str] = None) -> None:
+    """Restrict the visible cards of ``device_type`` to the requested indices.
+
+    Works for any backend that declares a ``visible_devices_env_var`` (e.g.
+    ``CUDA_VISIBLE_DEVICES`` for CUDA, ``ZE_AFFINITY_MASK`` for XPU); backends
+    without one are silently ignored.
+    """
+    if device is None:
+        return
+    device = str(device).replace(" ", "")
+    if not device or device == "auto":
+        return
+    if device_type is None:
+        head = device.split(",")[0].split(":")[0]
+        device_type = head if head and not head.isdigit() else get_current_device_type()
+    env_var = get_ar_device(device_type).visible_devices_env_var
+    if not env_var:
+        return
+
+    devices = ["0"] if device == device_type else device.split(",")
+    devices = [dev.split(":")[-1] for dev in devices]
+    if not all(s.isdigit() for s in devices):
+        return
+
+    current = os.environ.get(env_var)
+    if current is None:
+        # Use the cleaned/normalized device indices (no spaces, no type
+        # prefixes) when initially setting the environment variable.
+        os.environ[env_var] = ",".join(devices)
+        return
+
+    current_visible_devices = current.split(",")
+    try:
+        pick_device = [current_visible_devices[int(dev)] for dev in devices]
+    except Exception:
+        raise ValueError(
+            "Invalid '--device' value: It must be smaller than the number of available devices."
+            f" For example, with {env_var}=4,5, "
+            "--device 0,1 is valid, but --device 4,5 is not supported."
+        )
+    os.environ[env_var] = ",".join(pick_device)
 
 
 def set_cuda_visible_devices(device: str):
-    if device == "cuda":
-        devices = ["0"]
-    elif device == "auto":
-        return
-    else:
-        devices = device.replace(" ", "").split(",")
-    devices = [device.split(":")[-1] for device in devices]
-    if all(s.isdigit() for s in devices):
-        if "CUDA_VISIBLE_DEVICES" in os.environ:
-            current_visible_devices = os.environ["CUDA_VISIBLE_DEVICES"]
-            current_visible_devices = current_visible_devices.split(",")
-            indices = [int(device) for device in devices]
-            try:
-                pick_device = [current_visible_devices[i] for i in indices]
-            except Exception:
-                raise ValueError(
-                    "Invalid '--device' value: It must be smaller than the number of available devices."
-                    " For example, with CUDA_VISIBLE_DEVICES=4,5, "
-                    "--device 0,1 is valid, but --device 4,5 is not supported."
-                )
-            visible_devices = ",".join(pick_device)
-            os.environ["CUDA_VISIBLE_DEVICES"] = visible_devices
-        else:
-            # Use the cleaned/normalized device indices (no spaces, no type
-            # prefixes) when initially setting the environment variable.
-            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(devices)
+    """Backward-compatible alias of :func:`set_visible_devices`."""
+    set_visible_devices(device)
 
 
 class override_cuda_device_capability(ContextDecorator):
@@ -1240,9 +1285,10 @@ def set_avg_auto_device_map(model: torch.nn.Module, device_map):
     device_list = parse_available_devices(device_map)
     gpu_devices = []
     for device in device_list:
-        if device.startswith("hpu") and len(device_list) > 1:
-            logger.warning_once("Auto-scheme does not support multiple HPUs.")
-        if device.startswith("cpu") or device.startswith("hpu"):
+        device_type = device.split(":")[0]
+        if not get_ar_device(device_type).supports_multi_card_tuning:
+            if device_type != "cpu" and len(device_list) > 1:
+                logger.warning_once(f"Auto-scheme does not support multiple {device_type} devices.")
             continue
         gpu_devices.append(device)
     num_devices = len(gpu_devices)
@@ -1320,14 +1366,8 @@ def parse_available_devices(device_map: Union[str, torch.device, int, dict, None
     # === Step 2. Parse different input formats ===
     if device_map is None:
         # Automatically detect one available device
-        if "cuda" in device_types:
-            return ["cuda:0"]
-        elif "xpu" in device_types:
-            return ["xpu:0"]
-        elif "hpu" in device_types:
-            return ["hpu:0"]
-        else:
-            return ["cpu"]
+        primary = device_types[0]
+        return ["cpu"] if primary == "cpu" else [f"{primary}:0"]
 
     if isinstance(device_map, torch.device):
         # Handle torch.device objects
@@ -1365,15 +1405,10 @@ def parse_available_devices(device_map: Union[str, torch.device, int, dict, None
         if device_map.lower() == "cpu":
             return ["cpu"]
         if device_map.lower() == "auto":
-            device_count = detect_device_count()
-            if "cuda" in device_types:
-                return [f"cuda:{i}" for i in range(device_count)]
-            elif "xpu" in device_types:
-                return [f"xpu:{i}" for i in range(device_count)]
-            elif "hpu" in device_types:
-                return [f"hpu:{i}" for i in range(device_count)]
-            else:
+            primary = device_types[0]
+            if primary == "cpu":
                 return ["cpu"]
+            return [f"{primary}:{i}" for i in range(detect_device_count())]
         # Split by commas
         parts = [x.strip() for x in device_map.split(",") if x.strip()]
         parsed = []

--- a/auto_round/utils/device_manager.py
+++ b/auto_round/utils/device_manager.py
@@ -30,6 +30,20 @@ device that PyTorch already supports works here with **zero** extra code.  Only
 out-of-tree backends that are not yet integrated into ``torch.accelerator``
 (currently Intel Gaudi / ``hpu``) need a tiny shim, handled below.
 
+Adding a device that needs custom behavior is a single subclass -- the class
+attributes below are the *only* knobs the generic code paths consult::
+
+    from auto_round.utils.device_manager import ARDevice, register_ar_device
+
+    @register_ar_device
+    class NpuARDevice(ARDevice):
+        device_type = "npu"
+        visible_devices_env_var = "ASCEND_RT_VISIBLE_DEVICES"
+        supports_pipeline_parallel = True
+
+If PyTorch exposes the backend but discovery misses it, set
+``AR_DEVICE_BACKENDS=<type>[,<type>...]`` -- no code change at all.
+
 Typical usage::
 
     from auto_round.utils.device_manager import get_current_device_manager, get_ar_device
@@ -47,6 +61,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import gc
+import os
 import re
 import sys
 from typing import Optional, Union
@@ -61,6 +76,7 @@ __all__ = [
     "device_manager",
     "normalize_default_device_map",
     "get_ar_device",
+    "register_ar_device",
     "default_enable_torch_compile",
     "get_current_device_manager",
     "get_current_device_type",
@@ -70,6 +86,7 @@ __all__ = [
     "detect_device_count",
     "get_device_and_parallelism",
     "get_packing_device",
+    "get_active_device",
     "is_auto_device_mapping",
     "get_device_memory",
     "ClearMemory",
@@ -80,29 +97,47 @@ __all__ = [
 # ---------------------------------------------------------------------------
 # Backend discovery helpers
 # ---------------------------------------------------------------------------
-# Priority order used as a *fallback* hint when ``torch.accelerator`` is not
-# available (PyTorch < 2.6).  ``hpu`` is kept explicit because Intel Gaudi is an
-# out-of-tree backend that historically was not registered with
-# ``torch.accelerator``.  Any backend that IS registered with
-# ``torch.accelerator`` (cuda/xpu/mps/npu/...) is discovered automatically and
-# does NOT need to appear in this list.
-_PREFERRED_ORDER = ("cuda", "xpu", "hpu")  # add mps later
+# Backends that PyTorch exposes as ``torch.<name>`` but that are *not* reported
+# by ``torch.accelerator`` (out-of-tree vendor integrations).  Everything that
+# IS registered with ``torch.accelerator`` (cuda/xpu/mps/npu/mtia/...) or with
+# the ``PrivateUse1`` mechanism is discovered automatically and does NOT need to
+# be listed anywhere.
+_OUT_OF_TREE_BACKENDS = ("hpu",)
+
+# Priority hint used when probing manually (PyTorch < 2.6 has no
+# ``torch.accelerator``).  This is only an *ordering* hint -- a new backend does
+# not need to be added here to be supported.
+_PREFERRED_ORDER = ("cuda", "xpu", "hpu")
+
+#: Comma separated escape hatch, e.g. ``AR_DEVICE_BACKENDS=npu,mtia``.  Lets a
+#: brand-new PyTorch backend be used with zero code change.
+_BACKENDS_ENV_VAR = "AR_DEVICE_BACKENDS"
 
 
 def normalize_default_device_map(device_map: Union[None, str, int, torch.device, dict]):
     """Normalize default device selection across entry points.
 
-    On Apple Silicon, the default ``0`` / ``"0"`` / ``None`` / ``"auto"``
-    selection would otherwise resolve to MPS.  That tends to OOM on larger
-    models, so keep the historical behavior of defaulting to CPU unless the
-    caller explicitly requests MPS.
+    Some backends should not be picked implicitly (they declare
+    ``auto_select_by_default = False``); Apple Silicon / MPS is the canonical
+    example because it tends to OOM on larger models.  When such a backend is
+    the only one available, the default ``0`` / ``"0"`` / ``None`` / ``"auto"``
+    selection falls back to CPU unless the caller asked for it explicitly.
     """
-    if torch.mps.is_available() and device_map in (0, "0", None, "auto"):
-        logger.warning(
-            "MPS detected. Using CPU by default to avoid potential memory issues. "
-            "Set --device_map=mps to force MPS usage."
-        )
-        return "cpu"
+    if device_map not in (0, "0", None, "auto"):
+        return device_map
+    for device_type, device_cls in list(ARDevice._registry.items()):
+        if device_cls.auto_select_by_default:
+            continue
+        try:
+            available = get_ar_device(device_type).is_available()
+        except Exception:
+            available = False
+        if available:
+            logger.warning(
+                f"{device_type} detected. Using CPU by default to avoid potential memory issues. "
+                f"Set --device_map={device_type} to force {device_type} usage."
+            )
+            return "cpu"
     return device_map
 
 
@@ -167,6 +202,59 @@ def _hpu_available() -> bool:
         return False
 
 
+def _privateuse1_backend_name() -> Optional[str]:
+    """Name of the ``PrivateUse1`` backend when a vendor registered one."""
+    try:
+        name = torch._C._get_privateuse1_backend_name()
+    except Exception:
+        return None
+    return name if name and name != "privateuseone" else None
+
+
+def _candidate_backend_types() -> list[str]:
+    """Every backend type worth probing, discovered rather than hardcoded.
+
+    Sources, in priority order: the ``AR_DEVICE_BACKENDS`` env override,
+    out-of-tree backends, ``torch.accelerator``, the ``PrivateUse1`` backend
+    name, the legacy probing hint and finally every :class:`ARDevice` subclass
+    someone registered.  Adding a new device therefore never requires editing
+    this function.
+    """
+    env_backends = (part.strip() for part in os.environ.get(_BACKENDS_ENV_VAR, "").split(",") if part.strip())
+    names: list[str] = []
+    for name in (
+        *env_backends,
+        *_OUT_OF_TREE_BACKENDS,
+        _torch_accelerator_type(),
+        _privateuse1_backend_name(),
+        *_PREFERRED_ORDER,
+        *ARDevice._registry,
+    ):
+        if name and name != "cpu" and name not in names:
+            names.append(name)
+    return names
+
+
+def _backend_available(device_type: str) -> bool:
+    """Whether ``device_type`` is usable, without knowing anything about it.
+
+    Relies solely on the uniform ``<runtime module>.is_available()`` contract
+    every PyTorch device backend implements.
+    """
+    if device_type == "cpu":
+        return True
+    if device_type == "hpu":
+        return _hpu_available()
+    module = ARDevice.get_device_module(device_type)
+    is_avail = getattr(module, "is_available", None)
+    if not callable(is_avail):
+        return False
+    try:
+        return bool(is_avail())
+    except Exception:
+        return False
+
+
 def _normalize_device_type(device: Union[None, str, int, torch.device]) -> Optional[str]:
     """Reduce any device spec to a bare backend type string (``"cuda"`` ...)."""
     if device is None:
@@ -188,8 +276,9 @@ def get_current_device_type() -> str:
 
     Discovery order:
       1. Intel Gaudi ("hpu") -- out-of-tree, may not register with torch.accelerator.
-      2. "torch.accelerator" -- the canonical API, covers cuda/xpu/mps/npu/...
-      3. Manual probing of :data:`_PREFERRED_ORDER` for older PyTorch releases.
+      2. ``torch.accelerator`` -- the canonical API, covers cuda/xpu/mps/npu/...
+      3. Generic probing of :func:`_candidate_backend_types` for older PyTorch
+         releases and vendor backends.
     """
     # "hpu" first: it may not be registered with torch.accelerator.
     if _hpu_available():
@@ -199,29 +288,27 @@ def get_current_device_type() -> str:
     if accel_type is not None:
         return accel_type
 
-    # PyTorch < 2.6: torch.accelerator may not exist; probe common backends.
-    for dtype in _PREFERRED_ORDER:
-        if dtype == "hpu":
-            continue
-        mod = getattr(torch, dtype, None)
-        is_avail = getattr(mod, "is_available", None)
-        if callable(is_avail) and is_avail():
-            return dtype
+    # PyTorch < 2.6 / vendor backends: probe every discovered candidate.
+    for device_type in _candidate_backend_types():
+        if _backend_available(device_type):
+            return device_type
 
     return "cpu"
 
 
 def is_device_available() -> bool:
-    """Whether any (non-CPU) device is available."""
+    """Whether a device backend (CPU included) could be resolved."""
     return get_current_device_type() is not None
 
 
 def get_available_device_types() -> list[str]:
     """Return all available (non-CPU) backend types, in preferred order.
 
-    Uses ``torch.accelerator`` so backends registered with PyTorch -- including
-    out-of-tree ones such as ``npu`` -- are discovered automatically, without
-    callers ever probing ``torch.cuda`` / ``torch.xpu`` / ... by hand.
+    Every candidate reported by :func:`_candidate_backend_types` is probed
+    through the uniform ``is_available()`` contract, so backends registered with
+    PyTorch -- including out-of-tree ones such as ``npu`` -- are discovered
+    automatically, without callers ever touching ``torch.cuda`` / ``torch.xpu``
+    by hand.
     """
     available: list[str] = []
     # Out-of-tree hpu first (may not be registered with torch.accelerator).
@@ -231,6 +318,10 @@ def get_available_device_types() -> list[str]:
     accel_type = _torch_accelerator_type()
     if accel_type is not None and accel_type not in available:
         available.append(accel_type)
+    # Anything else PyTorch exposes but does not surface via torch.accelerator.
+    for device_type in _candidate_backend_types():
+        if device_type not in available and _backend_available(device_type):
+            available.append(device_type)
     return available
 
 
@@ -279,6 +370,32 @@ class ARDevice:
     #: the base class, which stays usable as a *generic* fallback for any
     #: PyTorch backend that lacks a dedicated subclass (e.g. a fresh ``npu``).
     device_type: str = ""
+
+    # -- capability / policy knobs -----------------------------------------
+    # Overriding these class attributes is normally the *only* thing a new
+    # backend has to do; every generic code path reads them instead of testing
+    # the device type by hand.
+
+    #: Environment variable used to restrict which cards of this backend are
+    #: visible to the process (e.g. ``CUDA_VISIBLE_DEVICES``).
+    visible_devices_env_var: Optional[str] = None
+
+    #: Whether naive multi-card (pipeline parallel) tuning is supported.
+    supports_pipeline_parallel: bool = False
+
+    #: Whether a block's layers may be spread across several cards of this backend.
+    supports_multi_card_tuning: bool = True
+
+    #: Whether the accelerate ``infer_auto_device_map`` + ``dispatch_model`` path
+    #: may be used for this backend.
+    supports_device_map_dispatch: bool = True
+
+    #: Whether the runtime exposes a usable caching-allocator ``empty_cache``.
+    supports_empty_cache: bool = True
+
+    #: Whether this backend may be selected implicitly when the user did not ask
+    #: for a specific device (see :func:`normalize_default_device_map`).
+    auto_select_by_default: bool = True
 
     _registry: dict[str, type["ARDevice"]] = {}
 
@@ -340,7 +457,7 @@ class ARDevice:
 
     def is_available(self) -> bool:
         """Whether this backend type is usable in the current build."""
-        return True
+        return _backend_available(self.type)
 
     def device_count(self) -> int:
         fn = getattr(self._module, "device_count", None)
@@ -372,9 +489,9 @@ class ARDevice:
             return torch.device(index if ":" in index else f"{self.type}:{index}")
         return torch.device(f"{self.type}:{int(index)}")
 
-    # def devices(self) -> list[torch.device]:
-    #     """Enumerate ``torch.device`` for every card of this backend."""
-    #     return [self.device(i) for i in range(self.device_count())]
+    def devices(self) -> list[torch.device]:
+        """Enumerate ``torch.device`` for every card of this backend."""
+        return [self.device(i) for i in range(self.device_count())]
 
     # -- runtime ------------------------------------------------------------
     def synchronize(self, index: Union[int, None] = None) -> None:
@@ -494,9 +611,23 @@ class ARDevice:
 
         return torch.compile(func)
 
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"{type(self).__name__}(type={self.type!r})"
 
-def __repr__(self) -> str:  # pragma: no cover - debug aid
-    return f"{type(self).__name__}(type={self.type!r})"
+
+class CudaARDevice(ARDevice):
+    """NVIDIA CUDA -- the reference backend."""
+
+    device_type = "cuda"
+    visible_devices_env_var = "CUDA_VISIBLE_DEVICES"
+    supports_pipeline_parallel = True
+
+
+class XpuARDevice(ARDevice):
+    """Intel GPU (XPU)."""
+
+    device_type = "xpu"
+    visible_devices_env_var = "ZE_AFFINITY_MASK"
 
 
 class HpuARDevice(ARDevice):
@@ -508,24 +639,21 @@ class HpuARDevice(ARDevice):
     """
 
     device_type = "hpu"
+    visible_devices_env_var = "HABANA_VISIBLE_MODULES"
+    supports_multi_card_tuning = False
+    supports_empty_cache = False
+    supports_device_map_dispatch = False
+
+    def __init__(self, device_type: Optional[str] = None):
+        # Always drive torch.hpu directly: on builds where Gaudi also registers
+        # with torch.accelerator, the accelerator module lacks the hpu-specific
+        # memory accounting this backend relies on.
+        self.type = "hpu"
+        self._module = self.get_device_module("hpu")
 
     @staticmethod
     def get_device_module(device: Union[None, str, int, torch.device] = None):
-        """Return the backend runtime module for ``device`` (e.g. ``torch.cuda``).
-
-        This is a thin, version-tolerant wrapper around ``torch.get_device_module``
-        that also understands ``hpu`` and plain device strings/indices.
-
-        Args:
-            device: ``"cuda"``, ``"xpu:0"``, ``torch.device(...)``, an int index
-                (interpreted against the current device) or ``None`` (current
-                device).
-
-        Returns:
-            The module exposing the device runtime API, or ``None`` for CPU / when
-            no device is available.
-        """
-
+        """Return ``torch.hpu``, falling back to the habana runtime module."""
         if hasattr(torch, "hpu"):
             return torch.hpu
         try:  # pragma: no cover - depends on Gaudi runtime
@@ -559,16 +687,9 @@ class HpuARDevice(ARDevice):
             return torch.compile(func, backend="hpu_backend")
         return func
 
-    def memory_allocated(self, index: int = 0) -> int:
-        return torch.hpu.memory_allocated(index)
-
-    def memory_reserved(self, index: int = 0) -> int:  # TODO have a check
-        return torch.hpu.memory_allocated(index)
-
-    def device_count(self) -> int:
-        import habana_frameworks.torch.hpu as hthpu  # pylint: disable=E0401
-
-        return hthpu.device_count()
+    def memory_reserved(self, index: int = 0) -> int:
+        # HPU has no separate reserved/allocated accounting.
+        return self.memory_allocated(index)
 
 
 class MpsARDevice(ARDevice):
@@ -576,10 +697,13 @@ class MpsARDevice(ARDevice):
 
     MPS's caching allocator is not yet compatible with ``torch.accelerator``'s
     generic ``empty_cache`` path (PyTorch asserts internally), so we bypass it
-    and call ``torch.mps`` methods directly.
+    and call ``torch.mps`` methods directly.  It is also never auto-selected:
+    unified memory makes it OOM easily on larger models.
     """
 
     device_type = "mps"
+    supports_multi_card_tuning = False
+    auto_select_by_default = False
 
     def __init__(self, device_type: Optional[str] = None):
         # Always use torch.mps directly, never torch.accelerator.
@@ -588,28 +712,22 @@ class MpsARDevice(ARDevice):
 
     @staticmethod
     def get_device_module(device: Union[None, str, int, torch.device] = None):
-        """Return the backend runtime module for ``device`` (e.g. ``torch.cuda``).
-
-        This is a thin, version-tolerant wrapper around ``torch.get_device_module``
-        that also understands ``hpu`` and plain device strings/indices.
-
-        Args:
-            device: ``"cuda"``, ``"xpu:0"``, ``torch.device(...)``, an int index
-                (interpreted against the current device) or ``None`` (current
-                device).
-
-        Returns:
-            The module exposing the device runtime API, or ``None`` for CPU / when
-            no device is available.
-        """
-        return torch.mps
+        """Return ``torch.mps`` (never the generic accelerator API)."""
+        return getattr(torch, "mps", None)
 
     def is_available(self) -> bool:
         """Whether this backend type is usable in the current build."""
-        return self._module.is_available()
+        is_avail = getattr(self._module, "is_available", None)
+        try:
+            return bool(is_avail()) if callable(is_avail) else False
+        except Exception:
+            return False
 
     def current_device(self) -> int:
         return 0
+
+    def device_count(self) -> int:  # MPS exposes a single unified device.
+        return 1
 
     def set_device(self, index: Union[int, str, torch.device]) -> None:
         return None
@@ -618,17 +736,8 @@ class MpsARDevice(ARDevice):
         """Build a ``torch.device`` for this backend / card ``index``."""
         return torch.device("mps")
 
-    def device_index(self, index: int):
-        """Context manager that sets the current device index for this backend.
-
-        Uses ``torch.accelerator.device_index`` when available; otherwise falls
-        back to a tiny save/restore around :meth:`set_device`.
-        """
-        if self._module is not None:
-            ctx = getattr(self._module, "device_index", None)
-            if callable(ctx):
-                return ctx(index)
-        return _DeviceIndexContext(self, index)
+    def device_index(self, index: int):  # nothing to switch on MPS.
+        return contextlib.nullcontext()
 
     def total_memory(self, index: int = 0) -> int:
         return torch.mps.recommended_max_memory()
@@ -638,30 +747,6 @@ class MpsARDevice(ARDevice):
 
     def memory_allocated(self, index: int = 0) -> int:
         return torch.mps.current_allocated_memory()
-
-    # def mem_get_info(self, index: int = 0) -> tuple[int, int]:
-    #     """Return ``(free_bytes, total_bytes)`` for ``index``.
-    #
-    #     Falls back to ``total - reserved`` when the backend lacks a native
-    #     ``mem_get_info`` implementation.
-    #     """
-    #     module = self.get_device_module(self.type) if self._module is _accelerator_api() else self._module
-    #     fn = getattr(module, "get_memory_info", None)
-    #
-    #     return fn(index) if callable(fn) else (0, 0)  # pylint: disable=E1102
-
-    # -- numeric format / mixed-precision policy ---------------------------
-    def supports_bf16(self) -> bool:
-        """Whether this backend can execute the ``bfloat16`` data type."""
-        return True
-
-    def prefers_bf16(self) -> bool:
-        """Whether this backend prefers bf16 as the mixed-precision compute dtype.
-
-        Defaults to ``True`` (bf16 is the preferred tuning dtype); backends that
-        would rather honour the model's own non-fp32 dtype can override this.
-        """
-        return True
 
 
 class CpuARDevice(ARDevice):
@@ -676,6 +761,7 @@ class CpuARDevice(ARDevice):
     """
 
     device_type = "cpu"
+    supports_multi_card_tuning = False
 
     @staticmethod
     def get_device_module(device: Union[None, str, int, torch.device] = None):
@@ -743,12 +829,6 @@ class CpuARDevice(ARDevice):
 
     def memory_allocated(self, index: int = 0) -> int:
         return self.memory_reserved(index)
-
-    # def mem_get_info(self, index: int = 0) -> tuple[int, int]:
-    #     vm = self._virtual_memory()
-    #     if vm is None:
-    #         return 0, 0
-    #     return int(vm.available), int(vm.total)
 
     def is_torch_compile_supported(self) -> bool:
         return True
@@ -844,12 +924,14 @@ class DeviceManager:
 
     # -- registration -------------------------------------------------------
     def register(self, device_cls: type[ARDevice]) -> None:
-        """Register a custom :class:`Device` subclass and drop any stale cache."""
+        """Register a custom :class:`ARDevice` subclass and drop any stale cache."""
         dtype = device_cls.device_type
         if not dtype:
             raise ValueError("Device subclass must define a non-empty 'device_type'")
         ARDevice._registry[dtype] = device_cls
         self._cache.pop(dtype, None)
+        # Discovery caches may already have decided this backend does not exist.
+        get_current_device_type.cache_clear()
 
     # -- lookup -------------------------------------------------------------
     def get_ar_device(self, device_type: Union[None, str, int, torch.device] = None) -> ARDevice:
@@ -890,8 +972,24 @@ device_manager = DeviceManager()
 
 
 def get_ar_device(device_type: Union[None, str, int, torch.device] = None) -> ARDevice:
-    """Return the cached :class:`Device` handle for a specific backend type."""
+    """Return the cached :class:`ARDevice` handle for a specific backend type."""
     return device_manager.get_ar_device(device_type)
+
+
+def register_ar_device(device_cls: type[ARDevice]) -> type[ARDevice]:
+    """Register a custom :class:`ARDevice` subclass; usable as a decorator.
+
+    Subclassing :class:`ARDevice` with a non-empty ``device_type`` already
+    self-registers; this helper exists so out-of-tree code can register a handle
+    explicitly (and refresh the discovery caches) in one call::
+
+        @register_ar_device
+        class MyNpuDevice(ARDevice):
+            device_type = "npu"
+            visible_devices_env_var = "ASCEND_RT_VISIBLE_DEVICES"
+    """
+    device_manager.register(device_cls)
+    return device_cls
 
 
 def default_enable_torch_compile(
@@ -917,9 +1015,9 @@ def detect_device_count() -> int:
 def get_device_and_parallelism(device: Union[str, torch.device, int, dict]) -> tuple[str, bool]:
     """Resolve a device spec into ``(device, parallelism)``.
 
-    The multi-card *parallelism* policy itself is kept as a standalone function
-    (:func:`auto_round.utils.device.is_pipeline_parallel_supported`) rather than
-    living on the device manager.
+    Whether multi-card (naive pipeline) parallel tuning is possible is read from
+    the backend's :attr:`ARDevice.supports_pipeline_parallel` flag, so a new
+    device only has to declare it once.
     """
     if device is None:
         device = get_major_device(device)
@@ -948,10 +1046,7 @@ def get_device_and_parallelism(device: Union[str, torch.device, int, dict]) -> t
     if is_multi_card:
         # Pick the active backend generically rather than probing each one by hand.
         device_type = get_current_device_type() or "cpu"
-        # Parallelism policy is intentionally not part of the device manager.
-        from auto_round.utils.device import is_pipeline_parallel_supported
-
-        return device_type, is_pipeline_parallel_supported(device_type)
+        return device_type, get_ar_device(device_type).supports_pipeline_parallel
     elif device == "auto":
         device = get_major_device(device)
         parallelism = True
@@ -959,6 +1054,23 @@ def get_device_and_parallelism(device: Union[str, torch.device, int, dict]) -> t
         device = get_major_device(device)
         parallelism = False
     return device, parallelism
+
+
+def get_active_device(index: int = 0) -> torch.device:
+    """A ``torch.device`` for the active accelerator, or CPU when there is none.
+
+    Backends that opt out of implicit selection (``auto_select_by_default``,
+    e.g. MPS) resolve to CPU, so callers that only need *a* sensible device stay
+    consistent with :func:`normalize_default_device_map` instead of re-deriving
+    the policy from a device-type check.
+    """
+    device_type = get_current_device_type()
+    if device_type == "cpu":
+        return torch.device("cpu")
+    device = get_ar_device(device_type)
+    if not device.auto_select_by_default:
+        return torch.device("cpu")
+    return device.device(index)
 
 
 def get_packing_device(device: Union[str, torch.device, None] = "auto") -> torch.device:
@@ -970,10 +1082,7 @@ def get_packing_device(device: Union[str, torch.device, None] = "auto") -> torch
     - ``None``: treated as ``"auto"``.
     """
     if device is None or (isinstance(device, str) and device.lower() == "auto"):
-        device_type = get_current_device_type()
-        if device_type is not None and device_type != "cpu":
-            return torch.device(f"{device_type}:0")
-        return torch.device("cpu")
+        return get_active_device()
 
     if isinstance(device, torch.device):
         return device
@@ -1171,16 +1280,16 @@ class ClearMemory:
         device_list: Union[list, tuple, None] = None,
     ):
         # Lazy imports: these symbols live in utils/device.py.
-        from auto_round.utils.device import _force_trim_malloc, is_hpex_available, memory_monitor
+        from auto_round.utils.device import _force_trim_malloc, memory_monitor
 
-        if is_hpex_available():
-            if device_list is not None:
-                self.device_list = device_list
-            final_device_list = self.device_list
-            # Keep peak accounting consistent with non-HPU path: sample first,
-            # then release memory so post-clear values do not hide true peaks.
-            memory_monitor.update_hpu(final_device_list)
-            # Clear CPU-side references so Python can reclaim them.
+        if device_list is not None:
+            self.device_list = device_list
+        final_device_list = self.device_list
+        # Sample peak accounting first, so post-clear values do not hide true peaks.
+        memory_monitor.update(final_device_list)
+
+        if not get_current_device_manager().supports_empty_cache:
+            # No caching allocator to flush (e.g. HPU): only drop CPU-side refs.
             if isinstance(tensor, list):
                 for i in range(len(tensor)):
                     tensor[i] = None
@@ -1188,12 +1297,8 @@ class ClearMemory:
             gc.collect()
             _force_trim_malloc()
             return
-        else:
-            if device_list is not None:
-                self.device_list = device_list
-            final_device_list = self.device_list
-            memory_monitor.update(final_device_list)
-            _clear_memory_for_cpu_and_cuda(tensor, final_device_list)
+
+        _clear_memory_for_cpu_and_cuda(tensor, final_device_list)
 
 
 clear_memory = torch._dynamo.disable()(ClearMemory(device_list=None))

--- a/test/unit/common/utils/test_device.py
+++ b/test/unit/common/utils/test_device.py
@@ -1753,10 +1753,21 @@ class TestFakeTritonForHpuExtra:
 class TestDeviceEnvironVariableMappingExtra:
     """Additional ``DEVICE_ENVIRON_VARIABLE_MAPPING`` tests."""
 
-    def test_is_dict(self):
+    def test_is_mapping(self):
+        from collections.abc import Mapping
+
         from auto_round.utils.device import DEVICE_ENVIRON_VARIABLE_MAPPING
 
-        assert isinstance(DEVICE_ENVIRON_VARIABLE_MAPPING, dict)
+        assert isinstance(DEVICE_ENVIRON_VARIABLE_MAPPING, Mapping)
+        assert "cuda" in DEVICE_ENVIRON_VARIABLE_MAPPING
+        assert DEVICE_ENVIRON_VARIABLE_MAPPING["cuda"] == "CUDA_VISIBLE_DEVICES"
+
+    def test_unknown_backend_raises_key_error(self):
+        from auto_round.utils.device import DEVICE_ENVIRON_VARIABLE_MAPPING
+
+        assert "not_a_backend" not in DEVICE_ENVIRON_VARIABLE_MAPPING
+        with pytest.raises(KeyError):
+            DEVICE_ENVIRON_VARIABLE_MAPPING["not_a_backend"]
 
     def test_mapping_values_nonempty(self):
         from auto_round.utils.device import DEVICE_ENVIRON_VARIABLE_MAPPING

--- a/test/unit/common/utils/test_device_manager.py
+++ b/test/unit/common/utils/test_device_manager.py
@@ -351,26 +351,12 @@ class TestAcceleratorHelpers:
 # ---------------------------------------------------------------------------
 class TestGetCurrentDeviceType:
     def test_returns_cpu_when_nothing_available(self):
-        from auto_round.utils.device_manager import (
-            _hpu_available,
-            _torch_accelerator_type,
-            get_current_device_type,
-        )
+        from auto_round.utils.device_manager import get_current_device_type
 
         # Force every discovery path to report "nothing"
-        with patch.object(
-            __import__("auto_round.utils.device_manager", fromlist=["_hpu_available"]),
-            "_hpu_available",
-            return_value=False,
-        ), patch.object(
-            __import__("auto_round.utils.device_manager", fromlist=["_torch_accelerator_type"]),
-            "_torch_accelerator_type",
-            return_value=None,
-        ), patch.object(
-            __import__("auto_round.utils.device_manager", fromlist=["_PREFERRED_ORDER"]),
-            "_PREFERRED_ORDER",
-            (),
-        ):
+        with patch("auto_round.utils.device_manager._hpu_available", return_value=False), patch(
+            "auto_round.utils.device_manager._torch_accelerator_type", return_value=None
+        ), patch("auto_round.utils.device_manager._backend_available", return_value=False):
             # Need to clear the lru_cache
             get_current_device_type.cache_clear()
             try:
@@ -417,7 +403,7 @@ class TestAvailableHelpers:
 
         with patch("auto_round.utils.device_manager._hpu_available", return_value=False), patch(
             "auto_round.utils.device_manager._torch_accelerator_type", return_value=None
-        ):
+        ), patch("auto_round.utils.device_manager._backend_available", return_value=False):
             assert get_available_device_types() == []
 
 
@@ -800,3 +786,157 @@ class TestClearMemoryHelper:
             _clear_memory_for_cpu_and_cuda(tensor=tensor_list, device_list=None)
         # After the call, the local list elements should be set to None
         assert all(t is None for t in tensor_list)
+
+
+# ---------------------------------------------------------------------------
+# Extensibility: adding a new device must require no changes in this module
+# ---------------------------------------------------------------------------
+class TestNewBackendSupport:
+    """Guards the two design goals: cheap new devices, automatic discovery."""
+
+    def setup_method(self):
+        from auto_round.utils.device_manager import DeviceManager, get_current_device_type
+
+        DeviceManager._instance = None
+        get_current_device_type.cache_clear()
+
+    def teardown_method(self):
+        from auto_round.utils.device_manager import ARDevice, get_current_device_type
+
+        ARDevice._registry.pop("_fake_npu_zzz", None)
+        ARDevice._registry.pop("_fake_env_zzz", None)
+        get_current_device_type.cache_clear()
+
+    def test_declared_registration_is_enough(self):
+        """A subclass with a device_type + env var is fully usable, no edit needed.
+
+        ``vulkan`` stands in for a PyTorch-known backend without a dedicated
+        handle; a genuinely new name additionally needs the vendor to call
+        ``torch.utils.rename_privateuse1_backend`` (a PyTorch requirement).
+        """
+        from auto_round.utils.device_manager import (
+            ARDevice,
+            get_ar_device,
+            register_ar_device,
+        )
+
+        @register_ar_device
+        class _FakeVulkan(ARDevice):
+            device_type = "vulkan"
+            visible_devices_env_var = "VULKAN_VISIBLE_DEVICES"
+            supports_pipeline_parallel = True
+
+        try:
+            device = get_ar_device("vulkan")
+            assert isinstance(device, _FakeVulkan)
+            assert device.visible_devices_env_var == "VULKAN_VISIBLE_DEVICES"
+            assert device.supports_pipeline_parallel is True
+            assert device.device(2) == torch.device("vulkan:2")
+        finally:
+            from auto_round.utils.device_manager import device_manager
+
+            ARDevice._registry.pop("vulkan", None)
+            device_manager._cache.pop("vulkan", None)
+
+    def test_policy_flags_replace_device_type_checks(self):
+        """Generic code paths read the flags instead of branching on the type."""
+        from auto_round.utils.device import is_pipeline_parallel_supported
+        from auto_round.utils.device_manager import ARDevice, register_ar_device
+
+        class _FakeNpu(ARDevice):
+            device_type = "_fake_npu_zzz"
+            supports_pipeline_parallel = True
+
+        register_ar_device(_FakeNpu)
+        assert is_pipeline_parallel_supported("_fake_npu_zzz") is True
+        assert is_pipeline_parallel_supported("mps") is False
+
+    def test_env_var_opt_in_is_discovered(self):
+        """AR_DEVICE_BACKENDS lets an unknown PyTorch backend be picked up."""
+        from auto_round.utils.device_manager import _candidate_backend_types
+
+        with patch.dict("os.environ", {"AR_DEVICE_BACKENDS": "_fake_env_zzz, cuda"}):
+            candidates = _candidate_backend_types()
+        assert candidates[0] == "_fake_env_zzz"
+        assert "cuda" in candidates
+
+    def test_registered_backend_appears_in_candidates(self):
+        from auto_round.utils.device_manager import (
+            ARDevice,
+            _candidate_backend_types,
+            register_ar_device,
+        )
+
+        class _FakeNpu(ARDevice):
+            device_type = "_fake_npu_zzz"
+
+        register_ar_device(_FakeNpu)
+        assert "_fake_npu_zzz" in _candidate_backend_types()
+
+    def test_available_types_probes_every_candidate(self):
+        """Discovery is driven by is_available(), not by a hardcoded list."""
+        from auto_round.utils.device_manager import get_available_device_types
+
+        with patch("auto_round.utils.device_manager._hpu_available", return_value=False), patch(
+            "auto_round.utils.device_manager._torch_accelerator_type", return_value=None
+        ), patch(
+            "auto_round.utils.device_manager._candidate_backend_types",
+            return_value=["cuda", "xpu"],
+        ), patch(
+            "auto_round.utils.device_manager._backend_available",
+            side_effect=lambda name: name == "xpu",
+        ):
+            assert get_available_device_types() == ["xpu"]
+
+    def test_unknown_backend_uses_generic_handle(self):
+        """No dedicated subclass still works via torch.get_device_module."""
+        from auto_round.utils.device_manager import ARDevice
+
+        device = ARDevice.create("_brand_new_backend")
+        assert type(device) is ARDevice
+        assert device.type == "_brand_new_backend"
+
+    def test_devices_enumerates_all_cards(self):
+        from auto_round.utils.device_manager import ARDevice
+
+        original = ARDevice._registry.get("cuda")
+
+        class _FakeCuda(ARDevice):
+            device_type = "cuda"
+
+            def device_count(self):
+                return 3
+
+        try:
+            assert _FakeCuda().devices() == [
+                torch.device("cuda:0"),
+                torch.device("cuda:1"),
+                torch.device("cuda:2"),
+            ]
+        finally:
+            ARDevice._registry["cuda"] = original
+
+    def test_get_active_device_respects_opt_out(self):
+        from auto_round.utils.device_manager import get_active_device
+
+        with patch("auto_round.utils.device_manager.get_current_device_type", return_value="mps"):
+            assert get_active_device() == torch.device("cpu")
+        with patch("auto_round.utils.device_manager.get_current_device_type", return_value="cpu"):
+            assert get_active_device() == torch.device("cpu")
+
+    def test_get_active_device_uses_active_accelerator(self):
+        from auto_round.utils.device_manager import get_active_device
+
+        with patch("auto_round.utils.device_manager.get_current_device_type", return_value="cuda"):
+            assert get_active_device() == torch.device("cuda:0")
+            assert get_active_device(3) == torch.device("cuda:3")
+
+    def test_normalize_default_device_map_skips_opt_out_backends(self):
+        from auto_round.utils.device_manager import normalize_default_device_map
+
+        with patch("auto_round.utils.device_manager.get_ar_device") as fake_get:
+            fake_get.return_value.is_available.return_value = True
+            fake_get.return_value.auto_select_by_default = False
+            assert normalize_default_device_map(None) == "cpu"
+            # An explicit request is never overridden.
+            assert normalize_default_device_map("mps") == "mps"


### PR DESCRIPTION
## Description

Refine device operations into a unified DeviceManager / ARDevice abstraction so that (1) adding a new device is cheap and 
(2) every device PyTorch supports works automatically with no per-device code.


a) Discovery is now data-driven. Backends are found via `torch.accelerator`, the `PrivateUse1` registration, and a generic `is_available()` probe, and fall back to a preferred-order hint on older PyTorch. AR_DEVICE_BACKENDS=<type> is an escape hatch for brand-new backends with zero code change.
b) Capability flags replace device-type branches. ARDevice now declares `visible_devices_env_var`, `supports_pipeline_parallel`, `supports_multi_card_tuning`, `supports_empty_cache`, `supports_device_map_dispatch`, and `auto_select_by_default`. 
c) New APIs: `register_ar_device()` and `get_active_device()`, and a CudaARDevice/XpuARDevice handle for the built-in backends.
Route remaining torch.cuda.* call sites (hadamard, spinquant, calibration, convert_model) through the device manager.


## Type of Change

Enhancement

## Related Issues

https://github.com/intel/auto-round/issues/1788

## Checklist Before Submitting

- [x] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
