### PR TITLE
fix: reload Diffusers blocks from component checkpoints

### DIFF
--- a/auto_round/utils/model.py
+++ b/auto_round/utils/model.py
@@ -1052,9 +1052,15 @@ def diffusion_load_model(
     if hasattr(pipe, "unet"):
         # Stable Diffusion pipelines (e.g., SD and SDXL) use a UNet denoiser.
         model = pipe.unet
+        model_component_name = "unet"
     else:
         # DiT-based pipelines (e.g., Flux and SD3) use a Transformer denoiser.
         model = pipe.transformer
+        model_component_name = "transformer"
+
+    # Diffusers keeps denoiser checkpoints below the pipeline repository root.
+    # Retain the component name so block-wise offloading can find those files.
+    model._autoround_checkpoint_subfolder = model_component_name
 
     # Attach custom pipeline function for models that need special API calls
     _attach_diffusion_pipeline_fn(pipe)
@@ -1081,6 +1087,7 @@ def diffusion_load_model(
             and comp is not None
             and isinstance(comp, torch.nn.Module)
         ):
+            comp._autoround_checkpoint_subfolder = comp_name
             setattr(
                 comp.config, "save_pretrained", partial(config_save_pretrained, comp.config, "config.json", model=comp)
             )

--- a/auto_round/utils/offload.py
+++ b/auto_round/utils/offload.py
@@ -218,6 +218,12 @@ def _resolve_model_dir(model_dir: str, revision: Optional[str] = None) -> str:
 def _build_weight_map(model_dir: str) -> dict[str, str]:
     """Build ``{tensor_name: shard_filename}`` from the model directory."""
     index_path = os.path.join(model_dir, "model.safetensors.index.json")
+    if not os.path.exists(index_path) and os.path.isdir(model_dir):
+        custom_indexes = sorted(
+            filename for filename in os.listdir(model_dir) if filename.endswith(".safetensors.index.json")
+        )
+        if custom_indexes:
+            index_path = os.path.join(model_dir, custom_indexes[0])
     if os.path.exists(index_path):
         with open(index_path) as f:
             return json.load(f)["weight_map"]
@@ -230,6 +236,10 @@ def _build_weight_map(model_dir: str) -> dict[str, str]:
             return {k: "model.safetensors" for k in f.keys()}
 
     bin_index_path = os.path.join(model_dir, "pytorch_model.bin.index.json")
+    if not os.path.exists(bin_index_path) and os.path.isdir(model_dir):
+        custom_indexes = sorted(filename for filename in os.listdir(model_dir) if filename.endswith(".bin.index.json"))
+        if custom_indexes:
+            bin_index_path = os.path.join(model_dir, custom_indexes[0])
     if os.path.exists(bin_index_path):
         with open(bin_index_path) as f:
             return json.load(f)["weight_map"]
@@ -241,7 +251,7 @@ def _build_weight_map(model_dir: str) -> dict[str, str]:
 
     raise FileNotFoundError(
         f"Could not find model weight files in {model_dir}. "
-        "Expected model.safetensors or pytorch_model.bin (with optional index.json)."
+        "Expected a safetensors or PyTorch .bin checkpoint (with optional index.json)."
     )
 
 
@@ -593,6 +603,13 @@ class OffloadManager:
         module = get_module(model, name)
         if module is None:
             return
+        model_dir = self.model_dir
+        component_subfolder = getattr(model, "_autoround_checkpoint_subfolder", None)
+        if model_dir is not None and component_subfolder:
+            resolved_dir = _resolve_model_dir(model_dir)
+            component_dir = os.path.join(resolved_dir, component_subfolder)
+            if os.path.isdir(component_dir):
+                model_dir = component_dir
         if self.mode == "offload":
             if name not in self._saved:
                 # Before falling back to the
@@ -621,8 +638,8 @@ class OffloadManager:
                 # meta skeleton (AR_DISK_STREAM_MODEL=1) instead of a full CPU
                 # load. There is nothing on the temp dir to load from -- read
                 # straight from the original checkpoint instead.
-                if self.model_dir is not None:
-                    load_block_from_model_files(self.model_dir, name, module)
+                if model_dir is not None:
+                    load_block_from_model_files(model_dir, name, module)
                 return
             self._load_from_disk(name, module)
             if not self.retain_saved_entries:
@@ -631,7 +648,7 @@ class OffloadManager:
             if self.model_dir is None:
                 logger.warning("OffloadManager: model_dir is required for clean mode")
                 return
-            load_block_from_model_files(self.model_dir, name, module)
+            load_block_from_model_files(model_dir, name, module)
 
     # ------------------------------------------------------------------
     # Hook-based transparent offloading

--- a/test/unit/common/utils/test_offload_helpers.py
+++ b/test/unit/common/utils/test_offload_helpers.py
@@ -20,6 +20,7 @@ The full save/reload path requires a real model checkpoint and is covered
 elsewhere.
 """
 
+import json
 import os
 from unittest.mock import patch
 
@@ -299,6 +300,20 @@ class TestResolveModelDir:
         resolve.assert_called_once_with("org/model", revision="commit")
         load_block.assert_called_once_with(str(snapshot), "0", model[0])
 
+    def test_offload_manager_uses_diffusion_component_subfolder(self, tmp_path):
+        """Diffusers block reloads must read from the active pipeline component."""
+        from auto_round.utils.offload import OffloadManager
+
+        component_dir = tmp_path / "transformer_2"
+        component_dir.mkdir()
+        model = nn.Sequential(nn.Linear(2, 2))
+        model._autoround_checkpoint_subfolder = "transformer_2"
+        with patch("auto_round.utils.offload.load_block_from_model_files") as load_block:
+            manager = OffloadManager(mode="clean", model_dir=str(tmp_path))
+            manager.reload(model, "0")
+
+        load_block.assert_called_once_with(str(component_dir), "0", model[0])
+
     def test_offload_manager_does_not_eagerly_resolve_without_revision(self):
         """Revision-less and non-Hugging Face sources retain the legacy lazy path."""
         from auto_round.utils.offload import OffloadManager
@@ -322,3 +337,14 @@ class TestResolveModelDir:
             _resolve_model_dir("org/model", revision="commit")
 
         assert exc_info.value is error
+
+
+class TestBuildWeightMap:
+    def test_custom_diffusers_safetensors_index(self, tmp_path):
+        from auto_round.utils.offload import _build_weight_map
+
+        weight_map = {"blocks.0.weight": "diffusion_pytorch_model-00001-of-00002.safetensors"}
+        index_path = tmp_path / "diffusion_pytorch_model.safetensors.index.json"
+        index_path.write_text(json.dumps({"weight_map": weight_map}))
+
+        assert _build_weight_map(str(tmp_path)) == weight_map


### PR DESCRIPTION
## Description

Fix Diffusers block reload failures when `low_cpu_mem_usage=True`.

Diffusers stores denoiser weights in component subfolders such as `transformer` and uses filenames like `diffusion_pytorch_model.safetensors.index.json`. The offloader previously searched only the pipeline root for standard Transformers checkpoint names, causing `FileNotFoundError` during zero-shot/RTN quantization.

## Type of Change

<!-- Bug fix / New feature / Documentation / Performance / Refactor / Other: __________ -->

Bug fix

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes or relates to #2355

## Checklist Before Submitting

- [ ] My code has been tested locally.
- [ ] Documentation has been updated as needed.
- [ ] New or updated tests are included where applicable.
- [ ] The CUDA CI has passed. You can trigger it by commenting `/azp run Unit-Test-CUDA-AutoRound`.

<!-- Optional: Tag reviewers or add extra notes below -->
