### PR TITLE
fix: support list inputs in diffusion tuning cache

### DIFF
--- a/auto_round/compressors/diffusion/tuning_cache.py
+++ b/auto_round/compressors/diffusion/tuning_cache.py
@@ -74,6 +74,9 @@ class DiffusionTuningCache:
 
     @classmethod
     def create(cls, block, runner, inputs, others, outputs, sampler, iters, budget_gib, device):
+        # Single-output blocks (e.g. Wan) pass a tensor list to the next block.
+        if isinstance(inputs, list):
+            inputs = {"hidden_states": inputs}
         if runner.batch_size != 1 or not isinstance(inputs, dict) or iters <= 0:
             return None
         cache = cls()


### PR DESCRIPTION

## Description

Single-output diffusion blocks pass tensor lists to subsequent blocks, causing the dict-only cache guard to silently skip prefetch and GPU best snapshots. Normalize these inputs inside the diffusion cache to preserve the existing block data flow.

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
